### PR TITLE
feat(contracts): Cross-Contract Communication Handler (#25)

### DIFF
--- a/contracts/cross-contract-handler/Cargo.toml
+++ b/contracts/cross-contract-handler/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-cross-contract-handler"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/cross-contract-handler/README.md
+++ b/contracts/cross-contract-handler/README.md
@@ -1,0 +1,39 @@
+# Cross-Contract Communication Handler
+
+Platform-core contract for routing and tracking cross-contract requests. Admin registers routes (source → target + selector); authorized callers dispatch requests; targets (or admin) acknowledge with results.
+
+## Methods
+
+| Method | Description | Authorization |
+|--------|-------------|---------------|
+| `init(admin, registry_contract)` | Initialize handler. Call once. | `admin` (require_auth) |
+| `register_route(admin, source_contract, target_contract, selector)` | Register a route; returns `route_id`. | Admin only |
+| `dispatch(caller, request_id, route_id, payload)` | Create a pending request on a route. | `caller` must authorize and be admin or `source_contract` for that route |
+| `acknowledge(caller, request_id, result)` | Mark request as completed with a result. | `caller` must authorize and be admin or `target_contract` for that request's route |
+| `get_route(route_id)` | Read route data. | Anyone (view) |
+
+## Storage
+
+- **Instance:** `Admin`, `RegistryContract`, `NextRouteId`, `Route(u32)`, `Request(Symbol)`.
+- **Routes:** Stored by auto-incrementing `route_id` (1, 2, …).
+- **Requests:** Keyed by caller-provided `request_id` (Symbol). Status: `Pending { route_id, payload }` or `Acknowledged { result }`.
+
+## Events
+
+- `Initialized { admin, registry_contract }`
+- `RouteRegistered { route_id, source_contract, target_contract, selector }`
+- `Dispatched { request_id, route_id, payload }`
+- `Acknowledged { request_id, result }`
+
+## Invariants
+
+- `source_contract` and `target_contract` must differ for a route.
+- A given `request_id` can only be dispatched once (no duplicate processing).
+- A request can only be acknowledged once (no double acknowledge).
+- Only admin or the route’s source can dispatch; only admin or the route’s target can acknowledge.
+
+## Integration
+
+- Dependent contracts should call this handler to register routes and dispatch/acknowledge requests.
+- The `registry_contract` stored at init can be used by off-chain or other contracts to resolve contract addresses.
+- For pause/emergency behavior, integrate with the platform’s emergency-pause contract where applicable.

--- a/contracts/cross-contract-handler/src/lib.rs
+++ b/contracts/cross-contract-handler/src/lib.rs
@@ -1,0 +1,273 @@
+//! Stellarcade Cross-Contract Communication Handler
+//!
+//! Platform-core contract that routes and tracks cross-contract requests.
+//! Admin registers routes (source → target + selector); authorized callers
+//! dispatch requests and targets (or admin) acknowledge with results.
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+use soroban_sdk::{
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, Env, Symbol,
+};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    RegistryContract,
+    NextRouteId,
+    Route(u32),
+    Request(Symbol),
+}
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Route {
+    pub source_contract: Address,
+    pub target_contract: Address,
+    pub selector: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequestStatus {
+    Pending(u32, Bytes),
+    Acknowledged(Bytes),
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+    RouteNotFound = 4,
+    RequestNotFound = 5,
+    DuplicateRequestId = 6,
+    RequestAlreadyAcknowledged = 7,
+    InvalidRoute = 8,
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+#[contractevent]
+pub struct Initialized {
+    pub admin: Address,
+    pub registry_contract: Address,
+}
+
+#[contractevent]
+pub struct RouteRegistered {
+    pub route_id: u32,
+    pub source_contract: Address,
+    pub target_contract: Address,
+    pub selector: Symbol,
+}
+
+#[contractevent]
+pub struct Dispatched {
+    #[topic]
+    pub request_id: Symbol,
+    pub route_id: u32,
+    pub payload: Bytes,
+}
+
+#[contractevent]
+pub struct Acknowledged {
+    #[topic]
+    pub request_id: Symbol,
+    pub result: Bytes,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct CrossContractHandler;
+
+#[contractimpl]
+impl CrossContractHandler {
+    /// Initialize with admin and optional registry contract. Call once.
+    pub fn init(env: Env, admin: Address, registry_contract: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::RegistryContract, &registry_contract);
+        env.storage().instance().set(&DataKey::NextRouteId, &0u32);
+        Initialized {
+            admin,
+            registry_contract,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Register a route: source_contract may dispatch to target_contract via selector. Admin only.
+    pub fn register_route(
+        env: Env,
+        admin: Address,
+        source_contract: Address,
+        target_contract: Address,
+        selector: Symbol,
+    ) -> Result<u32, Error> {
+        require_admin(&env, &admin)?;
+        if source_contract == target_contract {
+            return Err(Error::InvalidRoute);
+        }
+        let next: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextRouteId)
+            .unwrap_or(0);
+        let route_id = next.checked_add(1).ok_or(Error::InvalidRoute)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::NextRouteId, &route_id);
+        let route = Route {
+            source_contract: source_contract.clone(),
+            target_contract: target_contract.clone(),
+            selector: selector.clone(),
+        };
+        env.storage().instance().set(&DataKey::Route(route_id), &route);
+        RouteRegistered {
+            route_id,
+            source_contract,
+            target_contract,
+            selector,
+        }
+        .publish(&env);
+        Ok(route_id)
+    }
+
+    /// Dispatch a request along a registered route. Caller must be admin or source_contract for that route.
+    pub fn dispatch(
+        env: Env,
+        caller: Address,
+        request_id: Symbol,
+        route_id: u32,
+        payload: Bytes,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        let route: Route = env
+            .storage()
+            .instance()
+            .get(&DataKey::Route(route_id))
+            .ok_or(Error::RouteNotFound)?;
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if caller != admin && caller != route.source_contract {
+            return Err(Error::NotAuthorized);
+        }
+        if env.storage().instance().has(&DataKey::Request(request_id.clone())) {
+            return Err(Error::DuplicateRequestId);
+        }
+        let status = RequestStatus::Pending(route_id, payload.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::Request(request_id.clone()), &status);
+        Dispatched {
+            request_id,
+            route_id,
+            payload,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Acknowledge a pending request with a result. Caller must be admin or target_contract for that request's route.
+    pub fn acknowledge(
+        env: Env,
+        caller: Address,
+        request_id: Symbol,
+        result: Bytes,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        let status: RequestStatus = env
+            .storage()
+            .instance()
+            .get(&DataKey::Request(request_id.clone()))
+            .ok_or(Error::RequestNotFound)?;
+        let route_id = match &status {
+            RequestStatus::Pending(rid, _) => *rid,
+            RequestStatus::Acknowledged(_) => return Err(Error::RequestAlreadyAcknowledged),
+        };
+        let route: Route = env
+            .storage()
+            .instance()
+            .get(&DataKey::Route(route_id))
+            .ok_or(Error::RouteNotFound)?;
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if caller != admin && caller != route.target_contract {
+            return Err(Error::NotAuthorized);
+        }
+        let new_status = RequestStatus::Acknowledged(result.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::Request(request_id.clone()), &new_status);
+        Acknowledged {
+            request_id,
+            result,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Return the route for a given route_id, or None if not found.
+    pub fn get_route(env: Env, route_id: u32) -> Result<Route, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Route(route_id))
+            .ok_or(Error::RouteNotFound)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    caller.require_auth();
+    if *caller != admin {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test;

--- a/contracts/cross-contract-handler/src/test.rs
+++ b/contracts/cross-contract-handler/src/test.rs
@@ -1,0 +1,158 @@
+//! Unit tests for Cross-Contract Handler.
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, Symbol};
+
+fn setup(
+    env: &Env,
+) -> (
+    CrossContractHandlerClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let admin = Address::generate(env);
+    let registry = Address::generate(env);
+    let source = Address::generate(env);
+    let target = Address::generate(env);
+    let contract_id = env.register(CrossContractHandler, ());
+    let client = CrossContractHandlerClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.init(&admin, &registry);
+    (client, admin, registry, source, target)
+}
+
+#[test]
+fn test_init_succeeds() {
+    let env = Env::default();
+    let (_, _, _, _, _) = setup(&env);
+}
+
+#[test]
+fn test_init_rejects_reinit() {
+    let env = Env::default();
+    let (client, admin, registry, _, _) = setup(&env);
+    env.mock_all_auths();
+    let result = client.try_init(&admin, &registry);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_register_route_returns_route_id() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let route_id = client.register_route(
+        &admin,
+        &source,
+        &target,
+        &Symbol::new(&env, "handle"),
+    );
+    assert_eq!(route_id, 1);
+}
+
+#[test]
+fn test_register_route_increments_route_id() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let s2 = Address::generate(&env);
+    let t2 = Address::generate(&env);
+    let id1 = client.register_route(&admin, &source, &target, &Symbol::new(&env, "a"));
+    let id2 = client.register_route(&admin, &s2, &t2, &Symbol::new(&env, "b"));
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn test_get_route_returns_registered_route() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let selector = Symbol::new(&env, "handle");
+    let route_id = client.register_route(&admin, &source, &target, &selector);
+    let route = client.get_route(&route_id);
+    assert_eq!(route.source_contract, source);
+    assert_eq!(route.target_contract, target);
+    assert_eq!(route.selector, selector);
+}
+
+#[test]
+fn test_get_route_not_found() {
+    let env = Env::default();
+    let (client, _, _, _, _) = setup(&env);
+    let result = client.try_get_route(&999);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_dispatch_by_source_succeeds() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let route_id = client.register_route(&admin, &source, &target, &Symbol::new(&env, "handle"));
+    let request_id = Symbol::new(&env, "req1");
+    let payload = Bytes::from_slice(&env, &[1, 2, 3]);
+    client.dispatch(&source, &request_id, &route_id, &payload);
+}
+
+#[test]
+fn test_dispatch_by_admin_succeeds() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let route_id = client.register_route(&admin, &source, &target, &Symbol::new(&env, "handle"));
+    let request_id = Symbol::new(&env, "req1");
+    let payload = Bytes::from_slice(&env, &[1, 2, 3]);
+    client.dispatch(&admin, &request_id, &route_id, &payload);
+}
+
+#[test]
+fn test_dispatch_duplicate_request_id_rejected() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let route_id = client.register_route(&admin, &source, &target, &Symbol::new(&env, "handle"));
+    let request_id = Symbol::new(&env, "req1");
+    let payload = Bytes::from_slice(&env, &[1, 2, 3]);
+    client.dispatch(&source, &request_id, &route_id, &payload);
+    let result = client.try_dispatch(&source, &request_id, &route_id, &payload);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_acknowledge_by_target_succeeds() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let route_id = client.register_route(&admin, &source, &target, &Symbol::new(&env, "handle"));
+    let request_id = Symbol::new(&env, "req1");
+    let payload = Bytes::from_slice(&env, &[1, 2, 3]);
+    client.dispatch(&source, &request_id, &route_id, &payload);
+    let result = Bytes::from_slice(&env, &[4, 5, 6]);
+    client.acknowledge(&target, &request_id, &result);
+}
+
+#[test]
+fn test_acknowledge_already_acknowledged_rejected() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+    let route_id = client.register_route(&admin, &source, &target, &Symbol::new(&env, "handle"));
+    let request_id = Symbol::new(&env, "req1");
+    let payload = Bytes::from_slice(&env, &[1, 2, 3]);
+    client.dispatch(&source, &request_id, &route_id, &payload);
+    let result = Bytes::from_slice(&env, &[4, 5, 6]);
+    client.acknowledge(&target, &request_id, &result);
+    let result2 = client.try_acknowledge(&target, &request_id, &result);
+    assert!(result2.is_err());
+}
+
+#[test]
+fn test_register_route_same_source_target_rejected() {
+    let env = Env::default();
+    let (client, admin, _, source, _) = setup(&env);
+    env.mock_all_auths();
+    let result = client.try_register_route(&admin, &source, &source, &Symbol::new(&env, "handle"));
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
Implements the Cross-Contract Communication Handler per issue #25.

## Changes
- **contracts/cross-contract-handler/** (new)
  - `init(admin, registry_contract)` — initialize once
  - `register_route(admin, source_contract, target_contract, selector)` — returns route_id
  - `dispatch(caller, request_id, route_id, payload)` — caller must be admin or source for route
  - `acknowledge(caller, request_id, result)` — caller must be admin or target for request's route
  - `get_route(route_id)` — view
- Events: Initialized, RouteRegistered, Dispatched, Acknowledged
- Storage: instance (Admin, RegistryContract, NextRouteId, Route(u32), Request(Symbol))
- README: methods, storage, events, invariants
- Unit tests: 12 tests (init, register_route, get_route, dispatch, acknowledge, failure paths)

## Testing
`cd contracts/cross-contract-handler && cargo test` — all 12 tests pass.

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a Cross-Contract Communication Handler for routing and tracking cross-contract requests between services.
  * Added support for route registration, request dispatching, and acknowledgment with admin and authorization controls.

* **Documentation**
  * Added comprehensive documentation covering methods, storage model, events, and integration guidance.

* **Tests**
  * Included comprehensive unit test suite covering initialization, routing, dispatching, and acknowledgment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->