### PR TITLE
feat(contract-upgrade-timelock): add get_queued_upgrade accessor with readiness flag

### DIFF
--- a/contracts/contract-upgrade-timelock/src/lib.rs
+++ b/contracts/contract-upgrade-timelock/src/lib.rs
@@ -391,6 +391,24 @@ mod test {
     }
 
     #[test]
+    fn test_get_queued_upgrade_returns_none_after_cancel() {
+        let env = Env::default();
+        env.mock_all_auths();
+        set_time(&env, 1000);
+
+        let admin = Address::generate(&env);
+        let target = Address::generate(&env);
+        let contract_id = env.register_contract(None, ContractUpgradeTimelock);
+        let client = ContractUpgradeTimelockClient::new(&env, &contract_id);
+        client.init(&admin, &3600u64);
+
+        let uid = client.queue_upgrade(&target, &Symbol::new(&env, "H7"), &(1000 + 3600 + 1));
+        client.cancel_upgrade(&uid);
+
+        assert!(client.get_queued_upgrade(&uid).is_none());
+    }
+
+    #[test]
     fn test_get_queued_upgrade_ready() {
         let env = Env::default();
         env.mock_all_auths();

--- a/docs/contracts/contract-upgrade-timelock.md
+++ b/docs/contracts/contract-upgrade-timelock.md
@@ -96,7 +96,7 @@ Returns `None` in two deterministic cases:
 
 When `Some` is returned, the `is_ready` field is `true` iff `current_ledger_timestamp >= eta`, meaning the upgrade may be executed immediately. Consumers should treat `is_ready = false` as "still within the timelock window" and must not attempt execution.
 
-The entire view is computed in a single storage read, so there is no risk of partial state across multiple calls.
+The entire view is computed in a single storage read, so there is no risk of partial state within a single call/snapshot.
 
 #### Parameters
 


### PR DESCRIPTION
## Summary

Adds a single-read inspection accessor `get_queued_upgrade` to the upgrade timelock contract, returning a typed snapshot of any queued upgrade together with a computed readiness flag.

## Changes

### `contracts/contract-upgrade-timelock/src/lib.rs`
- Added `QueuedUpgradeView` struct (`upgrade_id`, `target_contract`, `queued_at_ledger`, `eta`, `is_ready`)
- Added `queued_at_ledger: u32` field to `UpgradeRecord`, populated at queue time via `env.ledger().sequence()`
- Added `get_queued_upgrade(env, upgrade_id) -> Option<QueuedUpgradeView>`:
  - Returns `None` when no record exists or the upgrade is no longer `Queued` (executed/cancelled)
  - Returns `Some` with `is_ready = now >= eta` computed atomically in a single storage read
- Added 3 new tests: `test_get_queued_upgrade_no_queue`, `test_get_queued_upgrade_not_ready`, `test_get_queued_upgrade_ready`

### `docs/contracts/contract-upgrade-timelock.md`
- Documented `get_queued_upgrade` method, return type, and all `QueuedUpgradeView` fields with readiness semantics

## Test Results

All 8 tests pass (5 pre-existing + 3 new).

```
test test::test_get_queued_upgrade_no_queue ... ok
test test::test_get_queued_upgrade_not_ready ... ok
test test::test_get_queued_upgrade_ready ... ok
test test::test_queue_and_execute ... ok
test test::test_execute_too_early_fails ... ok
test test::test_cancel_upgrade ... ok
test test::test_eta_too_soon_fails ... ok
test test::test_double_init_fails ... ok
```

Closes #287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to query details about queued contract upgrades, including when they were queued and a readiness indicator based on current ledger time.

* **Documentation**
  * Added API docs for the new queued-upgrade query, describing return values and readiness semantics.

* **Tests**
  * Added unit tests covering missing, queued-not-ready, queued-then-cancelled, and queued-becomes-ready scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->