### PR TITLE
feat(contracts): add audit tracking and rule counting to cross-contra…

### DIFF
--- a/contracts/cross-contract-call-guard/src/lib.rs
+++ b/contracts/cross-contract-call-guard/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, Address,
-    Env, Symbol,
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, Env, Symbol,
 };
 
 // ---------------------------------------------------------------------------
@@ -39,10 +38,21 @@ pub struct PolicyKey {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeniedCallAudit {
+    pub source: Address,
+    pub target: Address,
+    pub selector: Symbol,
+    pub denied_at: u64,
+}
+
+#[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
     Policy(PolicyKey),
+    DeniedAudit(PolicyKey),
+    RuleCount(Address),
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +76,14 @@ pub struct CallDenied {
     pub source: Address,
     pub target: Address,
     pub selector: Symbol,
+}
+
+#[contractevent]
+pub struct DeniedCallAuditEvent {
+    pub source: Address,
+    pub target: Address,
+    pub selector: Symbol,
+    pub denied_at: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -101,11 +119,19 @@ impl CrossContractCallGuard {
         let admin = Self::require_admin(&env)?;
         admin.require_auth();
 
-        let key = DataKey::Policy(PolicyKey {
+        let policy_key = PolicyKey {
             source: source.clone(),
             target: target.clone(),
             selector: selector.clone(),
-        });
+        };
+        let key = DataKey::Policy(policy_key);
+
+        // Only increment rule count if the policy did not already exist
+        let already_exists = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&key)
+            .unwrap_or(false);
 
         env.storage().persistent().set(&key, &true);
         env.storage().persistent().extend_ttl(
@@ -114,7 +140,24 @@ impl CrossContractCallGuard {
             PERSISTENT_BUMP_LEDGERS,
         );
 
-        CallAllowed { source, target, selector }.publish(&env);
+        if !already_exists {
+            let count_key = DataKey::RuleCount(source.clone());
+            let current: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+            let new_count = current.saturating_add(1);
+            env.storage().persistent().set(&count_key, &new_count);
+            env.storage().persistent().extend_ttl(
+                &count_key,
+                PERSISTENT_BUMP_THRESHOLD,
+                PERSISTENT_BUMP_LEDGERS,
+            );
+        }
+
+        CallAllowed {
+            source,
+            target,
+            selector,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -129,15 +172,64 @@ impl CrossContractCallGuard {
         let admin = Self::require_admin(&env)?;
         admin.require_auth();
 
-        let key = DataKey::Policy(PolicyKey {
+        let policy_key = PolicyKey {
             source: source.clone(),
             target: target.clone(),
             selector: selector.clone(),
-        });
+        };
+        let key = DataKey::Policy(policy_key.clone());
+
+        // Only decrement rule count if the policy existed
+        let existed = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&key)
+            .unwrap_or(false);
 
         env.storage().persistent().remove(&key);
 
-        CallDenied { source, target, selector }.publish(&env);
+        if existed {
+            let count_key = DataKey::RuleCount(source.clone());
+            let current: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+            let new_count = current.saturating_sub(1);
+            env.storage().persistent().set(&count_key, &new_count);
+            env.storage().persistent().extend_ttl(
+                &count_key,
+                PERSISTENT_BUMP_THRESHOLD,
+                PERSISTENT_BUMP_LEDGERS,
+            );
+        }
+
+        // Store denied-call audit snapshot
+        let denied_at = env.ledger().timestamp();
+        let audit = DeniedCallAudit {
+            source: source.clone(),
+            target: target.clone(),
+            selector: selector.clone(),
+            denied_at,
+        };
+        let audit_key = DataKey::DeniedAudit(policy_key);
+        env.storage().persistent().set(&audit_key, &audit);
+        env.storage().persistent().extend_ttl(
+            &audit_key,
+            PERSISTENT_BUMP_THRESHOLD,
+            PERSISTENT_BUMP_LEDGERS,
+        );
+
+        DeniedCallAuditEvent {
+            source: source.clone(),
+            target: target.clone(),
+            selector: selector.clone(),
+            denied_at,
+        }
+        .publish(&env);
+
+        CallDenied {
+            source,
+            target,
+            selector,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -155,7 +247,12 @@ impl CrossContractCallGuard {
             selector,
         });
 
-        if !env.storage().persistent().get::<_, bool>(&key).unwrap_or(false) {
+        if !env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&key)
+            .unwrap_or(false)
+        {
             return Err(Error::CallDenied);
         }
 
@@ -163,12 +260,7 @@ impl CrossContractCallGuard {
     }
 
     /// Check the state of a specific policy.
-    pub fn policy_state(
-        env: Env,
-        source: Address,
-        target: Address,
-        selector: Symbol,
-    ) -> bool {
+    pub fn policy_state(env: Env, source: Address, target: Address, selector: Symbol) -> bool {
         let key = DataKey::Policy(PolicyKey {
             source,
             target,
@@ -176,6 +268,28 @@ impl CrossContractCallGuard {
         });
 
         env.storage().persistent().get(&key).unwrap_or(false)
+    }
+
+    /// Read-only accessor: returns the audit snapshot for a denied call, or None.
+    pub fn denied_audit(
+        env: Env,
+        source: Address,
+        target: Address,
+        selector: Symbol,
+    ) -> Option<DeniedCallAudit> {
+        let key = DataKey::DeniedAudit(PolicyKey {
+            source,
+            target,
+            selector,
+        });
+
+        env.storage().persistent().get(&key)
+    }
+
+    /// Read-only accessor: returns the count of active (allowed) rules for a source.
+    pub fn rule_summary(env: Env, source: Address) -> u32 {
+        let key = DataKey::RuleCount(source);
+        env.storage().persistent().get(&key).unwrap_or(0)
     }
 
     // ---------------------------------------------------------------------------
@@ -197,7 +311,7 @@ impl CrossContractCallGuard {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Address, Env, symbol_short};
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
 
     struct Setup<'a> {
         _env: Env,
@@ -217,7 +331,11 @@ mod test {
 
         let client: CrossContractCallGuardClient<'static> = unsafe { core::mem::transmute(client) };
 
-        Setup { _env: env, client, _admin: admin }
+        Setup {
+            _env: env,
+            client,
+            _admin: admin,
+        }
     }
 
     #[test]
@@ -257,9 +375,65 @@ mod test {
 
         // Allow
         s.client.allow_call(&source, &target, &selector);
-        
+
         // Assert should pass
         let result = s.client.try_assert_allowed(&source, &target, &selector);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_denied_call_audit() {
+        let s = setup();
+        let source = Address::generate(&s._env);
+        let target = Address::generate(&s._env);
+        let selector = symbol_short!("swap");
+
+        // No audit before any denial
+        let audit = s.client.denied_audit(&source, &target, &selector);
+        assert_eq!(audit, None);
+
+        // Allow then deny
+        s.client.allow_call(&source, &target, &selector);
+        s.client.deny_call(&source, &target, &selector);
+
+        // Audit should now exist
+        let audit = s.client.denied_audit(&source, &target, &selector);
+        assert!(audit.is_some());
+        let record = audit.unwrap();
+        assert_eq!(record.source, source);
+        assert_eq!(record.target, target);
+        assert_eq!(record.selector, selector);
+    }
+
+    #[test]
+    fn test_rule_summary() {
+        let s = setup();
+        let source = Address::generate(&s._env);
+        let target_a = Address::generate(&s._env);
+        let target_b = Address::generate(&s._env);
+        let sel_swap = symbol_short!("swap");
+        let sel_xfer = symbol_short!("transfer");
+
+        // Starts at zero
+        assert_eq!(s.client.rule_summary(&source), 0);
+
+        // Allow two rules for the same source
+        s.client.allow_call(&source, &target_a, &sel_swap);
+        assert_eq!(s.client.rule_summary(&source), 1);
+
+        s.client.allow_call(&source, &target_b, &sel_xfer);
+        assert_eq!(s.client.rule_summary(&source), 2);
+
+        // Re-allowing the same rule should NOT increment
+        s.client.allow_call(&source, &target_a, &sel_swap);
+        assert_eq!(s.client.rule_summary(&source), 2);
+
+        // Deny one rule
+        s.client.deny_call(&source, &target_a, &sel_swap);
+        assert_eq!(s.client.rule_summary(&source), 1);
+
+        // Denying a rule that no longer exists should NOT decrement
+        s.client.deny_call(&source, &target_a, &sel_swap);
+        assert_eq!(s.client.rule_summary(&source), 1);
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,9 +66,10 @@ const AppContent: React.FC = () => {
 
   return (
     <div className="app-container">
-      <header className="app-header">
+      <a href="#main-content" className="skip-link">Skip to main content</a>
+      <header className="app-header" role="banner">
         <div className="logo">{t('app.title')}</div>
-        <nav>
+        <nav aria-label="Main navigation">
           <ul>
             <li><a href="/" className="active">{t('nav.lobby')}</a></li>
             <li><a href="/games">{t('nav.games')}</a></li>
@@ -78,13 +79,13 @@ const AppContent: React.FC = () => {
         <LocaleSwitcher />
       </header>
       
-      <main className="app-content">
+      <main className="app-content" id="main-content">
         <RouteErrorBoundary>
           <GameLobby />
         </RouteErrorBoundary>
       </main>
 
-      <footer className="app-footer">
+      <footer className="app-footer" role="contentinfo">
         <div className="footer-content">
           <p>{t('footer.copyright')}</p>
           <div className="footer-links">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,6 +23,33 @@ body {
   overflow-x: hidden;
 }
 
+/* --- Skip Link (accessibility) --- */
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: 1000;
+  padding: 0.75rem 1.5rem;
+  background: var(--accent);
+  color: #000;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 0 0 8px 0;
+}
+
+.skip-link:focus {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: auto;
+  height: auto;
+  z-index: 1000;
+}
+
 .app-container {
   min-height: 100vh;
   display: flex;

--- a/frontend/src/pages/GameLobby.tsx
+++ b/frontend/src/pages/GameLobby.tsx
@@ -51,12 +51,12 @@ export const GameLobby: React.FC = () => {
     await retryNetworkCheck();
   }, [retryNetworkCheck]);
 
-  if (loading) return <div className="lobby-loading">Loading elite games...</div>;
-  if (error) return <div className="lobby-error">Failed to load games: {error}</div>;
+  if (loading) return <div className="lobby-loading" role="status" aria-live="polite">Loading elite games...</div>;
+  if (error) return <div className="lobby-error" role="status" aria-live="polite">Failed to load games: {error}</div>;
 
   return (
     <div className="game-lobby">
-      <div className="lobby-dashboard">
+      <section aria-label="Wallet and network status" className="lobby-dashboard">
         <div className="lobby-dashboard__col">
           <NetworkGuardBanner
             network={wallet.network}
@@ -92,30 +92,32 @@ export const GameLobby: React.FC = () => {
 
         <div className="lobby-dashboard__col">
           <div className="lobby-header">
-            <h2>Live Arena</h2>
+            <h2 id="games-heading">Live Arena</h2>
             <p>Real-time game status across the Stellar ecosystem.</p>
           </div>
         </div>
-      </div>
+      </section>
 
-      {games.length === 0 ? (
-        <div className="lobby-empty">
-          <div className="empty-icon">📭</div>
-          <p>No games active at the moment. Check back later!</p>
-        </div>
-      ) : (
-        <div className="games-grid">
-          {games.map((game) => (
-            <StatusCard
-              key={game.id}
-              id={game.id}
-              name={game.name}
-              status={game.status}
-              wager={game.wager as number | undefined}
-            />
-          ))}
-        </div>
-      )}
+      <section aria-labelledby="games-heading" className="games-section">
+        {games.length === 0 ? (
+          <div className="lobby-empty" role="status" aria-live="polite">
+            <div className="empty-icon">📭</div>
+            <p>No games active at the moment. Check back later!</p>
+          </div>
+        ) : (
+          <div className="games-grid" role="region" aria-label="Active games">
+            {games.map((game) => (
+              <StatusCard
+                key={game.id}
+                id={game.id}
+                name={game.name}
+                status={game.status}
+                wager={game.wager as number | undefined}
+              />
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   );
 };

--- a/frontend/tests/components/GameLobby.test.tsx
+++ b/frontend/tests/components/GameLobby.test.tsx
@@ -4,6 +4,28 @@ import GameLobby from '../../src/pages/GameLobby';
 import { ApiClient } from '../../src/services/typed-api-sdk';
 
 vi.mock('../../src/services/typed-api-sdk');
+vi.mock('../../src/hooks/v1/useWalletStatus', () => ({
+  useWalletStatus: () => ({
+    status: 'disconnected',
+    address: null,
+    network: null,
+    provider: null,
+    capabilities: { isConnected: false },
+    error: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    refresh: vi.fn(),
+    isRefreshing: false,
+    lastUpdatedAt: null,
+  }),
+}));
+vi.mock('../../src/utils/v1/useNetworkGuard', () => ({
+  isSupportedNetwork: () => ({
+    isSupported: true,
+    normalizedActual: 'TESTNET',
+    supportedNetworks: ['TESTNET', 'PUBLIC'],
+  }),
+}));
 
 test('renders GameLobby and fetches games', async () => {
   const mockGames = [
@@ -77,6 +99,108 @@ describe('GameLobby two-column layout', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/No games active/i)).toBeDefined();
+    });
+  });
+});
+
+describe('GameLobby accessibility landmarks', () => {
+  it('renders loading state with role="status" and aria-live', () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue(
+      new Promise(() => {}),
+    );
+
+    const { container } = render(<GameLobby />);
+    const loadingEl = container.querySelector('.lobby-loading');
+    expect(loadingEl).toBeTruthy();
+    expect(loadingEl?.getAttribute('role')).toBe('status');
+    expect(loadingEl?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('renders error state with role="status" and aria-live', async () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: false,
+      error: { message: 'Network error' },
+    });
+
+    const { container } = render(<GameLobby />);
+
+    await waitFor(() => {
+      const errorEl = container.querySelector('.lobby-error');
+      expect(errorEl).toBeTruthy();
+      expect(errorEl?.getAttribute('role')).toBe('status');
+      expect(errorEl?.getAttribute('aria-live')).toBe('polite');
+    });
+  });
+
+  it('renders dashboard as a section with aria-label', async () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+
+    const { container } = render(<GameLobby />);
+
+    await waitFor(() => {
+      const dashboard = container.querySelector('.lobby-dashboard');
+      expect(dashboard).toBeTruthy();
+      expect(dashboard?.tagName).toBe('SECTION');
+      expect(dashboard?.getAttribute('aria-label')).toBe(
+        'Wallet and network status',
+      );
+    });
+  });
+
+  it('renders games section with aria-labelledby referencing heading', async () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [{ id: 'g1', name: 'Game One', status: 'active', wager: 25 }],
+    });
+
+    const { container } = render(<GameLobby />);
+
+    await waitFor(() => {
+      const gamesSection = container.querySelector('.games-section');
+      expect(gamesSection).toBeTruthy();
+      expect(gamesSection?.tagName).toBe('SECTION');
+      expect(gamesSection?.getAttribute('aria-labelledby')).toBe(
+        'games-heading',
+      );
+
+      const heading = container.querySelector('#games-heading');
+      expect(heading).toBeTruthy();
+      expect(heading?.textContent).toBe('Live Arena');
+    });
+  });
+
+  it('renders games grid with role="region" and aria-label', async () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [{ id: 'g2', name: 'Game Two', status: 'active', wager: 10 }],
+    });
+
+    const { container } = render(<GameLobby />);
+
+    await waitFor(() => {
+      const grid = container.querySelector('.games-grid');
+      expect(grid).toBeTruthy();
+      expect(grid?.getAttribute('role')).toBe('region');
+      expect(grid?.getAttribute('aria-label')).toBe('Active games');
+    });
+  });
+
+  it('renders empty state with role="status" and aria-live', async () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+
+    const { container } = render(<GameLobby />);
+
+    await waitFor(() => {
+      const emptyEl = container.querySelector('.lobby-empty');
+      expect(emptyEl).toBeTruthy();
+      expect(emptyEl?.getAttribute('role')).toBe('status');
+      expect(emptyEl?.getAttribute('aria-live')).toBe('polite');
     });
   });
 });


### PR DESCRIPTION
…ct call guard

- Add DeniedCallAudit struct to capture denied call snapshots with timestamp
- Add DeniedCallAuditEvent for emitting audit trail on policy denial
- Implement rule counting per source address via RuleCount data key
- Track policy existence to only increment/decrement counts on actual changes
- Add denied_audit() accessor to retrieve audit snapshots for denied calls
- Add rule_summary() accessor to get active rule count for a source
- Store audit snapshots when policies are denied with ledger timestamp
- Improve code formatting and import organization for consistency
- Add comprehensive test coverage for new audit and counting functionality

closes #361 
closes #372 
closes #356 
closes #363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added skip-to-content accessibility link for keyboard navigation.
  * Enhanced semantic structure of navigation, main content, and footer regions for better screen reader support.
  * Improved live region announcements for loading and error states.
  * Added audit tracking for denied contract calls with timestamp information and rule counters.

* **Tests**
  * Expanded test coverage for accessibility landmarks and new audit/rule-tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->