### PR TITLE
feat(contracts): add round and policy snapshot accessors

### DIFF
--- a/contracts/daily-trivia/README.md
+++ b/contracts/daily-trivia/README.md
@@ -19,6 +19,19 @@ payload. The contract verifies the submission against a trusted answer hash
 - `submit_answer(player, round_id, answer_payload)`
 - `close_round(round_id)`
 - `claim_reward(player, round_id)`
+- `get_round_snapshot()`
+- `get_participant_answer_summary()`
+- `get_reward_pool_snapshot()`
+
+## Snapshot Reads
+
+- `get_participant_answer_summary` returns deterministic latest-round counters for
+  participant, correct, and incorrect submissions.
+- `get_reward_pool_snapshot` returns latest-round reward values that align with
+  settlement outcomes (`reward_amount`, `winner_count`, and payout totals).
+- If no round has been opened, both accessors report an `Uninitialized` status
+  with zeroed values.
+- Closed rounds are reported as resolved and remain stable across repeated reads.
 
 ## Settlement
 

--- a/contracts/daily-trivia/src/lib.rs
+++ b/contracts/daily-trivia/src/lib.rs
@@ -114,6 +114,30 @@ pub struct RoundSnapshot {
     pub closed_at: u64,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParticipantAnswerSummary {
+    pub status: RoundSnapshotStatus,
+    pub round_id: u64,
+    pub is_open: bool,
+    pub participant_count: u32,
+    pub correct_count: u32,
+    pub incorrect_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RewardPoolSnapshot {
+    pub status: RoundSnapshotStatus,
+    pub round_id: u64,
+    pub reward_amount: i128,
+    pub payout_per_winner: i128,
+    pub winner_count: u32,
+    pub total_claimable: i128,
+    pub total_distributed: i128,
+    pub total_unclaimed: i128,
+}
+
 // ---------------------------------------------------------------------------
 // Events
 // ---------------------------------------------------------------------------
@@ -435,6 +459,115 @@ impl DailyTrivia {
             payout_per_winner: round.payout_per_winner,
             opened_at: round.opened_at,
             closed_at: round.closed_at,
+        })
+    }
+
+    /// Returns participation/correctness counters for the latest round.
+    ///
+    /// If no round exists yet, returns an `Uninitialized` summary.
+    /// If the latest round is closed, status is `Resolved` with final counters.
+    pub fn get_participant_answer_summary(env: Env) -> Result<ParticipantAnswerSummary, Error> {
+        require_initialized(&env)?;
+
+        let Some(round_id) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::LatestRoundId)
+        else {
+            return Ok(ParticipantAnswerSummary {
+                status: RoundSnapshotStatus::Uninitialized,
+                round_id: 0,
+                is_open: false,
+                participant_count: 0,
+                correct_count: 0,
+                incorrect_count: 0,
+            });
+        };
+
+        let round: RoundData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Round(round_id))
+            .ok_or(Error::RoundNotFound)?;
+
+        let incorrect_count = round
+            .participant_count
+            .checked_sub(round.winner_count)
+            .ok_or(Error::Overflow)?;
+
+        Ok(ParticipantAnswerSummary {
+            status: match round.status {
+                RoundStatus::Open => RoundSnapshotStatus::Active,
+                RoundStatus::Closed => RoundSnapshotStatus::Resolved,
+            },
+            round_id,
+            is_open: round.status == RoundStatus::Open,
+            participant_count: round.participant_count,
+            correct_count: round.winner_count,
+            incorrect_count,
+        })
+    }
+
+    /// Returns reward-pool relevant values for the latest round.
+    ///
+    /// If no round exists yet, returns an `Uninitialized` snapshot.
+    /// During active rounds, distribution values remain zero until close.
+    pub fn get_reward_pool_snapshot(env: Env) -> Result<RewardPoolSnapshot, Error> {
+        require_initialized(&env)?;
+
+        let Some(round_id) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::LatestRoundId)
+        else {
+            return Ok(RewardPoolSnapshot {
+                status: RoundSnapshotStatus::Uninitialized,
+                round_id: 0,
+                reward_amount: 0,
+                payout_per_winner: 0,
+                winner_count: 0,
+                total_claimable: 0,
+                total_distributed: 0,
+                total_unclaimed: 0,
+            });
+        };
+
+        let round: RoundData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Round(round_id))
+            .ok_or(Error::RoundNotFound)?;
+
+        let total_claimable = round
+            .payout_per_winner
+            .checked_mul(round.winner_count as i128)
+            .ok_or(Error::Overflow)?;
+        let total_distributed = if round.status == RoundStatus::Closed {
+            total_claimable
+        } else {
+            0
+        };
+        let total_unclaimed = if round.status == RoundStatus::Closed {
+            round
+                .reward_amount
+                .checked_sub(total_claimable)
+                .ok_or(Error::Overflow)?
+        } else {
+            round.reward_amount
+        };
+
+        Ok(RewardPoolSnapshot {
+            status: match round.status {
+                RoundStatus::Open => RoundSnapshotStatus::Active,
+                RoundStatus::Closed => RoundSnapshotStatus::Resolved,
+            },
+            round_id,
+            reward_amount: round.reward_amount,
+            payout_per_winner: round.payout_per_winner,
+            winner_count: round.winner_count,
+            total_claimable,
+            total_distributed,
+            total_unclaimed,
         })
     }
 }

--- a/contracts/leaderboard/src/lib.rs
+++ b/contracts/leaderboard/src/lib.rs
@@ -46,6 +46,13 @@ pub struct ScoreEntry {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerRankLookup {
+    pub ranked: bool,
+    pub rank: u32,
+}
+
+#[contracttype]
 pub enum DataKey {
     Admin,
     Authorized(Address),
@@ -241,6 +248,62 @@ impl LeaderboardContract {
         }
 
         Ok(0)
+    }
+
+    /// Returns explicit rank lookup metadata for a player.
+    pub fn player_rank_lookup(
+        env: Env,
+        game_id: Symbol,
+        player: Address,
+    ) -> Result<PlayerRankLookup, Error> {
+        let rank = Self::player_rank(env, game_id, player)?;
+        Ok(PlayerRankLookup {
+            ranked: rank > 0,
+            rank,
+        })
+    }
+
+    /// Returns a deterministic rank-ordered slice around `player`.
+    ///
+    /// `radius` controls how many neighbors above and below are included.
+    /// Returns an empty slice if the player is not currently ranked.
+    pub fn neighboring_slice(
+        env: Env,
+        game_id: Symbol,
+        player: Address,
+        radius: u32,
+    ) -> Vec<ScoreEntry> {
+        let leaderboard: Vec<ScoreEntry> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Leaderboard(game_id))
+            .unwrap_or(Vec::new(&env));
+
+        let mut center: Option<u32> = None;
+        for i in 0..leaderboard.len() {
+            if leaderboard.get_unchecked(i).player == player {
+                center = Some(i);
+                break;
+            }
+        }
+
+        let Some(center_idx) = center else {
+            return Vec::new(&env);
+        };
+
+        let start = center_idx.saturating_sub(radius);
+        let mut end = center_idx
+            .checked_add(radius)
+            .unwrap_or(MAX_LEADERBOARD_SIZE - 1);
+        if end >= leaderboard.len() {
+            end = leaderboard.len().saturating_sub(1);
+        }
+
+        let mut result = Vec::new(&env);
+        for i in start..=end {
+            result.push_back(leaderboard.get_unchecked(i));
+        }
+        result
     }
 
     /// Get a player's raw score.

--- a/contracts/pattern-puzzle/src/lib.rs
+++ b/contracts/pattern-puzzle/src/lib.rs
@@ -43,19 +43,19 @@ pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    NotInitialized     = 1,
-    NotAuthorized      = 2,
-    RoundNotFound      = 3,
+    NotInitialized = 1,
+    NotAuthorized = 2,
+    RoundNotFound = 3,
     RoundAlreadyExists = 4,
-    RoundNotOpen       = 5,
-    RoundNotResolved   = 6,
-    AlreadySubmitted   = 7,
-    AlreadyClaimed     = 8,
-    NoRewardAvailable  = 9,
-    InvalidAmount      = 10,
-    Overflow           = 11,
+    RoundNotOpen = 5,
+    RoundNotResolved = 6,
+    AlreadySubmitted = 7,
+    AlreadyClaimed = 8,
+    NoRewardAvailable = 9,
+    InvalidAmount = 10,
+    Overflow = 11,
     CommitmentMismatch = 12,
-    RoundFull          = 13,
+    RoundFull = 13,
 }
 
 // ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@ pub enum Error {
 #[contracttype]
 #[derive(Clone, PartialEq)]
 pub enum RoundStatus {
-    Open     = 0,
+    Open = 0,
     Resolved = 1,
 }
 
@@ -77,17 +77,17 @@ pub enum RoundStatus {
 pub struct RoundData {
     /// SHA-256 hash of the correct pattern, committed before submissions open.
     pub pattern_commitment: BytesN<32>,
-    pub status:             RoundStatus,
+    pub status: RoundStatus,
     /// Set during resolve_round after iterating all submissions.
-    pub winner_count:       u32,
+    pub winner_count: u32,
     /// Populated only after resolve_round; empty Bytes while status is Open.
-    pub correct_pattern:    Bytes,
+    pub correct_pattern: Bytes,
     /// Amount each player must wager to enter (0 = free round).
-    pub entry_fee:          i128,
+    pub entry_fee: i128,
     /// Accumulated from all submitted entry fees.
-    pub total_pot:          i128,
+    pub total_pot: i128,
     /// Current number of submissions; enforces MAX_PLAYERS_PER_ROUND.
-    pub player_count:       u32,
+    pub player_count: u32,
 }
 
 /// A player's committed guess for a round.
@@ -95,7 +95,7 @@ pub struct RoundData {
 #[derive(Clone)]
 pub struct PlayerSubmission {
     pub solution: Bytes,
-    pub wager:    i128,
+    pub wager: i128,
 }
 
 /// Storage key discriminants.
@@ -112,6 +112,7 @@ pub enum DataKey {
     Admin,
     PrizePoolContract,
     BalanceContract,
+    LatestRoundId,
     // --- persistent() keys: round and player data ---
     /// RoundData keyed by round_id.
     Round(u32),
@@ -123,6 +124,33 @@ pub enum DataKey {
     IsWinner(u32, Address),
     /// Set to `true` during claim_reward to prevent double-claims.
     Claimed(u32, Address),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SnapshotStatus {
+    Missing = 0,
+    Unresolved = 1,
+    Resolved = 2,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RoundCommitmentSummary {
+    pub status: SnapshotStatus,
+    pub round_id: u32,
+    pub pattern_commitment: BytesN<32>,
+    pub player_count: u32,
+    pub entry_fee: i128,
+    pub total_pot: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct WinnerCountSnapshot {
+    pub status: SnapshotStatus,
+    pub round_id: u32,
+    pub winner_count: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -181,10 +209,10 @@ impl PatternPuzzle {
     /// address in instance storage. Subsequent calls are rejected with
     /// `NotAuthorized`.
     pub fn init(
-        env:                 Env,
-        admin:               Address,
+        env: Env,
+        admin: Address,
         prize_pool_contract: Address,
-        balance_contract:    Address,
+        balance_contract: Address,
     ) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::NotAuthorized);
@@ -192,9 +220,13 @@ impl PatternPuzzle {
 
         admin.require_auth();
 
-        env.storage().instance().set(&DataKey::Admin,             &admin);
-        env.storage().instance().set(&DataKey::PrizePoolContract, &prize_pool_contract);
-        env.storage().instance().set(&DataKey::BalanceContract,   &balance_contract);
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::PrizePoolContract, &prize_pool_contract);
+        env.storage()
+            .instance()
+            .set(&DataKey::BalanceContract, &balance_contract);
 
         Ok(())
     }
@@ -209,11 +241,11 @@ impl PatternPuzzle {
     /// `entry_fee` is the token amount each player must wager (0 for free rounds).
     /// Round data is stored in persistent storage with a 30-day TTL.
     pub fn create_puzzle(
-        env:                Env,
-        admin:              Address,
-        round_id:           u32,
+        env: Env,
+        admin: Address,
+        round_id: u32,
         pattern_commitment: BytesN<32>,
-        entry_fee:          i128,
+        entry_fee: i128,
     ) -> Result<(), Error> {
         let stored_admin: Address = env
             .storage()
@@ -236,29 +268,40 @@ impl PatternPuzzle {
 
         let round = RoundData {
             pattern_commitment: pattern_commitment.clone(),
-            status:             RoundStatus::Open,
-            winner_count:       0,
-            correct_pattern:    Bytes::new(&env),
+            status: RoundStatus::Open,
+            winner_count: 0,
+            correct_pattern: Bytes::new(&env),
             entry_fee,
-            total_pot:          0,
-            player_count:       0,
+            total_pot: 0,
+            player_count: 0,
         };
 
-        env.storage().persistent().set(&DataKey::Round(round_id), &round);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Round(round_id), &round);
+        env.storage()
+            .instance()
+            .set(&DataKey::LatestRoundId, &round_id);
         env.storage().persistent().extend_ttl(
             &DataKey::Round(round_id),
             PERSISTENT_BUMP_LEDGERS,
             PERSISTENT_BUMP_LEDGERS,
         );
 
-        env.storage().persistent().set(&DataKey::Players(round_id), &Vec::<Address>::new(&env));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Players(round_id), &Vec::<Address>::new(&env));
         env.storage().persistent().extend_ttl(
             &DataKey::Players(round_id),
             PERSISTENT_BUMP_LEDGERS,
             PERSISTENT_BUMP_LEDGERS,
         );
 
-        RoundCreated { round_id, pattern_commitment }.publish(&env);
+        RoundCreated {
+            round_id,
+            pattern_commitment,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -274,8 +317,8 @@ impl PatternPuzzle {
     /// revealed pattern during `resolve_round`. Entry fee accounting is updated here;
     /// actual token transfer should invoke the balance contract (see TODO below).
     pub fn submit_solution(
-        env:      Env,
-        player:   Address,
+        env: Env,
+        player: Address,
         round_id: u32,
         solution: Bytes,
     ) -> Result<(), Error> {
@@ -309,7 +352,7 @@ impl PatternPuzzle {
 
         let submission = PlayerSubmission {
             solution: solution.clone(),
-            wager:    round.entry_fee,
+            wager: round.entry_fee,
         };
         env.storage()
             .persistent()
@@ -342,18 +385,22 @@ impl PatternPuzzle {
             .total_pot
             .checked_add(round.entry_fee)
             .ok_or(Error::Overflow)?;
-        round.player_count = round
-            .player_count
-            .checked_add(1)
-            .ok_or(Error::Overflow)?;
-        env.storage().persistent().set(&DataKey::Round(round_id), &round);
+        round.player_count = round.player_count.checked_add(1).ok_or(Error::Overflow)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Round(round_id), &round);
         env.storage().persistent().extend_ttl(
             &DataKey::Round(round_id),
             PERSISTENT_BUMP_LEDGERS,
             PERSISTENT_BUMP_LEDGERS,
         );
 
-        SolutionSubmitted { player, round_id, solution }.publish(&env);
+        SolutionSubmitted {
+            player,
+            round_id,
+            solution,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -369,9 +416,9 @@ impl PatternPuzzle {
     /// `MAX_PLAYERS_PER_ROUND`) to mark winners and compute `winner_count`.
     /// Transitions the round to `Resolved`.
     pub fn resolve_round(
-        env:             Env,
-        admin:           Address,
-        round_id:        u32,
+        env: Env,
+        admin: Address,
+        round_id: u32,
         correct_pattern: Bytes,
     ) -> Result<(), Error> {
         let stored_admin: Address = env
@@ -431,17 +478,24 @@ impl PatternPuzzle {
             }
         }
 
-        round.status          = RoundStatus::Resolved;
+        round.status = RoundStatus::Resolved;
         round.correct_pattern = correct_pattern.clone();
-        round.winner_count    = winner_count;
-        env.storage().persistent().set(&DataKey::Round(round_id), &round);
+        round.winner_count = winner_count;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Round(round_id), &round);
         env.storage().persistent().extend_ttl(
             &DataKey::Round(round_id),
             PERSISTENT_BUMP_LEDGERS,
             PERSISTENT_BUMP_LEDGERS,
         );
 
-        RoundResolved { round_id, correct_pattern, winner_count }.publish(&env);
+        RoundResolved {
+            round_id,
+            correct_pattern,
+            winner_count,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -455,11 +509,7 @@ impl PatternPuzzle {
     /// Returns the reward amount (`total_pot / winner_count`). The `Claimed` flag
     /// is set before any external call to preserve reentrancy safety. Actual token
     /// transfer should invoke the prize pool contract (see TODO below).
-    pub fn claim_reward(
-        env:      Env,
-        player:   Address,
-        round_id: u32,
-    ) -> Result<i128, Error> {
+    pub fn claim_reward(env: Env, player: Address, round_id: u32) -> Result<i128, Error> {
         player.require_auth();
 
         let round: RoundData = env
@@ -512,7 +562,12 @@ impl PatternPuzzle {
         // TODO: Invoke prize_pool_contract to transfer `reward` tokens to `player`.
         // prize_pool_contract_client::new(&env, &prize_pool_contract).payout(&player, &reward);
 
-        RewardClaimed { player, round_id, amount: reward }.publish(&env);
+        RewardClaimed {
+            player,
+            round_id,
+            amount: reward,
+        }
+        .publish(&env);
 
         Ok(reward)
     }
@@ -553,12 +608,76 @@ impl PatternPuzzle {
 
         let l = limit.unwrap_or(players.len());
         let n = if l > players.len() { players.len() } else { l };
-        
+
         let mut result = Vec::new(&env);
         for i in 0..n {
             result.push_back(players.get(i).unwrap());
         }
         result
+    }
+
+    /// Returns commitment metadata for the latest known round.
+    pub fn get_round_commitment_summary(env: Env) -> Result<RoundCommitmentSummary, Error> {
+        let Some(round_id) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::LatestRoundId)
+        else {
+            return Ok(RoundCommitmentSummary {
+                status: SnapshotStatus::Missing,
+                round_id: 0,
+                pattern_commitment: BytesN::from_array(&env, &[0; 32]),
+                player_count: 0,
+                entry_fee: 0,
+                total_pot: 0,
+            });
+        };
+
+        let round: RoundData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Round(round_id))
+            .ok_or(Error::RoundNotFound)?;
+
+        Ok(RoundCommitmentSummary {
+            status: match round.status {
+                RoundStatus::Open => SnapshotStatus::Unresolved,
+                RoundStatus::Resolved => SnapshotStatus::Resolved,
+            },
+            round_id,
+            pattern_commitment: round.pattern_commitment,
+            player_count: round.player_count,
+            entry_fee: round.entry_fee,
+            total_pot: round.total_pot,
+        })
+    }
+
+    /// Returns winner count for a specific round, with explicit status.
+    pub fn get_winner_count_snapshot(env: Env, round_id: u32) -> WinnerCountSnapshot {
+        let Some(round) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, RoundData>(&DataKey::Round(round_id))
+        else {
+            return WinnerCountSnapshot {
+                status: SnapshotStatus::Missing,
+                round_id,
+                winner_count: 0,
+            };
+        };
+
+        match round.status {
+            RoundStatus::Open => WinnerCountSnapshot {
+                status: SnapshotStatus::Unresolved,
+                round_id,
+                winner_count: 0,
+            },
+            RoundStatus::Resolved => WinnerCountSnapshot {
+                status: SnapshotStatus::Resolved,
+                round_id,
+                winner_count: round.winner_count,
+            },
+        }
     }
 }
 

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -77,6 +77,17 @@ pub struct TreasuryState {
     pub total_released: i128,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TreasuryPolicySnapshot {
+    pub initialized: bool,
+    pub paused: bool,
+    pub admin: Address,
+    pub token_address: Address,
+    pub signer_count: u32,
+    pub approval_threshold: u32,
+}
+
 #[contractevent]
 pub struct Initialized {
     pub admin: Address,
@@ -346,6 +357,29 @@ impl Treasury {
         }
 
         Ok(state)
+    }
+
+    /// Returns treasury policy and signer-threshold metadata.
+    pub fn policy_snapshot(env: Env) -> Result<TreasuryPolicySnapshot, Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Ok(TreasuryPolicySnapshot {
+                initialized: false,
+                paused: false,
+                admin: env.current_contract_address(),
+                token_address: env.current_contract_address(),
+                signer_count: 0,
+                approval_threshold: 0,
+            });
+        }
+
+        Ok(TreasuryPolicySnapshot {
+            initialized: true,
+            paused: is_paused(&env),
+            admin: get_admin(&env),
+            token_address: get_token(&env),
+            signer_count: 1,
+            approval_threshold: 1,
+        })
     }
 }
 

--- a/docs/contracts/daily-trivia.md
+++ b/docs/contracts/daily-trivia.md
@@ -122,6 +122,46 @@ pub fn get_round_snapshot(env: Env) -> Result<RoundSnapshot, Error>
 
 `Result<RoundSnapshot, Error>`
 
+### `get_participant_answer_summary`
+Returns deterministic participation and correctness counters for the latest known round.
+
+```rust
+pub fn get_participant_answer_summary(env: Env) -> Result<ParticipantAnswerSummary, Error>
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+
+#### Return Type
+
+`Result<ParticipantAnswerSummary, Error>`
+
+### `get_reward_pool_snapshot`
+Returns reward pool and payout totals for the latest known round.
+
+```rust
+pub fn get_reward_pool_snapshot(env: Env) -> Result<RewardPoolSnapshot, Error>
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+
+#### Return Type
+
+`Result<RewardPoolSnapshot, Error>`
+
+## Snapshot Status Semantics
+
+- `Uninitialized`: no round has been opened yet.
+- `Active`: latest round is open and may still accept submissions.
+- `Resolved`: latest round is closed; counters and reward values are final.
+
 ### `reserve`
 ```rust
 pub fn reserve(env: Env, _admin: Address, game_id: u64, amount: i128)
@@ -223,4 +263,3 @@ pub fn balance_of(env: Env, user: Address) -> i128
 #### Return Type
 
 `i128`
-

--- a/docs/contracts/leaderboard.md
+++ b/docs/contracts/leaderboard.md
@@ -137,6 +137,50 @@ pub fn player_rank(env: Env, game_id: Symbol, player: Address) -> Result<u32, Er
 
 `Result<u32, Error>`
 
+### `player_rank_lookup`
+Returns explicit rank lookup metadata for a player.
+
+```rust
+pub fn player_rank_lookup(env: Env, game_id: Symbol, player: Address) -> Result<PlayerRankLookup, Error>
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `game_id` | `Symbol` |
+| `player` | `Address` |
+
+#### Return Type
+
+`Result<PlayerRankLookup, Error>`
+
+### `neighboring_slice`
+Returns entries around a ranked player with deterministic boundaries and ordering.
+
+```rust
+pub fn neighboring_slice(env: Env, game_id: Symbol, player: Address, radius: u32) -> Vec<ScoreEntry>
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `game_id` | `Symbol` |
+| `player` | `Address` |
+| `radius` | `u32` |
+
+#### Return Type
+
+`Vec<ScoreEntry>`
+
+## Missing Player Behavior
+
+- `player_rank_lookup` returns `{ ranked: false, rank: 0 }`.
+- `neighboring_slice` returns an empty vector.
+
 ### `get_player_score`
 Get a player's raw score.
 
@@ -155,4 +199,3 @@ pub fn get_player_score(env: Env, game_id: Symbol, player: Address) -> u64
 #### Return Type
 
 `u64`
-

--- a/docs/contracts/pattern-puzzle.md
+++ b/docs/contracts/pattern-puzzle.md
@@ -179,3 +179,43 @@ pub fn get_leaderboard(env: Env, round_id: u32, limit: Option<u32>) -> Vec<Addre
 
 `Vec<Address>`
 
+### `get_round_commitment_summary`
+Returns commitment metadata for the latest known round.
+
+```rust
+pub fn get_round_commitment_summary(env: Env) -> Result<RoundCommitmentSummary, Error>
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+
+#### Return Type
+
+`Result<RoundCommitmentSummary, Error>`
+
+### `get_winner_count_snapshot`
+Returns winner-count metadata for a specific round.
+
+```rust
+pub fn get_winner_count_snapshot(env: Env, round_id: u32) -> WinnerCountSnapshot
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `round_id` | `u32` |
+
+#### Return Type
+
+`WinnerCountSnapshot`
+
+## Snapshot Status Semantics
+
+- `Missing`: target round does not exist.
+- `Unresolved`: round exists but has not been resolved.
+- `Resolved`: round is finalized; `winner_count` is stable.

--- a/docs/contracts/treasury.md
+++ b/docs/contracts/treasury.md
@@ -120,3 +120,26 @@ pub fn treasury_state(env: Env) -> Result<TreasuryState, Error>
 
 `Result<TreasuryState, Error>`
 
+### `policy_snapshot`
+Returns treasury policy configuration and signer-threshold metadata.
+
+```rust
+pub fn policy_snapshot(env: Env) -> Result<TreasuryPolicySnapshot, Error>
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+
+#### Return Type
+
+`Result<TreasuryPolicySnapshot, Error>`
+
+## Initialization Semantics
+
+- Uninitialized treasury returns `initialized = false`, `signer_count = 0`, and
+  `approval_threshold = 0`.
+- Configured treasury returns `initialized = true` with current admin/token,
+  plus signer-threshold metadata for policy inspection.


### PR DESCRIPTION
## Summary
- Add deterministic snapshot/read accessors across `daily-trivia`, `pattern-puzzle`, `leaderboard`, and `treasury` to expose participation, commitments, ranking context, and policy/threshold metadata for UI and ops surfaces.
- Update contract docs to describe new methods and explicit behavior for uninitialized/missing/unresolved/resolved states.
- Keep behavior side-effect free and compact so results are cheap to poll and stable for dashboards.

Closes #469
Closes #470
Closes #471
Closes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Daily Trivia: Added read-only snapshot queries to inspect participant answer summaries and reward pool information for the latest round.
  * Leaderboard: Added methods to look up player ranking status and retrieve neighboring leaderboard entries.
  * Pattern Puzzle: Added snapshot accessors for round commitment metadata and winner count information.
  * Treasury: Added policy configuration snapshot query to inspect treasury settings.
  * Updated contract documentation with new query methods and their behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->