### PR TITLE
feat:Contract price-prediction: add settlement preview and participan…

### DIFF
--- a/contracts/price-prediction/src/lib.rs
+++ b/contracts/price-prediction/src/lib.rs
@@ -26,7 +26,7 @@
 
 use soroban_sdk::{
     contract, contractclient, contracterror, contractevent, contractimpl, contracttype,
-    token::TokenClient, Address, Env, Symbol,
+    token::TokenClient, Address, Env, Symbol, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -60,26 +60,26 @@ pub trait OracleContract {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    AlreadyInitialized  = 1,
-    NotInitialized      = 2,
-    NotAuthorized       = 3,
-    InvalidAmount       = 4,
-    InvalidDirection    = 5,
-    RoundAlreadyExists  = 6,
-    RoundNotFound       = 7,
-    AlreadySettled      = 8,
-    NotSettled          = 9,
-    RoundNotClosed      = 10,
-    RoundClosed         = 11,
-    BetAlreadyPlaced    = 12,
-    BetNotFound         = 13,
-    AlreadyClaimed      = 14,
-    NoPayout            = 15,
-    WagerTooLow         = 16,
-    WagerTooHigh        = 17,
-    Overflow            = 18,
-    InvalidCloseTime    = 19,
-    InvalidPrice        = 20,
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+    InvalidAmount = 4,
+    InvalidDirection = 5,
+    RoundAlreadyExists = 6,
+    RoundNotFound = 7,
+    AlreadySettled = 8,
+    NotSettled = 9,
+    RoundNotClosed = 10,
+    RoundClosed = 11,
+    BetAlreadyPlaced = 12,
+    BetNotFound = 13,
+    AlreadyClaimed = 14,
+    NoPayout = 15,
+    WagerTooLow = 16,
+    WagerTooHigh = 17,
+    Overflow = 18,
+    InvalidCloseTime = 19,
+    InvalidPrice = 20,
 }
 
 // ---------------------------------------------------------------------------
@@ -104,6 +104,7 @@ pub enum DataKey {
     HouseEdgeBps,
     Round(u64),
     Bet(BetKey),
+    Participants(u64),
 }
 
 #[contracttype]
@@ -128,6 +129,45 @@ pub struct BetData {
     pub direction: u32,
     pub wager: i128,
     pub claimed: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParticipantPosition {
+    pub player: Address,
+    pub direction: u32,
+    pub wager: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoundParticipantSummary {
+    pub has_round: bool,
+    pub round_id: u64,
+    pub accepting_predictions: bool,
+    pub is_settled: bool,
+    pub total_participants: u32,
+    pub up_participants: u32,
+    pub down_participants: u32,
+    pub total_up_wager: i128,
+    pub total_down_wager: i128,
+    pub positions: Vec<ParticipantPosition>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SettlementPreview {
+    pub has_round: bool,
+    pub round_id: u64,
+    pub is_provisional: bool,
+    pub is_settled: bool,
+    pub open_price: i128,
+    pub reference_price: i128,
+    pub projected_outcome: u32,
+    pub is_push: bool,
+    pub total_pool: i128,
+    pub projected_net_pool: i128,
+    pub projected_winning_total: i128,
 }
 
 // ---------------------------------------------------------------------------
@@ -199,11 +239,15 @@ impl PricePrediction {
         admin.require_auth();
 
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::OracleContract, &oracle_contract);
+        env.storage()
+            .instance()
+            .set(&DataKey::OracleContract, &oracle_contract);
         env.storage().instance().set(&DataKey::Token, &token);
         env.storage().instance().set(&DataKey::MinWager, &min_wager);
         env.storage().instance().set(&DataKey::MaxWager, &max_wager);
-        env.storage().instance().set(&DataKey::HouseEdgeBps, &house_edge_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::HouseEdgeBps, &house_edge_bps);
         Ok(())
     }
 
@@ -250,11 +294,19 @@ impl PricePrediction {
             winning_total: 0,
         };
         env.storage().persistent().set(&round_key, &round);
-        env.storage()
-            .persistent()
-            .extend_ttl(&round_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
+        env.storage().persistent().extend_ttl(
+            &round_key,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
 
-        MarketOpened { round_id, asset, open_price, close_time }.publish(&env);
+        MarketOpened {
+            round_id,
+            asset,
+            open_price,
+            close_time,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -313,11 +365,7 @@ impl PricePrediction {
 
         // Transfer tokens from player to contract
         let token = get_token(&env);
-        TokenClient::new(&env, &token).transfer(
-            &player,
-            env.current_contract_address(),
-            &wager,
-        );
+        TokenClient::new(&env, &token).transfer(&player, env.current_contract_address(), &wager);
 
         // Update round totals
         if direction == DIRECTION_UP {
@@ -326,9 +374,11 @@ impl PricePrediction {
             round.total_down = round.total_down.checked_add(wager).ok_or(Error::Overflow)?;
         }
         env.storage().persistent().set(&round_key, &round);
-        env.storage()
-            .persistent()
-            .extend_ttl(&round_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
+        env.storage().persistent().extend_ttl(
+            &round_key,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
 
         // Store bet
         let bet = BetData {
@@ -337,11 +387,35 @@ impl PricePrediction {
             claimed: false,
         };
         env.storage().persistent().set(&bet_key, &bet);
+        env.storage().persistent().extend_ttl(
+            &bet_key,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
+
+        let participants_key = DataKey::Participants(round_id);
+        let mut participants: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&participants_key)
+            .unwrap_or(Vec::new(&env));
+        participants.push_back(player.clone());
         env.storage()
             .persistent()
-            .extend_ttl(&bet_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
+            .set(&participants_key, &participants);
+        env.storage().persistent().extend_ttl(
+            &participants_key,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
 
-        PredictionPlaced { round_id, player, direction, wager }.publish(&env);
+        PredictionPlaced {
+            round_id,
+            player,
+            direction,
+            wager,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -396,8 +470,11 @@ impl PricePrediction {
         let (net_pool, winning_total) = if is_push {
             (0i128, 0i128)
         } else {
-            let house_edge_bps: i128 =
-                env.storage().instance().get(&DataKey::HouseEdgeBps).unwrap();
+            let house_edge_bps: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::HouseEdgeBps)
+                .unwrap();
             let fee = total_pool
                 .checked_mul(house_edge_bps)
                 .and_then(|v| v.checked_div(BASIS_POINTS_DIVISOR))
@@ -418,11 +495,20 @@ impl PricePrediction {
         round.net_pool = net_pool;
         round.winning_total = winning_total;
         env.storage().persistent().set(&round_key, &round);
-        env.storage()
-            .persistent()
-            .extend_ttl(&round_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
+        env.storage().persistent().extend_ttl(
+            &round_key,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
 
-        RoundSettled { round_id, close_price, outcome, is_push, net_pool }.publish(&env);
+        RoundSettled {
+            round_id,
+            close_price,
+            outcome,
+            is_push,
+            net_pool,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -481,18 +567,21 @@ impl PricePrediction {
         // State update before transfer (reentrancy-safe)
         bet.claimed = true;
         env.storage().persistent().set(&bet_key, &bet);
-        env.storage()
-            .persistent()
-            .extend_ttl(&bet_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
-
-        let token = get_token(&env);
-        TokenClient::new(&env, &token).transfer(
-            &env.current_contract_address(),
-            &player,
-            &payout,
+        env.storage().persistent().extend_ttl(
+            &bet_key,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
         );
 
-        Claimed { round_id, player, payout }.publish(&env);
+        let token = get_token(&env);
+        TokenClient::new(&env, &token).transfer(&env.current_contract_address(), &player, &payout);
+
+        Claimed {
+            round_id,
+            player,
+            payout,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -510,6 +599,139 @@ impl PricePrediction {
             .persistent()
             .get(&DataKey::Bet(BetKey { round_id, player }))
             .ok_or(Error::BetNotFound)
+    }
+
+    /// Return a compact participant summary for a round.
+    ///
+    /// Missing rounds return `has_round = false` and an empty participant list.
+    pub fn participant_summary(env: Env, round_id: u64) -> RoundParticipantSummary {
+        let Some(round) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, RoundData>(&DataKey::Round(round_id))
+        else {
+            return RoundParticipantSummary {
+                has_round: false,
+                round_id,
+                accepting_predictions: false,
+                is_settled: false,
+                total_participants: 0,
+                up_participants: 0,
+                down_participants: 0,
+                total_up_wager: 0,
+                total_down_wager: 0,
+                positions: Vec::new(&env),
+            };
+        };
+
+        let participants: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Participants(round_id))
+            .unwrap_or(Vec::new(&env));
+
+        let mut positions = Vec::new(&env);
+        let mut up_participants = 0u32;
+        let mut down_participants = 0u32;
+
+        for player in participants.iter() {
+            if let Some(bet) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, BetData>(&DataKey::Bet(BetKey {
+                    round_id,
+                    player: player.clone(),
+                }))
+            {
+                if bet.direction == DIRECTION_UP {
+                    up_participants = up_participants.saturating_add(1);
+                } else {
+                    down_participants = down_participants.saturating_add(1);
+                }
+
+                positions.push_back(ParticipantPosition {
+                    player,
+                    direction: bet.direction,
+                    wager: bet.wager,
+                });
+            }
+        }
+
+        RoundParticipantSummary {
+            has_round: true,
+            round_id,
+            accepting_predictions: !round.settled && env.ledger().timestamp() < round.close_time,
+            is_settled: round.settled,
+            total_participants: positions.len(),
+            up_participants,
+            down_participants,
+            total_up_wager: round.total_up,
+            total_down_wager: round.total_down,
+            positions,
+        }
+    }
+
+    /// Preview settlement using the round's current wagers and the oracle's
+    /// current price feed. Before final settlement this view is provisional.
+    pub fn settlement_preview(env: Env, round_id: u64) -> SettlementPreview {
+        let Some(round) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, RoundData>(&DataKey::Round(round_id))
+        else {
+            return SettlementPreview {
+                has_round: false,
+                round_id,
+                is_provisional: false,
+                is_settled: false,
+                open_price: 0,
+                reference_price: 0,
+                projected_outcome: OUTCOME_FLAT,
+                is_push: true,
+                total_pool: 0,
+                projected_net_pool: 0,
+                projected_winning_total: 0,
+            };
+        };
+
+        if round.settled {
+            return SettlementPreview {
+                has_round: true,
+                round_id,
+                is_provisional: false,
+                is_settled: true,
+                open_price: round.open_price,
+                reference_price: round.close_price,
+                projected_outcome: round.outcome,
+                is_push: round.is_push,
+                total_pool: round.total_up.saturating_add(round.total_down),
+                projected_net_pool: round.net_pool,
+                projected_winning_total: round.winning_total,
+            };
+        }
+
+        let reference_price = OracleClient::new(&env, &get_oracle(&env)).get_price(&round.asset);
+        let house_edge_bps: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::HouseEdgeBps)
+            .unwrap();
+        let (projected_outcome, is_push, total_pool, projected_net_pool, projected_winning_total) =
+            preview_settlement_values(&round, reference_price, house_edge_bps);
+
+        SettlementPreview {
+            has_round: true,
+            round_id,
+            is_provisional: true,
+            is_settled: false,
+            open_price: round.open_price,
+            reference_price,
+            projected_outcome,
+            is_push,
+            total_pool,
+            projected_net_pool,
+            projected_winning_total,
+        }
     }
 }
 
@@ -546,6 +768,47 @@ fn get_oracle(env: &Env) -> Address {
         .instance()
         .get(&DataKey::OracleContract)
         .expect("PricePrediction: oracle not set")
+}
+
+fn preview_settlement_values(
+    round: &RoundData,
+    reference_price: i128,
+    house_edge_bps: i128,
+) -> (u32, bool, i128, i128, i128) {
+    let total_pool = round.total_up.saturating_add(round.total_down);
+
+    let outcome = if reference_price > round.open_price {
+        OUTCOME_UP
+    } else if reference_price < round.open_price {
+        OUTCOME_DOWN
+    } else {
+        OUTCOME_FLAT
+    };
+
+    let is_push =
+        outcome == OUTCOME_FLAT || total_pool == 0 || round.total_up == 0 || round.total_down == 0;
+
+    if is_push {
+        return (outcome, true, total_pool, 0, 0);
+    }
+
+    let fee = total_pool
+        .saturating_mul(house_edge_bps)
+        .saturating_div(BASIS_POINTS_DIVISOR);
+    let projected_net_pool = total_pool.saturating_sub(fee);
+    let projected_winning_total = if outcome == OUTCOME_UP {
+        round.total_up
+    } else {
+        round.total_down
+    };
+
+    (
+        outcome,
+        false,
+        total_pool,
+        projected_net_pool,
+        projected_winning_total,
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/price-prediction/src/test.rs
+++ b/contracts/price-prediction/src/test.rs
@@ -77,7 +77,14 @@ fn setup(env: &Env) -> Setup<'_> {
     oracle_client.set_price(&btc(env), &50_000);
 
     // Init: min=10, max=10000, house edge 500 bps (5%)
-    client.init(&admin, &oracle_id, &token_addr, &10i128, &10_000i128, &500i128);
+    client.init(
+        &admin,
+        &oracle_id,
+        &token_addr,
+        &10i128,
+        &10_000i128,
+        &500i128,
+    );
 
     // Fund contract for payouts
     token_sac.mint(&contract_id, &1_000_000i128);
@@ -111,7 +118,9 @@ fn test_init_rejects_reinit() {
 
     let oracle = Address::generate(&env);
     let tok = Address::generate(&env);
-    let result = s.client.try_init(&Address::generate(&env), &oracle, &tok, &10, &10000, &500);
+    let result = s
+        .client
+        .try_init(&Address::generate(&env), &oracle, &tok, &10, &10000, &500);
     assert!(result.is_err());
 }
 
@@ -197,7 +206,8 @@ fn test_place_prediction_up() {
     s.token_sac.mint(&player, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player, &1u64, &DIRECTION_UP, &100);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_UP, &100);
 
     let round = s.client.get_round(&1u64);
     assert_eq!(round.total_up, 100);
@@ -226,7 +236,8 @@ fn test_place_prediction_down() {
     s.token_sac.mint(&player, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player, &1u64, &DIRECTION_DOWN, &200);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_DOWN, &200);
 
     let round = s.client.get_round(&1u64);
     assert_eq!(round.total_up, 0);
@@ -265,7 +276,9 @@ fn test_place_prediction_wager_too_low() {
     s.token_sac.mint(&player, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    let result = s.client.try_place_prediction(&player, &1u64, &DIRECTION_UP, &5i128); // min=10
+    let result = s
+        .client
+        .try_place_prediction(&player, &1u64, &DIRECTION_UP, &5i128); // min=10
     assert!(result.is_err());
 }
 
@@ -279,7 +292,9 @@ fn test_place_prediction_wager_too_high() {
     s.token_sac.mint(&player, &50_000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    let result = s.client.try_place_prediction(&player, &1u64, &DIRECTION_UP, &10_001i128); // max=10000
+    let result = s
+        .client
+        .try_place_prediction(&player, &1u64, &DIRECTION_UP, &10_001i128); // max=10000
     assert!(result.is_err());
 }
 
@@ -291,7 +306,9 @@ fn test_place_prediction_zero_wager() {
 
     let player = Address::generate(&env);
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    let result = s.client.try_place_prediction(&player, &1u64, &DIRECTION_UP, &0i128);
+    let result = s
+        .client
+        .try_place_prediction(&player, &1u64, &DIRECTION_UP, &0i128);
     assert!(result.is_err());
 }
 
@@ -315,7 +332,9 @@ fn test_place_prediction_after_close_time_rejected() {
         li.timestamp = 3000;
     });
 
-    let result = s.client.try_place_prediction(&player, &1u64, &DIRECTION_UP, &100);
+    let result = s
+        .client
+        .try_place_prediction(&player, &1u64, &DIRECTION_UP, &100);
     assert!(result.is_err());
 }
 
@@ -333,9 +352,12 @@ fn test_place_prediction_duplicate_rejected() {
     s.token_sac.mint(&player, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player, &1u64, &DIRECTION_UP, &100);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_UP, &100);
 
-    let result = s.client.try_place_prediction(&player, &1u64, &DIRECTION_DOWN, &200);
+    let result = s
+        .client
+        .try_place_prediction(&player, &1u64, &DIRECTION_DOWN, &200);
     assert!(result.is_err());
 }
 
@@ -352,7 +374,9 @@ fn test_place_prediction_round_not_found() {
     let player = Address::generate(&env);
     s.token_sac.mint(&player, &5000);
 
-    let result = s.client.try_place_prediction(&player, &99u64, &DIRECTION_UP, &100);
+    let result = s
+        .client
+        .try_place_prediction(&player, &99u64, &DIRECTION_UP, &100);
     assert!(result.is_err());
 }
 
@@ -372,8 +396,10 @@ fn test_settle_round_up_wins() {
     s.token_sac.mint(&player_b, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player_a, &1u64, &DIRECTION_UP, &300);
-    s.client.place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &500);
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_UP, &300);
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &500);
 
     // Advance time and set higher price
     env.ledger().with_mut(|li| {
@@ -408,8 +434,10 @@ fn test_settle_round_down_wins() {
     s.token_sac.mint(&player_b, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player_a, &1u64, &DIRECTION_UP, &400);
-    s.client.place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &600);
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_UP, &400);
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &600);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -443,8 +471,10 @@ fn test_settle_round_flat_push() {
     s.token_sac.mint(&player_b, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player_a, &1u64, &DIRECTION_UP, &100);
-    s.client.place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &200);
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_UP, &100);
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &200);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -514,7 +544,8 @@ fn test_settle_round_one_side_only_push() {
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
     // Only UP bets, no DOWN bets
-    s.client.place_prediction(&player, &1u64, &DIRECTION_UP, &500);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_UP, &500);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -568,8 +599,10 @@ fn test_claim_winner() {
     s.token_sac.mint(&loser, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&winner, &1u64, &DIRECTION_UP, &300);
-    s.client.place_prediction(&loser, &1u64, &DIRECTION_DOWN, &700);
+    s.client
+        .place_prediction(&winner, &1u64, &DIRECTION_UP, &300);
+    s.client
+        .place_prediction(&loser, &1u64, &DIRECTION_DOWN, &700);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -600,7 +633,8 @@ fn test_claim_push_refund() {
     s.token_sac.mint(&player, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player, &1u64, &DIRECTION_UP, &400);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_UP, &400);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -630,8 +664,10 @@ fn test_claim_loser_rejected() {
     s.token_sac.mint(&loser, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&winner, &1u64, &DIRECTION_UP, &300);
-    s.client.place_prediction(&loser, &1u64, &DIRECTION_DOWN, &700);
+    s.client
+        .place_prediction(&winner, &1u64, &DIRECTION_UP, &300);
+    s.client
+        .place_prediction(&loser, &1u64, &DIRECTION_DOWN, &700);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -660,8 +696,10 @@ fn test_claim_double_claim_rejected() {
     s.token_sac.mint(&player_b, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player_a, &1u64, &DIRECTION_UP, &500);
-    s.client.place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &500);
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_UP, &500);
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &500);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -689,7 +727,8 @@ fn test_claim_not_settled_rejected() {
     s.token_sac.mint(&player, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player, &1u64, &DIRECTION_UP, &100);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_UP, &100);
 
     let result = s.client.try_claim(&player, &1u64);
     assert!(result.is_err()); // NotSettled
@@ -709,7 +748,8 @@ fn test_claim_bet_not_found() {
     s.token_sac.mint(&player, &5000);
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player, &1u64, &DIRECTION_UP, &100);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_UP, &100);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -743,9 +783,12 @@ fn test_multiple_players_proportional_payout() {
     s.client.open_market(&1u64, &btc(&env), &2000u64);
 
     // Two UP bettors, one DOWN bettor
-    s.client.place_prediction(&player_a, &1u64, &DIRECTION_UP, &300);   // UP
-    s.client.place_prediction(&player_b, &1u64, &DIRECTION_UP, &200);   // UP
-    s.client.place_prediction(&player_c, &1u64, &DIRECTION_DOWN, &500); // DOWN
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_UP, &300); // UP
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_UP, &200); // UP
+    s.client
+        .place_prediction(&player_c, &1u64, &DIRECTION_DOWN, &500); // DOWN
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -762,8 +805,14 @@ fn test_multiple_players_proportional_payout() {
     s.client.claim(&player_a, &1u64);
     s.client.claim(&player_b, &1u64);
 
-    assert_eq!(tc(&env, &s.token_addr).balance(&player_a), 10_000 - 300 + 570);
-    assert_eq!(tc(&env, &s.token_addr).balance(&player_b), 10_000 - 200 + 380);
+    assert_eq!(
+        tc(&env, &s.token_addr).balance(&player_a),
+        10_000 - 300 + 570
+    );
+    assert_eq!(
+        tc(&env, &s.token_addr).balance(&player_b),
+        10_000 - 200 + 380
+    );
     // Player C lost, no claim — balance stays at 10_000 - 500
     assert_eq!(tc(&env, &s.token_addr).balance(&player_c), 9_500);
 }
@@ -783,12 +832,14 @@ fn test_full_lifecycle_two_rounds() {
 
     // Round 1: player bets UP, price goes up → wins
     s.client.open_market(&1u64, &btc(&env), &2000u64);
-    s.client.place_prediction(&player, &1u64, &DIRECTION_UP, &100);
+    s.client
+        .place_prediction(&player, &1u64, &DIRECTION_UP, &100);
 
     // Need a second player on the other side for non-push
     let opponent = Address::generate(&env);
     s.token_sac.mint(&opponent, &10_000);
-    s.client.place_prediction(&opponent, &1u64, &DIRECTION_DOWN, &100);
+    s.client
+        .place_prediction(&opponent, &1u64, &DIRECTION_DOWN, &100);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -804,8 +855,10 @@ fn test_full_lifecycle_two_rounds() {
     // Round 2: player bets DOWN, price goes down → wins
     s.oracle_client.set_price(&btc(&env), &60_000); // new open price
     s.client.open_market(&2u64, &btc(&env), &5000u64);
-    s.client.place_prediction(&player, &2u64, &DIRECTION_DOWN, &100);
-    s.client.place_prediction(&opponent, &2u64, &DIRECTION_UP, &100);
+    s.client
+        .place_prediction(&player, &2u64, &DIRECTION_DOWN, &100);
+    s.client
+        .place_prediction(&opponent, &2u64, &DIRECTION_UP, &100);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 6000;
@@ -836,8 +889,10 @@ fn test_push_one_side_refund() {
 
     s.client.open_market(&1u64, &btc(&env), &2000u64);
     // Both bet DOWN, no UP bets
-    s.client.place_prediction(&player_a, &1u64, &DIRECTION_DOWN, &300);
-    s.client.place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &200);
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_DOWN, &300);
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &200);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 3000;
@@ -870,6 +925,95 @@ fn test_get_round_not_found() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_participant_summary_reads() {
+    let env = Env::default();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let player_a = Address::generate(&env);
+    let player_b = Address::generate(&env);
+    s.token_sac.mint(&player_a, &5_000);
+    s.token_sac.mint(&player_b, &5_000);
+
+    s.client.open_market(&1u64, &btc(&env), &2_000u64);
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_UP, &300i128);
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &500i128);
+
+    let summary = s.client.participant_summary(&1u64);
+    assert!(summary.has_round);
+    assert!(summary.accepting_predictions);
+    assert!(!summary.is_settled);
+    assert_eq!(summary.total_participants, 2);
+    assert_eq!(summary.up_participants, 1);
+    assert_eq!(summary.down_participants, 1);
+    assert_eq!(summary.total_up_wager, 300);
+    assert_eq!(summary.total_down_wager, 500);
+    assert_eq!(summary.positions.len(), 2);
+
+    let first = summary.positions.get(0).unwrap();
+    let second = summary.positions.get(1).unwrap();
+    assert_eq!(first.player, player_a);
+    assert_eq!(first.direction, DIRECTION_UP);
+    assert_eq!(first.wager, 300);
+    assert_eq!(second.player, player_b);
+    assert_eq!(second.direction, DIRECTION_DOWN);
+    assert_eq!(second.wager, 500);
+}
+
+#[test]
+fn test_settlement_preview_reads() {
+    let env = Env::default();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let player_a = Address::generate(&env);
+    let player_b = Address::generate(&env);
+    s.token_sac.mint(&player_a, &5_000);
+    s.token_sac.mint(&player_b, &5_000);
+
+    s.client.open_market(&1u64, &btc(&env), &2_000u64);
+    s.client
+        .place_prediction(&player_a, &1u64, &DIRECTION_UP, &300i128);
+    s.client
+        .place_prediction(&player_b, &1u64, &DIRECTION_DOWN, &500i128);
+
+    s.oracle_client.set_price(&btc(&env), &55_000);
+
+    let preview = s.client.settlement_preview(&1u64);
+    assert!(preview.has_round);
+    assert!(preview.is_provisional);
+    assert!(!preview.is_settled);
+    assert_eq!(preview.open_price, 50_000);
+    assert_eq!(preview.reference_price, 55_000);
+    assert_eq!(preview.projected_outcome, OUTCOME_UP);
+    assert!(!preview.is_push);
+    assert_eq!(preview.total_pool, 800);
+    assert_eq!(preview.projected_net_pool, 760);
+    assert_eq!(preview.projected_winning_total, 300);
+}
+
+#[test]
+fn test_summary_and_preview_inactive_round_behavior() {
+    let env = Env::default();
+    let s = setup(&env);
+
+    let summary = s.client.participant_summary(&99u64);
+    assert!(!summary.has_round);
+    assert!(!summary.accepting_predictions);
+    assert_eq!(summary.total_participants, 0);
+    assert_eq!(summary.positions.len(), 0);
+
+    let preview = s.client.settlement_preview(&99u64);
+    assert!(!preview.has_round);
+    assert!(!preview.is_provisional);
+    assert_eq!(preview.reference_price, 0);
+    assert_eq!(preview.total_pool, 0);
+    assert!(preview.is_push);
+}
+
 // -------------------------------------------------------------------
 // 30. Place prediction on settled round rejected
 // -------------------------------------------------------------------
@@ -891,6 +1035,8 @@ fn test_place_prediction_on_settled_round_rejected() {
     s.oracle_client.set_price(&btc(&env), &55_000);
     s.client.settle_round(&1u64);
 
-    let result = s.client.try_place_prediction(&player, &1u64, &DIRECTION_UP, &100);
+    let result = s
+        .client
+        .try_place_prediction(&player, &1u64, &DIRECTION_UP, &100);
     assert!(result.is_err());
 }

--- a/contracts/streak-bonus/src/lib.rs
+++ b/contracts/streak-bonus/src/lib.rs
@@ -43,6 +43,36 @@ pub struct UserStreakData {
     pub last_claimed_streak: u32,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StreakSummaryStatus {
+    Missing = 0,
+    Active = 1,
+    Reset = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreakSummary {
+    pub status: StreakSummaryStatus,
+    pub active_streak: u32,
+    pub last_recorded_streak: u32,
+    pub last_claimed_streak: u32,
+    pub last_activity_ts: u64,
+    pub streak_window_ends_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NextBonusPreview {
+    pub status: StreakSummaryStatus,
+    pub active_streak: u32,
+    pub threshold_streak: u32,
+    pub streaks_needed: u32,
+    pub projected_reward: i128,
+    pub claimable_now: bool,
+}
+
 // ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
@@ -115,9 +145,11 @@ impl StreakBonus {
         let default_rules = StreakRules {
             min_streak_to_claim: 3,
             reward_per_streak: 1_000_000i128, // e.g. 1 unit in 6 decimals
-            streak_window_secs: 86400,         // 24h
+            streak_window_secs: 86400,        // 24h
         };
-        env.storage().instance().set(&DataKey::Rules, &default_rules);
+        env.storage()
+            .instance()
+            .set(&DataKey::Rules, &default_rules);
         Initialized {
             admin,
             reward_contract,
@@ -144,24 +176,22 @@ impl StreakBonus {
             .ok_or(Error::NotInitialized)?;
 
         let key = DataKey::UserData(user.clone());
-        let mut data: UserStreakData = env
-            .storage()
-            .instance()
-            .get(&key)
-            .unwrap_or(UserStreakData {
-                last_activity_ts: 0,
-                current_streak: 0,
-                last_claimed_streak: 0,
-            });
+        let mut data: UserStreakData =
+            env.storage()
+                .instance()
+                .get(&key)
+                .unwrap_or(UserStreakData {
+                    last_activity_ts: 0,
+                    current_streak: 0,
+                    last_claimed_streak: 0,
+                });
 
         let new_streak = if data.last_activity_ts == 0 {
             1u32
         } else if ts > data.last_activity_ts
             && ts.saturating_sub(data.last_activity_ts) <= rules.streak_window_secs
         {
-            data.current_streak
-                .checked_add(1)
-                .ok_or(Error::Overflow)?
+            data.current_streak.checked_add(1).ok_or(Error::Overflow)?
         } else {
             1u32
         };
@@ -188,6 +218,60 @@ impl StreakBonus {
             .get(&key)
             .map(|d: UserStreakData| d.current_streak)
             .unwrap_or(0)
+    }
+
+    /// Return a UI-friendly summary of a player's streak at `as_of_ts`.
+    ///
+    /// Missing players return a zeroed summary with `status = Missing`.
+    /// Players whose latest activity window has elapsed return `status = Reset`
+    /// with `active_streak = 0` while preserving the last recorded streak.
+    pub fn streak_summary(env: Env, user: Address, as_of_ts: u64) -> StreakSummary {
+        let Some(rules) = read_rules(&env) else {
+            return empty_streak_summary();
+        };
+
+        build_streak_summary(&env, &user, &rules, as_of_ts)
+    }
+
+    /// Preview the next streak bonus target for a player at `as_of_ts`.
+    ///
+    /// The preview is side-effect free and uses the effective active streak,
+    /// making reset streaks render as `active_streak = 0`.
+    pub fn next_bonus_preview(env: Env, user: Address, as_of_ts: u64) -> NextBonusPreview {
+        let Some(rules) = read_rules(&env) else {
+            return NextBonusPreview {
+                status: StreakSummaryStatus::Missing,
+                active_streak: 0,
+                threshold_streak: 0,
+                streaks_needed: 0,
+                projected_reward: 0,
+                claimable_now: false,
+            };
+        };
+
+        let summary = build_streak_summary(&env, &user, &rules, as_of_ts);
+        let next_unclaimed_streak = summary.last_claimed_streak.saturating_add(1);
+        let threshold_streak = if next_unclaimed_streak > rules.min_streak_to_claim {
+            next_unclaimed_streak
+        } else {
+            rules.min_streak_to_claim
+        };
+
+        let preview_threshold = if summary.active_streak >= threshold_streak {
+            summary.active_streak
+        } else {
+            threshold_streak
+        };
+
+        NextBonusPreview {
+            status: summary.status,
+            active_streak: summary.active_streak,
+            threshold_streak: preview_threshold,
+            streaks_needed: preview_threshold.saturating_sub(summary.active_streak),
+            projected_reward: (preview_threshold as i128).saturating_mul(rules.reward_per_streak),
+            claimable_now: summary.active_streak >= rules.min_streak_to_claim
+                && summary.active_streak > summary.last_claimed_streak,
+        }
     }
 
     /// Claim streak bonus for the current streak. User must authorize. Updates last_claimed_streak.
@@ -273,6 +357,59 @@ fn require_admin_or_self(env: &Env, caller: &Address, user: &Address) -> Result<
         return Err(Error::NotAuthorized);
     }
     Ok(())
+}
+
+fn read_rules(env: &Env) -> Option<StreakRules> {
+    env.storage().instance().get(&DataKey::Rules)
+}
+
+fn empty_streak_summary() -> StreakSummary {
+    StreakSummary {
+        status: StreakSummaryStatus::Missing,
+        active_streak: 0,
+        last_recorded_streak: 0,
+        last_claimed_streak: 0,
+        last_activity_ts: 0,
+        streak_window_ends_at: 0,
+    }
+}
+
+fn build_streak_summary(
+    env: &Env,
+    user: &Address,
+    rules: &StreakRules,
+    as_of_ts: u64,
+) -> StreakSummary {
+    let key = DataKey::UserData(user.clone());
+    let Some(data) = env
+        .storage()
+        .instance()
+        .get::<DataKey, UserStreakData>(&key)
+    else {
+        return empty_streak_summary();
+    };
+
+    let streak_window_ends_at = data
+        .last_activity_ts
+        .saturating_add(rules.streak_window_secs);
+    let streak_is_active = data.last_activity_ts > 0 && as_of_ts <= streak_window_ends_at;
+
+    StreakSummary {
+        status: if streak_is_active {
+            StreakSummaryStatus::Active
+        } else {
+            StreakSummaryStatus::Reset
+        },
+        active_streak: if streak_is_active {
+            data.current_streak
+        } else {
+            0
+        },
+        last_recorded_streak: data.current_streak,
+        last_claimed_streak: data.last_claimed_streak,
+        last_activity_ts: data.last_activity_ts,
+        streak_window_ends_at,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/streak-bonus/src/test.rs
+++ b/contracts/streak-bonus/src/test.rs
@@ -71,6 +71,85 @@ fn test_current_streak_zero_for_unknown_user() {
 }
 
 #[test]
+fn test_streak_summary_for_new_player() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let unknown = Address::generate(&env);
+
+    let summary = client.streak_summary(&unknown, &1_000u64);
+    assert_eq!(summary.status, StreakSummaryStatus::Missing);
+    assert_eq!(summary.active_streak, 0);
+    assert_eq!(summary.last_recorded_streak, 0);
+    assert_eq!(summary.last_claimed_streak, 0);
+    assert_eq!(summary.last_activity_ts, 0);
+    assert_eq!(summary.streak_window_ends_at, 0);
+}
+
+#[test]
+fn test_streak_summary_for_active_streak() {
+    let env = Env::default();
+    let (client, _, _, user) = setup(&env);
+    env.mock_all_auths();
+
+    client.record_activity(&user, &user, &Symbol::new(&env, "play"), &1_000u64);
+    client.record_activity(&user, &user, &Symbol::new(&env, "play"), &2_000u64);
+
+    let summary = client.streak_summary(&user, &2_500u64);
+    assert_eq!(summary.status, StreakSummaryStatus::Active);
+    assert_eq!(summary.active_streak, 2);
+    assert_eq!(summary.last_recorded_streak, 2);
+    assert_eq!(summary.last_activity_ts, 2_000);
+    assert_eq!(summary.streak_window_ends_at, 2_000 + 86_400);
+}
+
+#[test]
+fn test_streak_summary_for_broken_streak() {
+    let env = Env::default();
+    let (client, _, _, user) = setup(&env);
+    env.mock_all_auths();
+
+    client.record_activity(&user, &user, &Symbol::new(&env, "play"), &1_000u64);
+    client.record_activity(&user, &user, &Symbol::new(&env, "play"), &2_000u64);
+
+    let summary = client.streak_summary(&user, &100_000u64);
+    assert_eq!(summary.status, StreakSummaryStatus::Reset);
+    assert_eq!(summary.active_streak, 0);
+    assert_eq!(summary.last_recorded_streak, 2);
+    assert_eq!(summary.last_activity_ts, 2_000);
+}
+
+#[test]
+fn test_next_bonus_preview_tracks_threshold_and_reward() {
+    let env = Env::default();
+    let (client, _, _, user) = setup(&env);
+    env.mock_all_auths();
+
+    client.record_activity(&user, &user, &Symbol::new(&env, "play"), &1_000u64);
+    client.record_activity(&user, &user, &Symbol::new(&env, "play"), &2_000u64);
+
+    let preview = client.next_bonus_preview(&user, &2_500u64);
+    assert_eq!(preview.status, StreakSummaryStatus::Active);
+    assert_eq!(preview.active_streak, 2);
+    assert_eq!(preview.threshold_streak, 3);
+    assert_eq!(preview.streaks_needed, 1);
+    assert_eq!(preview.projected_reward, 3_000_000);
+    assert!(!preview.claimable_now);
+
+    client.record_activity(&user, &user, &Symbol::new(&env, "play"), &3_000u64);
+    let claimable = client.next_bonus_preview(&user, &3_500u64);
+    assert_eq!(claimable.threshold_streak, 3);
+    assert_eq!(claimable.projected_reward, 3_000_000);
+    assert!(claimable.claimable_now);
+
+    client.claim_streak_bonus(&user);
+    let next_target = client.next_bonus_preview(&user, &3_500u64);
+    assert_eq!(next_target.threshold_streak, 4);
+    assert_eq!(next_target.streaks_needed, 1);
+    assert_eq!(next_target.projected_reward, 4_000_000);
+    assert!(!next_target.claimable_now);
+}
+
+#[test]
 fn test_claim_requires_min_streak() {
     let env = Env::default();
     let (client, _, _, user) = setup(&env);

--- a/contracts/trivia-game/src/lib.rs
+++ b/contracts/trivia-game/src/lib.rs
@@ -1,19 +1,222 @@
 //! Stellarcade Daily Trivia Game Contract
+//!
+//! Supports lightweight round configuration so clients can inspect the
+//! currently active round and its question-set metadata.
 #![no_std]
 #![allow(unexpected_cfgs)]
 
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+    RoundAlreadyExists = 4,
+    RoundNotFound = 5,
+    InvalidConfig = 6,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Admin,
+    ActiveRoundId,
+    Round(u64),
+    Participation(u64, Address),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RoundStatus {
+    Configured = 0,
+    Active = 1,
+    Closed = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoundData {
+    pub question_set_id: u64,
+    pub question_count: u32,
+    pub category: String,
+    pub difficulty: u32,
+    pub starts_at: u64,
+    pub ends_at: u64,
+    pub participant_count: u32,
+    pub submission_count: u32,
+    pub status: RoundStatus,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestionSetMetadata {
+    pub round_id: u64,
+    pub question_set_id: u64,
+    pub question_count: u32,
+    pub category: String,
+    pub difficulty: u32,
+    pub starts_at: u64,
+    pub ends_at: u64,
+    pub status: RoundStatus,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActiveRoundSnapshot {
+    pub has_active_round: bool,
+    pub round_id: u64,
+    pub question_set_id: u64,
+    pub starts_at: u64,
+    pub ends_at: u64,
+    pub now: u64,
+    pub participant_count: u32,
+    pub submission_count: u32,
+    pub is_accepting_answers: bool,
+}
 
 #[contract]
 pub struct TriviaGame;
 
 #[contractimpl]
 impl TriviaGame {
-    /// Submit an answer for a specific question ID.
-    pub fn submit_answer(_env: Env, player: Address, _question_id: u32, _answer: String) {
+    /// Initialize the contract once with an admin who can configure rounds.
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Configure a round and its question-set metadata.
+    pub fn configure_round(
+        env: Env,
+        admin: Address,
+        round_id: u64,
+        question_set_id: u64,
+        question_count: u32,
+        category: String,
+        difficulty: u32,
+        starts_at: u64,
+        ends_at: u64,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+
+        if round_id == 0 || question_set_id == 0 || question_count == 0 || ends_at <= starts_at {
+            return Err(Error::InvalidConfig);
+        }
+
+        let key = DataKey::Round(round_id);
+        if env.storage().persistent().has(&key) {
+            return Err(Error::RoundAlreadyExists);
+        }
+
+        env.storage().persistent().set(
+            &key,
+            &RoundData {
+                question_set_id,
+                question_count,
+                category,
+                difficulty,
+                starts_at,
+                ends_at,
+                participant_count: 0,
+                submission_count: 0,
+                status: RoundStatus::Configured,
+            },
+        );
+        Ok(())
+    }
+
+    /// Mark a configured round as active.
+    pub fn activate_round(env: Env, admin: Address, round_id: u64) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+
+        let key = DataKey::Round(round_id);
+        let mut round: RoundData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::RoundNotFound)?;
+
+        if let Some(previous_round_id) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::ActiveRoundId)
+        {
+            if previous_round_id != round_id {
+                let previous_key = DataKey::Round(previous_round_id);
+                if let Some(mut previous_round) = env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, RoundData>(&previous_key)
+                {
+                    if previous_round.status == RoundStatus::Active {
+                        previous_round.status = RoundStatus::Configured;
+                        env.storage()
+                            .persistent()
+                            .set(&previous_key, &previous_round);
+                    }
+                }
+            }
+        }
+
+        round.status = RoundStatus::Active;
+        env.storage().persistent().set(&key, &round);
+        env.storage()
+            .instance()
+            .set(&DataKey::ActiveRoundId, &round_id);
+        Ok(())
+    }
+
+    /// Submit an answer for the current active round.
+    ///
+    /// The method records participation metadata only; answer validation
+    /// remains out of scope for this contract stub.
+    pub fn submit_answer(env: Env, player: Address, question_id: u32, answer: String) {
+        let _ = (question_id, answer);
         player.require_auth();
-        // TODO: Validate answer hash
-        // TODO: Record participation
+
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return;
+        }
+
+        let Some(round_id) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::ActiveRoundId)
+        else {
+            return;
+        };
+
+        let round_key = DataKey::Round(round_id);
+        let Some(mut round) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, RoundData>(&round_key)
+        else {
+            return;
+        };
+
+        let now = env.ledger().timestamp();
+        if round.status != RoundStatus::Active || now < round.starts_at || now > round.ends_at {
+            return;
+        }
+
+        round.submission_count = round.submission_count.saturating_add(1);
+
+        let participation_key = DataKey::Participation(round_id, player);
+        if !env.storage().persistent().has(&participation_key) {
+            env.storage().persistent().set(&participation_key, &true);
+            round.participant_count = round.participant_count.saturating_add(1);
+        }
+
+        env.storage().persistent().set(&round_key, &round);
     }
 
     /// Claim rewards for a correct answer.
@@ -21,5 +224,207 @@ impl TriviaGame {
         player.require_auth();
         // TODO: Verify winner status
         // TODO: Call PrizePool for payout
+    }
+
+    /// Return the display-safe question-set metadata for a configured round.
+    pub fn question_set_metadata(env: Env, round_id: u64) -> Result<QuestionSetMetadata, Error> {
+        require_initialized(&env)?;
+
+        let round: RoundData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Round(round_id))
+            .ok_or(Error::RoundNotFound)?;
+
+        Ok(QuestionSetMetadata {
+            round_id,
+            question_set_id: round.question_set_id,
+            question_count: round.question_count,
+            category: round.category,
+            difficulty: round.difficulty,
+            starts_at: round.starts_at,
+            ends_at: round.ends_at,
+            status: round.status,
+        })
+    }
+
+    /// Return a deterministic snapshot of the active round, if one exists.
+    ///
+    /// When no round is active the snapshot is zeroed with
+    /// `has_active_round = false`.
+    pub fn active_round_snapshot(env: Env) -> ActiveRoundSnapshot {
+        let now = env.ledger().timestamp();
+
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return empty_snapshot(now);
+        }
+
+        let Some(round_id) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::ActiveRoundId)
+        else {
+            return empty_snapshot(now);
+        };
+
+        let Some(round) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, RoundData>(&DataKey::Round(round_id))
+        else {
+            return empty_snapshot(now);
+        };
+
+        if round.status != RoundStatus::Active {
+            return empty_snapshot(now);
+        }
+
+        ActiveRoundSnapshot {
+            has_active_round: true,
+            round_id,
+            question_set_id: round.question_set_id,
+            starts_at: round.starts_at,
+            ends_at: round.ends_at,
+            now,
+            participant_count: round.participant_count,
+            submission_count: round.submission_count,
+            is_accepting_answers: now >= round.starts_at && now <= round.ends_at,
+        }
+    }
+}
+
+fn require_initialized(env: &Env) -> Result<(), Error> {
+    if !env.storage().instance().has(&DataKey::Admin) {
+        return Err(Error::NotInitialized);
+    }
+
+    Ok(())
+}
+
+fn require_admin(env: &Env, admin: &Address) -> Result<(), Error> {
+    require_initialized(env)?;
+
+    let stored_admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    admin.require_auth();
+
+    if admin != &stored_admin {
+        return Err(Error::NotAuthorized);
+    }
+
+    Ok(())
+}
+
+fn empty_snapshot(now: u64) -> ActiveRoundSnapshot {
+    ActiveRoundSnapshot {
+        has_active_round: false,
+        round_id: 0,
+        question_set_id: 0,
+        starts_at: 0,
+        ends_at: 0,
+        now,
+        participant_count: 0,
+        submission_count: 0,
+        is_accepting_answers: false,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env, String,
+    };
+
+    fn setup(env: &Env) -> (TriviaGameClient<'_>, Address) {
+        let admin = Address::generate(env);
+        let contract_id = env.register(TriviaGame, ());
+        let client = TriviaGameClient::new(env, &contract_id);
+        env.mock_all_auths();
+        client.init(&admin);
+        (client, admin)
+    }
+
+    fn set_time(env: &Env, timestamp: u64) {
+        env.ledger().with_mut(|li| {
+            li.timestamp = timestamp;
+        });
+    }
+
+    #[test]
+    fn test_active_round_snapshot_inactive_state() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+
+        set_time(&env, 1_000);
+        let snapshot = client.active_round_snapshot();
+        assert!(!snapshot.has_active_round);
+        assert_eq!(snapshot.round_id, 0);
+        assert_eq!(snapshot.question_set_id, 0);
+        assert_eq!(snapshot.participant_count, 0);
+        assert_eq!(snapshot.submission_count, 0);
+        assert!(!snapshot.is_accepting_answers);
+    }
+
+    #[test]
+    fn test_question_set_metadata_for_configured_round() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        env.mock_all_auths();
+
+        let category = String::from_str(&env, "general");
+        client.configure_round(
+            &admin, &7u64, &42u64, &12u32, &category, &3u32, &1_000u64, &2_000u64,
+        );
+
+        let metadata = client.question_set_metadata(&7u64);
+        assert_eq!(metadata.round_id, 7);
+        assert_eq!(metadata.question_set_id, 42);
+        assert_eq!(metadata.question_count, 12);
+        assert_eq!(metadata.category, category);
+        assert_eq!(metadata.difficulty, 3);
+        assert_eq!(metadata.starts_at, 1_000);
+        assert_eq!(metadata.ends_at, 2_000);
+        assert_eq!(metadata.status, RoundStatus::Configured);
+    }
+
+    #[test]
+    fn test_active_round_snapshot_tracks_timing_and_participation() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        env.mock_all_auths();
+
+        let category = String::from_str(&env, "arcade");
+        client.configure_round(
+            &admin, &9u64, &77u64, &8u32, &category, &2u32, &1_000u64, &2_000u64,
+        );
+        client.activate_round(&admin, &9u64);
+
+        set_time(&env, 1_500);
+        let player_a = Address::generate(&env);
+        let player_b = Address::generate(&env);
+        let answer = String::from_str(&env, "A");
+
+        client.submit_answer(&player_a, &1u32, &answer);
+        client.submit_answer(&player_a, &2u32, &answer);
+        client.submit_answer(&player_b, &3u32, &answer);
+
+        let snapshot = client.active_round_snapshot();
+        assert!(snapshot.has_active_round);
+        assert_eq!(snapshot.round_id, 9);
+        assert_eq!(snapshot.question_set_id, 77);
+        assert_eq!(snapshot.starts_at, 1_000);
+        assert_eq!(snapshot.ends_at, 2_000);
+        assert_eq!(snapshot.now, 1_500);
+        assert_eq!(snapshot.participant_count, 2);
+        assert_eq!(snapshot.submission_count, 3);
+        assert!(snapshot.is_accepting_answers);
+
+        let repeated_read = client.active_round_snapshot();
+        assert_eq!(snapshot, repeated_read);
     }
 }

--- a/contracts/vip-subscription/README.md
+++ b/contracts/vip-subscription/README.md
@@ -84,6 +84,52 @@ pub struct SubscriptionStatus {
 
 ---
 
+### `subscription_status(user) -> UserSubscriptionStatus`
+
+Returns a frontend-friendly subscription status that explicitly distinguishes never-subscribed, active, and expired users.
+
+```rust
+pub enum SubscriptionState {
+    NeverSubscribed,
+    Active,
+    Expired,
+}
+
+pub struct UserSubscriptionStatus {
+    pub state: SubscriptionState,
+    pub plan_id: u32,
+    pub expires_at: u64,
+    pub seconds_until_expiry: u64,
+}
+```
+
+- Never-subscribed users return `state = NeverSubscribed`, `plan_id = 0`, and `expires_at = 0`.
+- Expired subscriptions keep their stored `plan_id` and `expires_at` so clients can render renewal messaging without extra joins.
+
+---
+
+### `renewal_preview(user) -> RenewalPreview`
+
+Returns a side-effect free preview of what would happen if the user renewed now.
+
+```rust
+pub struct RenewalPreview {
+    pub state: SubscriptionState,
+    pub plan_id: u32,
+    pub can_renew: bool,
+    pub renewal_cost: i128,
+    pub renewal_duration: u64,
+    pub effective_from: u64,
+    pub next_expires_at: u64,
+}
+```
+
+- Active subscriptions preview a stacked renewal from the current `expires_at`.
+- Expired subscriptions preview reactivation from the current ledger timestamp.
+- Never-subscribed users return `can_renew = false` and zeroed timing/cost fields because `renew` requires an existing record.
+
+---
+
 ## Events
 
 | Event | Topics | Data | Emitted by |
@@ -145,5 +191,6 @@ pub struct SubscriptionStatus {
 
 - **Treasury contract** is a deployed SEP-41 token contract (e.g., USDC Stellar Asset Contract). All subscription payments are forwarded to its address via `TokenClient::transfer`.
 - **Dependents (issues #25, #26, #27, #28, #36):** Downstream contracts may call `status_of` to gate VIP-only features. No cross-contract call is required — callers read the status view directly.
+- **Status consumers:** New UI code can prefer `subscription_status` and `renewal_preview` for explicit rendering of never-subscribed, active, expired, and renewal-timing states.
 - **Off-chain services** listen for `PlanDefined`, `Subscribed`, and `Renewed` events to update user dashboards and apply benefits.
 - **Expired subscriptions** remain as storage records (not deleted) so renewal history is auditable and `renew` can reactivate without a fresh `subscribe`.

--- a/contracts/vip-subscription/src/lib.rs
+++ b/contracts/vip-subscription/src/lib.rs
@@ -121,6 +121,38 @@ pub struct SubscriptionStatus {
     pub is_active: bool,
 }
 
+/// Frontend-friendly state for a user's subscription lifecycle.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SubscriptionState {
+    NeverSubscribed = 0,
+    Active = 1,
+    Expired = 2,
+}
+
+/// Extended status view that distinguishes active, expired, and missing users.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserSubscriptionStatus {
+    pub state: SubscriptionState,
+    pub plan_id: u32,
+    pub expires_at: u64,
+    pub seconds_until_expiry: u64,
+}
+
+/// Side-effect free preview of the next renewal for a user.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RenewalPreview {
+    pub state: SubscriptionState,
+    pub plan_id: u32,
+    pub can_renew: bool,
+    pub renewal_cost: i128,
+    pub renewal_duration: u64,
+    pub effective_from: u64,
+    pub next_expires_at: u64,
+}
+
 // ---------------------------------------------------------------------------
 // Events
 // ---------------------------------------------------------------------------
@@ -364,23 +396,73 @@ impl VipSubscription {
     /// user has never subscribed. If a record exists, `is_active` reflects
     /// whether the current ledger timestamp is before `expires_at`.
     pub fn status_of(env: Env, user: Address) -> SubscriptionStatus {
-        let sub_key = DataKey::Subscription(user);
-        match get_subscription(&env, &sub_key) {
-            None => SubscriptionStatus {
-                has_subscription: false,
+        let status = build_user_subscription_status(&env, &user);
+        SubscriptionStatus {
+            has_subscription: status.state != SubscriptionState::NeverSubscribed,
+            plan_id: status.plan_id,
+            expires_at: status.expires_at,
+            is_active: status.state == SubscriptionState::Active,
+        }
+    }
+
+    /// Return a frontend-friendly subscription status for `user`.
+    ///
+    /// Missing users return `NeverSubscribed`, while expired users retain
+    /// their stored `plan_id` and `expires_at` for renewal messaging.
+    pub fn subscription_status(env: Env, user: Address) -> UserSubscriptionStatus {
+        build_user_subscription_status(&env, &user)
+    }
+
+    /// Preview the effect of renewing the user's current subscription now.
+    ///
+    /// This accessor never mutates state. Active subscriptions preview a stacked
+    /// renewal from the current expiry; expired subscriptions preview a renewal
+    /// starting from `now`; never-subscribed users return `can_renew = false`.
+    pub fn renewal_preview(env: Env, user: Address) -> RenewalPreview {
+        let status = build_user_subscription_status(&env, &user);
+        let now = env.ledger().timestamp();
+
+        if status.state == SubscriptionState::NeverSubscribed {
+            return RenewalPreview {
+                state: SubscriptionState::NeverSubscribed,
                 plan_id: 0,
-                expires_at: 0,
-                is_active: false,
+                can_renew: false,
+                renewal_cost: 0,
+                renewal_duration: 0,
+                effective_from: 0,
+                next_expires_at: 0,
+            };
+        }
+
+        let effective_from = if status.state == SubscriptionState::Active {
+            status.expires_at
+        } else {
+            now
+        };
+
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, PlanDefinition>(&DataKey::Plan(status.plan_id))
+        {
+            Some(plan) => RenewalPreview {
+                state: status.state,
+                plan_id: status.plan_id,
+                can_renew: true,
+                renewal_cost: plan.price,
+                renewal_duration: plan.duration,
+                effective_from,
+                next_expires_at: effective_from.saturating_add(plan.duration),
             },
-            Some(record) => {
-                let now = env.ledger().timestamp();
-                SubscriptionStatus {
-                    has_subscription: true,
-                    plan_id: record.plan_id,
-                    expires_at: record.expires_at,
-                    is_active: record.expires_at > now,
-                }
-            }
+            None => RenewalPreview {
+                state: status.state,
+                plan_id: status.plan_id,
+                can_renew: false,
+                renewal_cost: 0,
+                renewal_duration: 0,
+                effective_from,
+                next_expires_at: 0,
+            },
         }
     }
 }
@@ -427,6 +509,34 @@ fn get_treasury(env: &Env) -> Address {
 
 fn get_subscription(env: &Env, key: &DataKey) -> Option<SubscriptionRecord> {
     env.storage().persistent().get(key)
+}
+
+fn build_user_subscription_status(env: &Env, user: &Address) -> UserSubscriptionStatus {
+    let now = env.ledger().timestamp();
+    let sub_key = DataKey::Subscription(user.clone());
+
+    match get_subscription(env, &sub_key) {
+        None => UserSubscriptionStatus {
+            state: SubscriptionState::NeverSubscribed,
+            plan_id: 0,
+            expires_at: 0,
+            seconds_until_expiry: 0,
+        },
+        Some(record) => {
+            let state = if record.expires_at > now {
+                SubscriptionState::Active
+            } else {
+                SubscriptionState::Expired
+            };
+
+            UserSubscriptionStatus {
+                state,
+                plan_id: record.plan_id,
+                expires_at: record.expires_at,
+                seconds_until_expiry: record.expires_at.saturating_sub(now),
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -813,6 +923,114 @@ mod test {
         let status = client.status_of(&user);
         assert!(status.has_subscription);
         assert!(!status.is_active);
+    }
+
+    #[test]
+    fn test_subscription_status_never_subscribed() {
+        let env = Env::default();
+        let (client, _, _, _) = setup(&env);
+
+        let user = Address::generate(&env);
+        let status = client.subscription_status(&user);
+        assert_eq!(status.state, SubscriptionState::NeverSubscribed);
+        assert_eq!(status.plan_id, 0);
+        assert_eq!(status.expires_at, 0);
+        assert_eq!(status.seconds_until_expiry, 0);
+    }
+
+    #[test]
+    fn test_subscription_status_active() {
+        let env = Env::default();
+        let (client, admin, _, token_sac) = setup(&env);
+        env.mock_all_auths();
+
+        let duration: u64 = 86_400;
+        let hash = make_hash(&env, 30);
+        client.define_plan(&admin, &1u32, &250i128, &duration, &hash);
+
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &250i128);
+
+        set_time(&env, 1_000_000);
+        client.subscribe(&user, &1u32);
+
+        let status = client.subscription_status(&user);
+        assert_eq!(status.state, SubscriptionState::Active);
+        assert_eq!(status.plan_id, 1);
+        assert_eq!(status.expires_at, 1_000_000 + duration);
+        assert_eq!(status.seconds_until_expiry, duration);
+    }
+
+    #[test]
+    fn test_renewal_preview_never_subscribed() {
+        let env = Env::default();
+        let (client, _, _, _) = setup(&env);
+
+        let user = Address::generate(&env);
+        let preview = client.renewal_preview(&user);
+        assert_eq!(preview.state, SubscriptionState::NeverSubscribed);
+        assert!(!preview.can_renew);
+        assert_eq!(preview.renewal_cost, 0);
+        assert_eq!(preview.next_expires_at, 0);
+    }
+
+    #[test]
+    fn test_renewal_preview_active_subscription() {
+        let env = Env::default();
+        let (client, admin, _, token_sac) = setup(&env);
+        env.mock_all_auths();
+
+        let duration: u64 = 86_400;
+        let price: i128 = 400;
+        let hash = make_hash(&env, 31);
+        client.define_plan(&admin, &1u32, &price, &duration, &hash);
+
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &price);
+
+        set_time(&env, 1_000_000);
+        client.subscribe(&user, &1u32);
+
+        let preview = client.renewal_preview(&user);
+        assert_eq!(preview.state, SubscriptionState::Active);
+        assert!(preview.can_renew);
+        assert_eq!(preview.plan_id, 1);
+        assert_eq!(preview.renewal_cost, price);
+        assert_eq!(preview.renewal_duration, duration);
+        assert_eq!(preview.effective_from, 1_000_000 + duration);
+        assert_eq!(preview.next_expires_at, 1_000_000 + duration + duration);
+    }
+
+    #[test]
+    fn test_renewal_preview_expired_subscription() {
+        let env = Env::default();
+        let (client, admin, _, token_sac) = setup(&env);
+        env.mock_all_auths();
+
+        let duration: u64 = 86_400;
+        let price: i128 = 400;
+        let hash = make_hash(&env, 32);
+        client.define_plan(&admin, &1u32, &price, &duration, &hash);
+
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &price);
+
+        set_time(&env, 1_000_000);
+        client.subscribe(&user, &1u32);
+
+        let now = 1_000_000 + duration + 50;
+        set_time(&env, now);
+
+        let status = client.subscription_status(&user);
+        assert_eq!(status.state, SubscriptionState::Expired);
+        assert_eq!(status.seconds_until_expiry, 0);
+
+        let preview = client.renewal_preview(&user);
+        assert_eq!(preview.state, SubscriptionState::Expired);
+        assert!(preview.can_renew);
+        assert_eq!(preview.effective_from, now);
+        assert_eq!(preview.next_expires_at, now + duration);
+        assert_eq!(preview.renewal_cost, price);
     }
 
     // ------------------------------------------------------------------

--- a/docs/contracts/price-prediction.md
+++ b/docs/contracts/price-prediction.md
@@ -140,3 +140,49 @@ pub fn get_bet(env: Env, round_id: u64, player: Address) -> Result<BetData, Erro
 
 `Result<BetData, Error>`
 
+### `participant_summary`
+Return a compact and deterministic participant summary for a round.
+
+Missing rounds return `has_round = false` with zero counters and an empty
+`positions` list. Existing rounds return one entry per bettor in bet-placement
+order, along with aggregate side counts and wager totals.
+
+```rust
+pub fn participant_summary(env: Env, round_id: u64) -> RoundParticipantSummary
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `round_id` | `u64` |
+
+#### Return Type
+
+`RoundParticipantSummary`
+
+### `settlement_preview`
+Preview settlement using the round's current wager totals and the oracle's
+current price feed.
+
+Before final settlement this output is provisional and should be interpreted as
+"if the round settled right now." Once a round is settled, the preview mirrors
+the final stored result and returns `is_provisional = false`.
+
+Missing rounds return `has_round = false` and zeroed numeric fields.
+
+```rust
+pub fn settlement_preview(env: Env, round_id: u64) -> SettlementPreview
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `round_id` | `u64` |
+
+#### Return Type
+
+`SettlementPreview`

--- a/docs/contracts/streak-bonus.md
+++ b/docs/contracts/streak-bonus.md
@@ -60,6 +60,53 @@ pub fn current_streak(env: Env, user: Address) -> u32
 
 `u32`
 
+### `streak_summary`
+Return a per-player streak summary at `as_of_ts`.
+
+Missing players return `status = Missing` with all counters at `0`.
+If the stored streak window has elapsed by `as_of_ts`, the summary returns
+`status = Reset`, `active_streak = 0`, and preserves the previous
+`last_recorded_streak` for UI messaging.
+
+```rust
+pub fn streak_summary(env: Env, user: Address, as_of_ts: u64) -> StreakSummary
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `user` | `Address` |
+| `as_of_ts` | `u64` |
+
+#### Return Type
+
+`StreakSummary`
+
+### `next_bonus_preview`
+Preview the next streak-bonus threshold and projected reward at `as_of_ts`.
+
+The preview is deterministic for a given `as_of_ts`, side-effect free, and uses
+the effective active streak so broken streaks render from `0` while still
+retaining the player's historic `last_claimed_streak` progression.
+
+```rust
+pub fn next_bonus_preview(env: Env, user: Address, as_of_ts: u64) -> NextBonusPreview
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `user` | `Address` |
+| `as_of_ts` | `u64` |
+
+#### Return Type
+
+`NextBonusPreview`
+
 ### `claim_streak_bonus`
 Claim streak bonus for the current streak. User must authorize. Updates last_claimed_streak.
 
@@ -97,3 +144,9 @@ pub fn reset_rules(env: Env, admin: Address, config: StreakRules) -> Result<(), 
 
 `Result<(), Error>`
 
+## Read Semantics
+
+- `StreakSummary.status = Active` means the stored streak is still inside the configured streak window at `as_of_ts`.
+- `StreakSummary.status = Reset` means the streak has timed out; `active_streak` is reset to `0` but `last_recorded_streak` still shows the prior stored value.
+- `StreakSummary.status = Missing` means the player has no recorded activity yet.
+- `NextBonusPreview.threshold_streak` is the next streak count that would unlock a new bonus under the current lifetime `last_claimed_streak` progression.

--- a/docs/contracts/trivia-game.md
+++ b/docs/contracts/trivia-game.md
@@ -2,21 +2,47 @@
 
 ## Public Methods
 
-### `submit_answer`
-Submit an answer for a specific question ID.
+### `init`
+Initialize the contract with the admin allowed to configure rounds.
 
 ```rust
-pub fn submit_answer(_env: Env, player: Address, _question_id: u32, _answer: String)
+pub fn init(env: Env, admin: Address) -> Result<(), Error>
 ```
 
-#### Parameters
+### `configure_round`
+Configure a round and its question-set metadata. The stored metadata is safe
+for pre-round display because it exposes only display fields such as category,
+count, difficulty, and timing, not question content or answers.
 
-| Name | Type |
-|------|------|
-| `_env` | `Env` |
-| `player` | `Address` |
-| `_question_id` | `u32` |
-| `_answer` | `String` |
+```rust
+pub fn configure_round(
+    env: Env,
+    admin: Address,
+    round_id: u64,
+    question_set_id: u64,
+    question_count: u32,
+    category: String,
+    difficulty: u32,
+    starts_at: u64,
+    ends_at: u64,
+) -> Result<(), Error>
+```
+
+### `activate_round`
+Mark a configured round as active. Only one round is active at a time; if a
+different round was active it is moved back to `Configured`.
+
+```rust
+pub fn activate_round(env: Env, admin: Address, round_id: u64) -> Result<(), Error>
+```
+
+### `submit_answer`
+Submit an answer for the current active round. The contract records
+participation and submission counters for snapshot reads.
+
+```rust
+pub fn submit_answer(env: Env, player: Address, question_id: u32, answer: String)
+```
 
 ### `claim_reward`
 Claim rewards for a correct answer.
@@ -25,11 +51,26 @@ Claim rewards for a correct answer.
 pub fn claim_reward(_env: Env, player: Address, _game_id: u32)
 ```
 
-#### Parameters
+### `question_set_metadata`
+Return the configured question-set metadata for a round.
 
-| Name | Type |
-|------|------|
-| `_env` | `Env` |
-| `player` | `Address` |
-| `_game_id` | `u32` |
+```rust
+pub fn question_set_metadata(env: Env, round_id: u64) -> Result<QuestionSetMetadata, Error>
+```
 
+### `active_round_snapshot`
+Return a deterministic snapshot of the active round.
+
+If the contract has no active round, the snapshot is zeroed and
+`has_active_round = false`.
+
+```rust
+pub fn active_round_snapshot(env: Env) -> ActiveRoundSnapshot
+```
+
+## Read Semantics
+
+- `question_set_metadata` works for configured or active rounds and returns display-safe metadata only.
+- `active_round_snapshot.is_accepting_answers` is derived from the configured start/end times and current ledger timestamp.
+- Repeated reads in the same ledger state return the same snapshot values.
+- The storage layout is round-based (`Round(round_id)` plus `ActiveRoundId`) so it can be extended to multi-round trivia flows later.

--- a/docs/contracts/vip-subscription.md
+++ b/docs/contracts/vip-subscription.md
@@ -101,3 +101,48 @@ pub fn status_of(env: Env, user: Address) -> SubscriptionStatus
 
 `SubscriptionStatus`
 
+### `subscription_status`
+Return a frontend-friendly subscription status for `user`.
+
+This accessor explicitly separates:
+- `NeverSubscribed` users with no stored record.
+- `Active` users whose `expires_at` is still in the future.
+- `Expired` users whose record remains on-chain for renewal and auditability.
+
+```rust
+pub fn subscription_status(env: Env, user: Address) -> UserSubscriptionStatus
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `user` | `Address` |
+
+#### Return Type
+
+`UserSubscriptionStatus`
+
+### `renewal_preview`
+Preview the next renewal cost and timing for `user`.
+
+This accessor is side-effect free. Active subscriptions preview stacked renewal
+from the current `expires_at`; expired subscriptions preview reactivation from
+the current ledger timestamp; never-subscribed users return `can_renew = false`
+with zeroed cost and timing fields.
+
+```rust
+pub fn renewal_preview(env: Env, user: Address) -> RenewalPreview
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `user` | `Address` |
+
+#### Return Type
+
+`RenewalPreview`


### PR DESCRIPTION
PR Title
Add visibility/status accessors for streak, VIP, trivia, and price prediction contracts

PR Description
This PR adds frontend-friendly, read-only accessors across four contracts so clients can inspect current player and round state without side effects. It includes streak summaries and next bonus previews, VIP subscription status and renewal previews, trivia question-set metadata and active round snapshots, and price prediction participant summaries plus provisional settlement previews.

It also updates the related docs to clarify missing-user, expired, reset, inactive, and provisional-preview behavior, and adds focused tests covering the new read paths while keeping existing contract behavior stable.


Closes #443
Closes #442
Closes #441
Closes #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Price Prediction: Added participant summary and settlement preview views for betting rounds
  * Streak Bonus: Added streak tracking and bonus threshold preview methods
  * Trivia Game: Introduced round configuration, activation, and active round inspection APIs
  * VIP Subscription: Added subscription status and renewal preview views

* **Documentation**
  * Updated contract documentation with new method specifications and read semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->