### PR TITLE
feat/Contract revenue-split: add beneficiary share preview and accrua…

### DIFF
--- a/contracts/revenue-split/README.md
+++ b/contracts/revenue-split/README.md
@@ -20,6 +20,8 @@ Soroban smart contract for deterministic revenue distribution to multiple recipi
 | `set_split_config(stream_id, recipients)` | admin | Define recipients and their BPS weights (must sum to 10000) |
 | `deposit_revenue(depositor, stream_id, amount)` | depositor | Deposit tokens into a stream |
 | `distribute(stream_id)` | admin | Distribute all pending revenue proportionally |
+| `preview_shares(stream_id, amount)` | — | Preview beneficiary shares for a prospective amount using the same rounding logic as `distribute` |
+| `get_split_state(stream_id)` | — | Read pending balance plus cumulative beneficiary accruals in configured order |
 | `recipient_balance(stream_id, recipient)` | — | Query cumulative distributed amount |
 
 ## Events
@@ -33,9 +35,17 @@ Soroban smart contract for deterministic revenue distribution to multiple recipi
 ## Invariants
 
 - Recipient weights must sum to exactly **10000 BPS** (100%).
-- Stream balance is zeroed **before** transfers (reentrancy guard).
+- Stream balance is updated **before** transfers (reentrancy guard). Any rounding remainder is carried forward as pending balance for the stream instead of being discarded.
 - Distribution requires a positive pending balance.
 - At least one recipient is required.
+
+## Preview And Snapshot Semantics
+
+- `preview_shares` mirrors the exact integer math used by `distribute`.
+- Each preview entry reports `share_amount`, `rounded_down`, and `remainder_numerator` so callers can see when basis-point division truncated a fractional entitlement.
+- `SharePreview.remainder` is the undistributed amount left after summing all floored beneficiary shares.
+- `get_split_state` returns beneficiary accruals in the same order they were configured in `set_split_config`, making reads deterministic for clients and auditors.
+- `get_split_state.pending_balance` includes both newly deposited funds and any carried rounding remainder from previous distributions.
 
 ## Dependencies
 

--- a/contracts/revenue-split/src/lib.rs
+++ b/contracts/revenue-split/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracttype,
-    token, Address, Env, Symbol, Vec,
+    contract, contractevent, contractimpl, contracttype, token, Address, Env, Symbol, Vec,
 };
 
 // ── Storage Keys ─────────────────────────────────────────────────
@@ -11,9 +10,9 @@ use soroban_sdk::{
 pub enum DataKey {
     Admin,
     Token,
-    SplitConfig(Symbol),                   // stream_id → SplitConfig
-    StreamBalance(Symbol),                  // stream_id → i128 (total deposited, not yet distributed)
-    RecipientBalance(Symbol, Address),      // (stream_id, recipient) → i128
+    SplitConfig(Symbol),               // stream_id → SplitConfig
+    StreamBalance(Symbol),             // stream_id → i128 (total deposited, not yet distributed)
+    RecipientBalance(Symbol, Address), // (stream_id, recipient) → i128
 }
 
 // ── Domain Types ─────────────────────────────────────────────────
@@ -30,6 +29,54 @@ pub struct RecipientWeight {
 pub struct SplitConfig {
     pub stream_id: Symbol,
     pub recipients: Vec<RecipientWeight>,
+}
+
+/// Per-beneficiary share calculation returned by `preview_shares`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SharePreviewEntry {
+    pub recipient: Address,
+    pub weight_bps: u32,
+    pub share_amount: i128,
+    /// The raw post-division remainder numerator (`amount * weight_bps % 10000`).
+    pub remainder_numerator: i128,
+    pub rounded_down: bool,
+}
+
+/// Read-only summary of how a prospective amount would be split.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SharePreview {
+    pub stream_id: Symbol,
+    pub amount: i128,
+    pub distributed_total: i128,
+    /// Amount that remains pending because integer division truncated one or
+    /// more recipient shares.
+    pub remainder: i128,
+    /// Entries are returned in the configured recipient order.
+    pub shares: Vec<SharePreviewEntry>,
+}
+
+/// Current cumulative accrual for a configured beneficiary.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BeneficiaryAccrual {
+    pub recipient: Address,
+    pub weight_bps: u32,
+    pub accrued_balance: i128,
+}
+
+/// Read-only snapshot of the stream's current split accounting state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SplitAccrualSnapshot {
+    pub stream_id: Symbol,
+    /// Undistributed balance still held by the contract for this stream,
+    /// including any carried rounding remainder from prior distributions.
+    pub pending_balance: i128,
+    pub accrued_total: i128,
+    /// Entries are returned in the configured recipient order.
+    pub accruals: Vec<BeneficiaryAccrual>,
 }
 
 // ── Events ────────────────────────────────────────────────────────
@@ -65,7 +112,9 @@ impl RevenueSplit {
             panic!("Already initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Token, &token_address);
+        env.storage()
+            .instance()
+            .set(&DataKey::Token, &token_address);
     }
 
     /// Configure or update a split for a stream. Admin-only.
@@ -86,7 +135,9 @@ impl RevenueSplit {
             stream_id: stream_id.clone(),
             recipients,
         };
-        env.storage().persistent().set(&DataKey::SplitConfig(stream_id.clone()), &config);
+        env.storage()
+            .persistent()
+            .set(&DataKey::SplitConfig(stream_id.clone()), &config);
 
         SplitConfigured { stream_id }.publish(&env);
     }
@@ -98,23 +149,29 @@ impl RevenueSplit {
 
         // Ensure config exists
         assert!(
-            env.storage().persistent().has(&DataKey::SplitConfig(stream_id.clone())),
+            env.storage()
+                .persistent()
+                .has(&DataKey::SplitConfig(stream_id.clone())),
             "Split config not found for stream"
         );
 
-        let token_addr: Address =
-            env.storage().instance().get(&DataKey::Token).expect("Not initialized");
+        let token_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("Not initialized");
         let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(&depositor, &env.current_contract_address(), &amount);
+        token_client.transfer(&depositor, env.current_contract_address(), &amount);
 
         let current: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::StreamBalance(stream_id.clone()))
             .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&DataKey::StreamBalance(stream_id.clone()), &(current.checked_add(amount).expect("Overflow")));
+        env.storage().persistent().set(
+            &DataKey::StreamBalance(stream_id.clone()),
+            &(current.checked_add(amount).expect("Overflow")),
+        );
 
         RevenueDeposited { stream_id, amount }.publish(&env);
     }
@@ -123,11 +180,7 @@ impl RevenueSplit {
     pub fn distribute(env: Env, stream_id: Symbol) {
         Self::require_admin(&env);
 
-        let config: SplitConfig = env
-            .storage()
-            .persistent()
-            .get(&DataKey::SplitConfig(stream_id.clone()))
-            .expect("Split config not found");
+        let config = Self::get_split_config(&env, stream_id.clone());
 
         let total: i128 = env
             .storage()
@@ -137,32 +190,34 @@ impl RevenueSplit {
 
         assert!(total > 0, "Nothing to distribute");
 
-        // Zero out the stream balance before transfers (reentrancy guard)
-        env.storage()
-            .persistent()
-            .set(&DataKey::StreamBalance(stream_id.clone()), &0i128);
+        let preview = Self::build_share_preview(&env, &config, stream_id.clone(), total);
 
-        let token_addr: Address =
-            env.storage().instance().get(&DataKey::Token).expect("Not initialized");
+        // Persist any rounding remainder before transfers (reentrancy guard).
+        env.storage().persistent().set(
+            &DataKey::StreamBalance(stream_id.clone()),
+            &preview.remainder,
+        );
+
+        let token_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("Not initialized");
         let token_client = token::Client::new(&env, &token_addr);
+        let contract_address = env.current_contract_address();
 
-        for r in config.recipients.iter() {
-            let share = total
-                .checked_mul(r.weight_bps as i128)
-                .expect("Overflow")
-                .checked_div(10_000)
-                .expect("Division by zero");
-
-            if share > 0 {
+        for share in preview.shares.iter() {
+            if share.share_amount > 0 {
                 // Credit to recipient internal balance
-                let bal_key = DataKey::RecipientBalance(stream_id.clone(), r.recipient.clone());
+                let bal_key = DataKey::RecipientBalance(stream_id.clone(), share.recipient.clone());
                 let prev: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
-                env.storage()
-                    .persistent()
-                    .set(&bal_key, &prev.checked_add(share).expect("Overflow"));
+                env.storage().persistent().set(
+                    &bal_key,
+                    &prev.checked_add(share.share_amount).expect("Overflow"),
+                );
 
                 // Immediate transfer
-                token_client.transfer(&env.current_contract_address(), &r.recipient, &share);
+                token_client.transfer(&contract_address, &share.recipient, &share.share_amount);
             }
         }
 
@@ -177,6 +232,56 @@ impl RevenueSplit {
             .unwrap_or(0)
     }
 
+    /// Preview how a prospective amount would be split for a configured stream.
+    /// The preview uses the exact same rounding logic as `distribute`.
+    pub fn preview_shares(env: Env, stream_id: Symbol, amount: i128) -> SharePreview {
+        assert!(amount >= 0, "Amount cannot be negative");
+        let config = Self::get_split_config(&env, stream_id.clone());
+        Self::build_share_preview(&env, &config, stream_id, amount)
+    }
+
+    /// Return a deterministic snapshot of current pending balance and
+    /// cumulative beneficiary accruals for the stream.
+    pub fn get_split_state(env: Env, stream_id: Symbol) -> SplitAccrualSnapshot {
+        let config = Self::get_split_config(&env, stream_id.clone());
+        let pending_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StreamBalance(stream_id.clone()))
+            .unwrap_or(0);
+
+        let mut accrued_total: i128 = 0;
+        let mut accruals = Vec::new(&env);
+
+        for recipient in config.recipients.iter() {
+            let accrued_balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::RecipientBalance(
+                    stream_id.clone(),
+                    recipient.recipient.clone(),
+                ))
+                .unwrap_or(0);
+
+            accrued_total = accrued_total
+                .checked_add(accrued_balance)
+                .expect("Overflow");
+
+            accruals.push_back(BeneficiaryAccrual {
+                recipient: recipient.recipient.clone(),
+                weight_bps: recipient.weight_bps,
+                accrued_balance,
+            });
+        }
+
+        SplitAccrualSnapshot {
+            stream_id,
+            pending_balance,
+            accrued_total,
+            accruals,
+        }
+    }
+
     // ── Internal ─────────────────────────────────────────────────
     fn require_admin(env: &Env) {
         let admin: Address = env
@@ -185,6 +290,53 @@ impl RevenueSplit {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         admin.require_auth();
+    }
+
+    fn get_split_config(env: &Env, stream_id: Symbol) -> SplitConfig {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SplitConfig(stream_id))
+            .expect("Split config not found")
+    }
+
+    fn build_share_preview(
+        env: &Env,
+        config: &SplitConfig,
+        stream_id: Symbol,
+        amount: i128,
+    ) -> SharePreview {
+        let mut distributed_total: i128 = 0;
+        let mut shares = Vec::new(env);
+
+        for recipient in config.recipients.iter() {
+            let numerator = amount
+                .checked_mul(recipient.weight_bps as i128)
+                .expect("Overflow");
+            let share_amount = numerator.checked_div(10_000).expect("Division by zero");
+            let remainder_numerator = numerator.checked_rem(10_000).expect("Division by zero");
+
+            distributed_total = distributed_total
+                .checked_add(share_amount)
+                .expect("Overflow");
+
+            shares.push_back(SharePreviewEntry {
+                recipient: recipient.recipient.clone(),
+                weight_bps: recipient.weight_bps,
+                share_amount,
+                remainder_numerator,
+                rounded_down: remainder_numerator > 0,
+            });
+        }
+
+        let remainder = amount.checked_sub(distributed_total).expect("Overflow");
+
+        SharePreview {
+            stream_id,
+            amount,
+            distributed_total,
+            remainder,
+            shares,
+        }
     }
 }
 
@@ -198,10 +350,17 @@ mod test {
         vec, Env, Symbol,
     };
 
-    fn setup_token<'a>(env: &Env, admin: &Address) -> (Address, StellarAssetClient<'a>, TokenClient<'a>) {
+    fn setup_token<'a>(
+        env: &Env,
+        admin: &Address,
+    ) -> (Address, StellarAssetClient<'a>, TokenClient<'a>) {
         let sac = env.register_stellar_asset_contract_v2(admin.clone());
         let addr = sac.address();
-        (addr.clone(), StellarAssetClient::new(env, &addr), TokenClient::new(env, &addr))
+        (
+            addr.clone(),
+            StellarAssetClient::new(env, &addr),
+            TokenClient::new(env, &addr),
+        )
     }
 
     #[test]
@@ -217,7 +376,7 @@ mod test {
         let (token_id, sa, tc) = setup_token(&env, &admin);
         sa.mint(&depositor, &1000);
 
-        let contract_id = env.register_contract(None, RevenueSplit);
+        let contract_id = env.register(RevenueSplit, ());
         let client = RevenueSplitClient::new(&env, &contract_id);
 
         client.init(&admin, &token_id);
@@ -225,8 +384,14 @@ mod test {
         let stream = Symbol::new(&env, "gaming");
         let recipients = vec![
             &env,
-            RecipientWeight { recipient: r1.clone(), weight_bps: 6000 },
-            RecipientWeight { recipient: r2.clone(), weight_bps: 4000 },
+            RecipientWeight {
+                recipient: r1.clone(),
+                weight_bps: 6000,
+            },
+            RecipientWeight {
+                recipient: r2.clone(),
+                weight_bps: 4000,
+            },
         ];
         client.set_split_config(&stream, &recipients);
 
@@ -239,6 +404,13 @@ mod test {
 
         assert_eq!(client.recipient_balance(&stream, &r1), 600);
         assert_eq!(client.recipient_balance(&stream, &r2), 400);
+
+        let snapshot = client.get_split_state(&stream);
+        assert_eq!(snapshot.pending_balance, 0);
+        assert_eq!(snapshot.accrued_total, 1000);
+        assert_eq!(snapshot.accruals.len(), 2);
+        assert_eq!(snapshot.accruals.get(0).unwrap().recipient, r1);
+        assert_eq!(snapshot.accruals.get(1).unwrap().recipient, r2);
     }
 
     #[test]
@@ -251,14 +423,17 @@ mod test {
         let r1 = Address::generate(&env);
         let token = Address::generate(&env);
 
-        let contract_id = env.register_contract(None, RevenueSplit);
+        let contract_id = env.register(RevenueSplit, ());
         let client = RevenueSplitClient::new(&env, &contract_id);
         client.init(&admin, &token);
 
         let stream = Symbol::new(&env, "bad");
         let recipients = vec![
             &env,
-            RecipientWeight { recipient: r1, weight_bps: 5000 }, // Only 50%, not 100%
+            RecipientWeight {
+                recipient: r1,
+                weight_bps: 5000,
+            }, // Only 50%, not 100%
         ];
         client.set_split_config(&stream, &recipients);
     }
@@ -273,12 +448,18 @@ mod test {
         let r1 = Address::generate(&env);
         let token = Address::generate(&env);
 
-        let contract_id = env.register_contract(None, RevenueSplit);
+        let contract_id = env.register(RevenueSplit, ());
         let client = RevenueSplitClient::new(&env, &contract_id);
         client.init(&admin, &token);
 
         let stream = Symbol::new(&env, "empty");
-        let recipients = vec![&env, RecipientWeight { recipient: r1, weight_bps: 10000 }];
+        let recipients = vec![
+            &env,
+            RecipientWeight {
+                recipient: r1,
+                weight_bps: 10000,
+            },
+        ];
         client.set_split_config(&stream, &recipients);
         client.distribute(&stream);
     }
@@ -290,9 +471,219 @@ mod test {
         env.mock_all_auths();
         let admin = Address::generate(&env);
         let token = Address::generate(&env);
-        let contract_id = env.register_contract(None, RevenueSplit);
+        let contract_id = env.register(RevenueSplit, ());
         let client = RevenueSplitClient::new(&env, &contract_id);
         client.init(&admin, &token);
         client.init(&admin, &token);
+    }
+
+    #[test]
+    fn test_preview_shares_matches_distribution_and_reports_rounding() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let r3 = Address::generate(&env);
+        let depositor = Address::generate(&env);
+
+        let (token_id, sa, tc) = setup_token(&env, &admin);
+        sa.mint(&depositor, &101);
+
+        let contract_id = env.register(RevenueSplit, ());
+        let client = RevenueSplitClient::new(&env, &contract_id);
+        client.init(&admin, &token_id);
+
+        let stream = Symbol::new(&env, "rounding");
+        let recipients = vec![
+            &env,
+            RecipientWeight {
+                recipient: r1.clone(),
+                weight_bps: 5000,
+            },
+            RecipientWeight {
+                recipient: r2.clone(),
+                weight_bps: 3000,
+            },
+            RecipientWeight {
+                recipient: r3.clone(),
+                weight_bps: 2000,
+            },
+        ];
+        client.set_split_config(&stream, &recipients);
+
+        let preview = client.preview_shares(&stream, &101);
+        assert_eq!(preview.amount, 101);
+        assert_eq!(preview.distributed_total, 100);
+        assert_eq!(preview.remainder, 1);
+        assert_eq!(preview.shares.len(), 3);
+        assert_eq!(preview.shares.get(0).unwrap().recipient, r1.clone());
+        assert_eq!(preview.shares.get(0).unwrap().share_amount, 50);
+        assert_eq!(preview.shares.get(0).unwrap().remainder_numerator, 5000);
+        assert!(preview.shares.get(0).unwrap().rounded_down);
+        assert_eq!(preview.shares.get(1).unwrap().recipient, r2.clone());
+        assert_eq!(preview.shares.get(1).unwrap().share_amount, 30);
+        assert_eq!(preview.shares.get(1).unwrap().remainder_numerator, 3000);
+        assert!(preview.shares.get(1).unwrap().rounded_down);
+        assert_eq!(preview.shares.get(2).unwrap().recipient, r3.clone());
+        assert_eq!(preview.shares.get(2).unwrap().share_amount, 20);
+        assert_eq!(preview.shares.get(2).unwrap().remainder_numerator, 2000);
+        assert!(preview.shares.get(2).unwrap().rounded_down);
+
+        client.deposit_revenue(&depositor, &stream, &101);
+        client.distribute(&stream);
+
+        assert_eq!(tc.balance(&r1), 50);
+        assert_eq!(tc.balance(&r2), 30);
+        assert_eq!(tc.balance(&r3), 20);
+        assert_eq!(tc.balance(&contract_id), 1);
+
+        let snapshot = client.get_split_state(&stream);
+        assert_eq!(snapshot.pending_balance, 1);
+        assert_eq!(snapshot.accrued_total, 100);
+        assert_eq!(snapshot.accruals.get(0).unwrap().accrued_balance, 50);
+        assert_eq!(snapshot.accruals.get(1).unwrap().accrued_balance, 30);
+        assert_eq!(snapshot.accruals.get(2).unwrap().accrued_balance, 20);
+    }
+
+    #[test]
+    fn test_get_split_state_returns_deterministic_accrual_order() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let r3 = Address::generate(&env);
+        let depositor = Address::generate(&env);
+
+        let (token_id, sa, _) = setup_token(&env, &admin);
+        sa.mint(&depositor, &1000);
+
+        let contract_id = env.register(RevenueSplit, ());
+        let client = RevenueSplitClient::new(&env, &contract_id);
+        client.init(&admin, &token_id);
+
+        let stream = Symbol::new(&env, "ordered");
+        let recipients = vec![
+            &env,
+            RecipientWeight {
+                recipient: r2.clone(),
+                weight_bps: 2000,
+            },
+            RecipientWeight {
+                recipient: r1.clone(),
+                weight_bps: 5000,
+            },
+            RecipientWeight {
+                recipient: r3.clone(),
+                weight_bps: 3000,
+            },
+        ];
+        client.set_split_config(&stream, &recipients);
+
+        client.deposit_revenue(&depositor, &stream, &1000);
+        let pending_snapshot = client.get_split_state(&stream);
+        assert_eq!(pending_snapshot.pending_balance, 1000);
+        assert_eq!(pending_snapshot.accrued_total, 0);
+        assert_eq!(pending_snapshot.accruals.len(), 3);
+        assert_eq!(
+            pending_snapshot.accruals.get(0).unwrap().recipient,
+            r2.clone()
+        );
+        assert_eq!(
+            pending_snapshot.accruals.get(1).unwrap().recipient,
+            r1.clone()
+        );
+        assert_eq!(
+            pending_snapshot.accruals.get(2).unwrap().recipient,
+            r3.clone()
+        );
+        assert_eq!(pending_snapshot.accruals.get(0).unwrap().accrued_balance, 0);
+        assert_eq!(pending_snapshot.accruals.get(1).unwrap().accrued_balance, 0);
+        assert_eq!(pending_snapshot.accruals.get(2).unwrap().accrued_balance, 0);
+
+        client.distribute(&stream);
+
+        let settled_snapshot = client.get_split_state(&stream);
+        assert_eq!(settled_snapshot.pending_balance, 0);
+        assert_eq!(settled_snapshot.accrued_total, 1000);
+        assert_eq!(settled_snapshot.accruals.get(0).unwrap().recipient, r2);
+        assert_eq!(
+            settled_snapshot.accruals.get(0).unwrap().accrued_balance,
+            200
+        );
+        assert_eq!(settled_snapshot.accruals.get(1).unwrap().recipient, r1);
+        assert_eq!(
+            settled_snapshot.accruals.get(1).unwrap().accrued_balance,
+            500
+        );
+        assert_eq!(settled_snapshot.accruals.get(2).unwrap().recipient, r3);
+        assert_eq!(
+            settled_snapshot.accruals.get(2).unwrap().accrued_balance,
+            300
+        );
+    }
+
+    #[test]
+    fn test_rounding_remainder_carries_forward_across_distributions() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let r3 = Address::generate(&env);
+        let depositor = Address::generate(&env);
+
+        let (token_id, sa, tc) = setup_token(&env, &admin);
+        sa.mint(&depositor, &200);
+
+        let contract_id = env.register(RevenueSplit, ());
+        let client = RevenueSplitClient::new(&env, &contract_id);
+        client.init(&admin, &token_id);
+
+        let stream = Symbol::new(&env, "carry");
+        let recipients = vec![
+            &env,
+            RecipientWeight {
+                recipient: r1.clone(),
+                weight_bps: 5000,
+            },
+            RecipientWeight {
+                recipient: r2.clone(),
+                weight_bps: 3000,
+            },
+            RecipientWeight {
+                recipient: r3.clone(),
+                weight_bps: 2000,
+            },
+        ];
+        client.set_split_config(&stream, &recipients);
+
+        client.deposit_revenue(&depositor, &stream, &101);
+        client.distribute(&stream);
+
+        let after_first = client.get_split_state(&stream);
+        assert_eq!(after_first.pending_balance, 1);
+        assert_eq!(after_first.accruals.get(0).unwrap().accrued_balance, 50);
+        assert_eq!(after_first.accruals.get(1).unwrap().accrued_balance, 30);
+        assert_eq!(after_first.accruals.get(2).unwrap().accrued_balance, 20);
+
+        client.deposit_revenue(&depositor, &stream, &99);
+        client.distribute(&stream);
+
+        let after_second = client.get_split_state(&stream);
+        assert_eq!(after_second.pending_balance, 0);
+        assert_eq!(after_second.accrued_total, 200);
+        assert_eq!(after_second.accruals.get(0).unwrap().accrued_balance, 100);
+        assert_eq!(after_second.accruals.get(1).unwrap().accrued_balance, 60);
+        assert_eq!(after_second.accruals.get(2).unwrap().accrued_balance, 40);
+
+        assert_eq!(tc.balance(&r1), 100);
+        assert_eq!(tc.balance(&r2), 60);
+        assert_eq!(tc.balance(&r3), 40);
+        assert_eq!(tc.balance(&contract_id), 0);
     }
 }

--- a/docs/contracts/revenue-split.md
+++ b/docs/contracts/revenue-split.md
@@ -62,6 +62,82 @@ pub fn distribute(env: Env, stream_id: Symbol)
 | `env` | `Env` |
 | `stream_id` | `Symbol` |
 
+### `preview_shares`
+Preview how a prospective revenue amount would be split for a configured stream.
+This accessor is read-only and uses the exact same integer math and remainder
+handling as `distribute`.
+
+```rust
+pub fn preview_shares(env: Env, stream_id: Symbol, amount: i128) -> SharePreview
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `stream_id` | `Symbol` |
+| `amount` | `i128` |
+
+#### Return Type
+
+`SharePreview`
+
+The returned `SharePreview` contains:
+
+| Field | Type | Description |
+|------|------|-------------|
+| `stream_id` | `Symbol` | Requested stream identifier. |
+| `amount` | `i128` | Prospective amount being previewed. |
+| `distributed_total` | `i128` | Sum of all floored beneficiary share amounts. |
+| `remainder` | `i128` | Undistributed amount left after rounding down beneficiary shares. |
+| `shares` | `Vec<SharePreviewEntry>` | Per-beneficiary preview entries in configured order. |
+
+Each `SharePreviewEntry` includes:
+
+| Field | Type | Description |
+|------|------|-------------|
+| `recipient` | `Address` | Beneficiary address. |
+| `weight_bps` | `u32` | Configured basis-point weight. |
+| `share_amount` | `i128` | Amount this beneficiary would receive. |
+| `remainder_numerator` | `i128` | Raw post-division remainder from `amount * weight_bps % 10000`. |
+| `rounded_down` | `bool` | `true` when a fractional entitlement was truncated. |
+
+### `get_split_state`
+Read the current accrual snapshot for a configured stream.
+
+```rust
+pub fn get_split_state(env: Env, stream_id: Symbol) -> SplitAccrualSnapshot
+```
+
+#### Parameters
+
+| Name | Type |
+|------|------|
+| `env` | `Env` |
+| `stream_id` | `Symbol` |
+
+#### Return Type
+
+`SplitAccrualSnapshot`
+
+The returned snapshot contains:
+
+| Field | Type | Description |
+|------|------|-------------|
+| `stream_id` | `Symbol` | Requested stream identifier. |
+| `pending_balance` | `i128` | Undistributed balance still held for the stream, including carried rounding remainder. |
+| `accrued_total` | `i128` | Sum of all cumulative beneficiary accrual balances. |
+| `accruals` | `Vec<BeneficiaryAccrual>` | Beneficiary balances in configured order. |
+
+Each `BeneficiaryAccrual` includes:
+
+| Field | Type | Description |
+|------|------|-------------|
+| `recipient` | `Address` | Beneficiary address. |
+| `weight_bps` | `u32` | Configured basis-point weight. |
+| `accrued_balance` | `i128` | Cumulative amount already distributed to that beneficiary for the stream. |
+
 ### `recipient_balance`
 Query cumulative amount distributed to a recipient for a stream.
 
@@ -81,3 +157,10 @@ pub fn recipient_balance(env: Env, stream_id: Symbol, recipient: Address) -> i12
 
 `i128`
 
+## Rounding And Remainder Handling
+
+- Beneficiary share math uses integer division on `amount * weight_bps / 10000`.
+- When a beneficiary share is not evenly divisible, the fractional portion is truncated and reported through `rounded_down = true` plus the raw `remainder_numerator`.
+- Any aggregate remainder left after summing all beneficiary `share_amount` values is returned as `SharePreview.remainder`.
+- `distribute` keeps that aggregate remainder in `StreamBalance(stream_id)`, so it stays visible through `get_split_state.pending_balance` and can be released by later deposits instead of being lost.
+- Preview and snapshot outputs are deterministic because both follow the configured recipient vector order.


### PR DESCRIPTION
Implementation

Added preview_shares(stream_id, amount) to the revenue-split contract so callers can preview beneficiary allocations before settlement using the exact same math as distribute.
Added get_split_state(stream_id) to expose a deterministic accrual snapshot with current pending balance and cumulative beneficiary balances in configured order.
Refactored settlement math into a shared path so preview and distribution stay consistent.
Updated distribution behavior to retain rounding remainder in StreamBalance instead of dropping it, making remainder handling explicit and observable.
Tests

Added coverage to verify preview_shares matches actual distribution outcomes.
Added snapshot tests for get_split_state, including deterministic beneficiary ordering.
Added rounding tests across multiple beneficiaries to confirm truncated amounts are reported and carried forward correctly.
Re-ran targeted crate checks to ensure unaffected behavior remains stable.
Docs

Updated contracts/revenue-split/README.md with the new public methods and summary semantics.
Updated docs/contracts/revenue-split.md with method signatures, return shapes, and rounding/remainder behavior.
Documented that preview output mirrors settlement logic, snapshot ordering is deterministic, and rounding remainder is retained as pending balance.

closes #444 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `preview_shares` query to inspect prospective share distributions without executing transfers.
  * Added `get_split_state` query to retrieve current accrual snapshots and pending balances.
  * Distribution logic now preserves rounding remainders in pending balance across multiple distributions.

* **Documentation**
  * Expanded documentation for new query methods with deterministic ordering guarantees and rounding semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->