### PR TITLE
feat: add WidgetTransitionGuard for empty-to-populated dashboard animation

### DIFF
--- a/frontend/src/components/v1/WidgetTransitionGuard.css
+++ b/frontend/src/components/v1/WidgetTransitionGuard.css
@@ -1,0 +1,18 @@
+.widget-transition-guard {
+  position: relative;
+}
+
+@keyframes widget-populate-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.widget-transition--populate {
+  animation: widget-populate-in 280ms ease-out both;
+}

--- a/frontend/src/components/v1/WidgetTransitionGuard.tsx
+++ b/frontend/src/components/v1/WidgetTransitionGuard.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './WidgetTransitionGuard.css';
+
+export interface WidgetTransitionGuardProps {
+  populated: boolean;
+  children: React.ReactNode;
+  animationClass?: string;
+  testId?: string;
+}
+
+export const WidgetTransitionGuard: React.FC<WidgetTransitionGuardProps> = ({
+  populated,
+  children,
+  animationClass = 'widget-transition--populate',
+  testId = 'widget-transition-guard',
+}) => {
+  const [isAnimating, setIsAnimating] = useState(false);
+  const prevPopulatedRef = useRef<boolean>(populated);
+
+  useEffect(() => {
+    if (!prevPopulatedRef.current && populated) {
+      setIsAnimating(true);
+    }
+    prevPopulatedRef.current = populated;
+  }, [populated]);
+
+  const handleAnimationEnd = () => setIsAnimating(false);
+
+  const classes = ['widget-transition-guard', isAnimating ? animationClass : '']
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classes}
+      data-testid={testId}
+      data-populated={populated}
+      data-animating={isAnimating}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default WidgetTransitionGuard;

--- a/frontend/tests/components/v1/WidgetTransitionGuard.test.tsx
+++ b/frontend/tests/components/v1/WidgetTransitionGuard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WidgetTransitionGuard } from '@/components/v1/WidgetTransitionGuard';
+
+describe('WidgetTransitionGuard', () => {
+  it('renders children', () => {
+    render(
+      <WidgetTransitionGuard populated={false}>
+        <span>child content</span>
+      </WidgetTransitionGuard>
+    );
+    expect(screen.getByText('child content')).toBeTruthy();
+  });
+
+  it('does NOT add animation class on initial render when populated=true', () => {
+    render(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).not.toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('false');
+  });
+
+  it('adds animation class when transitioning from populated=false to populated=true', () => {
+    const { rerender } = render(
+      <WidgetTransitionGuard populated={false}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).not.toContain('widget-transition--populate');
+
+    rerender(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    expect(guard.className).toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('true');
+  });
+
+  it('clears animation class after animationEnd event fires', () => {
+    const { rerender } = render(
+      <WidgetTransitionGuard populated={false}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    rerender(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).toContain('widget-transition--populate');
+
+    fireEvent.animationEnd(guard);
+    expect(guard.className).not.toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('false');
+  });
+
+  it('does NOT animate when going from populated=true to populated=false', () => {
+    const { rerender } = render(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).not.toContain('widget-transition--populate');
+
+    rerender(
+      <WidgetTransitionGuard populated={false}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    expect(guard.className).not.toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('false');
+  });
+});


### PR DESCRIPTION
Closes #543

## What changed
- Added WidgetTransitionGuard component
- CSS fade+slide animation on empty→populated transition
- Ignores populated→empty transitions

## How to test
- Wrap a dashboard widget with WidgetTransitionGuard populated={false} then switch to true
- Animation plays once then stops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a widget transition guard component that provides smooth populate animations with opacity and slide-in effects (280ms duration, ease-out timing).

* **Tests**
  * Added comprehensive test coverage for the transition guard component behavior and animation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->