### PR TITLE
feat: add FilterPresetBar for saved filter presets on leaderboard and event views

### DIFF
--- a/frontend/src/components/v1/FilterPresetBar.css
+++ b/frontend/src/components/v1/FilterPresetBar.css
@@ -1,0 +1,75 @@
+.filter-preset-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filter-preset-bar__save-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.filter-preset-bar__input {
+  flex: 1;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.filter-preset-bar__save-btn {
+  padding: 0.375rem 0.75rem;
+  border: none;
+  border-radius: 4px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.filter-preset-bar__save-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.filter-preset-bar__empty {
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+.filter-preset-bar__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.filter-preset-bar__item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: #f3f4f6;
+  border-radius: 4px;
+  padding: 0.25rem 0.375rem;
+}
+
+.filter-preset-bar__apply-btn {
+  background: none;
+  border: none;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  color: #1d4ed8;
+}
+
+.filter-preset-bar__delete-btn {
+  background: none;
+  border: none;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: #6b7280;
+  line-height: 1;
+  padding: 0 0.125rem;
+}

--- a/frontend/src/components/v1/FilterPresetBar.tsx
+++ b/frontend/src/components/v1/FilterPresetBar.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './FilterPresetBar.css';
+
+export interface FilterPreset<T = Record<string, unknown>> {
+  id: string;
+  name: string;
+  filters: T;
+  savedAt: number;
+}
+
+export interface FilterPresetBarProps<T = Record<string, unknown>> {
+  scope: string;
+  currentFilters: T;
+  onApply: (preset: FilterPreset<T>) => void;
+  testId?: string;
+}
+
+function storageKey(scope: string) {
+  return `stellarcade.filter-presets.${scope}`;
+}
+
+function loadPresets<T>(scope: string): FilterPreset<T>[] {
+  try {
+    const raw = localStorage.getItem(storageKey(scope));
+    return raw ? (JSON.parse(raw) as FilterPreset<T>[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function savePresets<T>(scope: string, presets: FilterPreset<T>[]): void {
+  try {
+    localStorage.setItem(storageKey(scope), JSON.stringify(presets));
+  } catch {
+    // storage full — silently ignore
+  }
+}
+
+export function FilterPresetBar<T = Record<string, unknown>>({
+  scope,
+  currentFilters,
+  onApply,
+  testId = 'filter-preset-bar',
+}: FilterPresetBarProps<T>): React.ReactElement {
+  const [presets, setPresets] = useState<FilterPreset<T>[]>(() => loadPresets<T>(scope));
+  const [inputName, setInputName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setPresets(loadPresets<T>(scope));
+  }, [scope]);
+
+  const handleSave = useCallback(() => {
+    const name = inputName.trim();
+    if (!name) return;
+    const newPreset: FilterPreset<T> = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      name,
+      filters: currentFilters,
+      savedAt: Date.now(),
+    };
+    const updated = [...presets, newPreset];
+    setPresets(updated);
+    savePresets(scope, updated);
+    setInputName('');
+    inputRef.current?.focus();
+  }, [inputName, currentFilters, presets, scope]);
+
+  const handleDelete = useCallback((id: string) => {
+    const updated = presets.filter((p) => p.id !== id);
+    setPresets(updated);
+    savePresets(scope, updated);
+  }, [presets, scope]);
+
+  const handleApply = useCallback((preset: FilterPreset<T>) => {
+    onApply(preset);
+  }, [onApply]);
+
+  return (
+    <div className="filter-preset-bar" data-testid={testId} role="region" aria-label="Filter presets">
+      <div className="filter-preset-bar__save-row">
+        <input
+          ref={inputRef}
+          className="filter-preset-bar__input"
+          type="text"
+          placeholder="Preset name…"
+          value={inputName}
+          onChange={(e) => setInputName(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); }}
+          aria-label="New preset name"
+          data-testid={`${testId}-name-input`}
+        />
+        <button
+          type="button"
+          className="filter-preset-bar__save-btn"
+          onClick={handleSave}
+          disabled={!inputName.trim()}
+          data-testid={`${testId}-save-btn`}
+        >
+          Save preset
+        </button>
+      </div>
+
+      {presets.length === 0 ? (
+        <p className="filter-preset-bar__empty" data-testid={`${testId}-empty`}>
+          No saved presets yet.
+        </p>
+      ) : (
+        <ul className="filter-preset-bar__list" data-testid={`${testId}-list`}>
+          {presets.map((preset) => (
+            <li key={preset.id} className="filter-preset-bar__item" data-testid={`${testId}-item-${preset.id}`}>
+              <button
+                type="button"
+                className="filter-preset-bar__apply-btn"
+                onClick={() => handleApply(preset)}
+                data-testid={`${testId}-apply-${preset.id}`}
+              >
+                {preset.name}
+              </button>
+              <button
+                type="button"
+                className="filter-preset-bar__delete-btn"
+                onClick={() => handleDelete(preset.id)}
+                aria-label={`Delete preset ${preset.name}`}
+                data-testid={`${testId}-delete-${preset.id}`}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default FilterPresetBar;

--- a/frontend/tests/components/v1/FilterPresetBar.test.tsx
+++ b/frontend/tests/components/v1/FilterPresetBar.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterPresetBar } from '@/components/v1/FilterPresetBar';
+
+describe('FilterPresetBar', () => {
+  beforeEach(() => {
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+  });
+
+  it('shows empty state when no presets exist', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('filter-preset-bar-empty')).toBeTruthy();
+    expect(screen.getByText('No saved presets yet.')).toBeTruthy();
+  });
+
+  it('save button is disabled when input is empty', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    const saveBtn = screen.getByTestId('filter-preset-bar-save-btn');
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('saving a preset name adds it to the list', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{ status: 'active' }}
+        onApply={vi.fn()}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'My Preset' } });
+
+    const saveBtn = screen.getByTestId('filter-preset-bar-save-btn');
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(saveBtn);
+
+    expect(screen.getByTestId('filter-preset-bar-list')).toBeTruthy();
+    expect(screen.getByText('My Preset')).toBeTruthy();
+  });
+
+  it('applying a preset calls onApply with the correct preset', () => {
+    const onApply = vi.fn();
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{ status: 'active' }}
+        onApply={onApply}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'Active Filter' } });
+    fireEvent.click(screen.getByTestId('filter-preset-bar-save-btn'));
+
+    const list = screen.getByTestId('filter-preset-bar-list');
+    const applyBtn = list.querySelector('[data-testid^="filter-preset-bar-apply-"]') as HTMLElement;
+    fireEvent.click(applyBtn);
+
+    expect(onApply).toHaveBeenCalledOnce();
+    const calledWith = onApply.mock.calls[0][0];
+    expect(calledWith.name).toBe('Active Filter');
+    expect(calledWith.filters).toEqual({ status: 'active' });
+  });
+
+  it('deleting a preset removes it from the list', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'To Delete' } });
+    fireEvent.click(screen.getByTestId('filter-preset-bar-save-btn'));
+
+    expect(screen.getByText('To Delete')).toBeTruthy();
+
+    const list = screen.getByTestId('filter-preset-bar-list');
+    const deleteBtn = list.querySelector('[data-testid^="filter-preset-bar-delete-"]') as HTMLElement;
+    fireEvent.click(deleteBtn);
+
+    expect(screen.queryByText('To Delete')).toBeNull();
+    expect(screen.getByTestId('filter-preset-bar-empty')).toBeTruthy();
+  });
+
+  it('Enter key saves the preset', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'Enter Preset' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByTestId('filter-preset-bar-list')).toBeTruthy();
+    expect(screen.getByText('Enter Preset')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #556

## What changed
- Added FilterPresetBar component
- Saves/loads presets from localStorage by scope key
- Apply and delete preset actions

## How to test
- Type a name, click Save preset — it appears in the list
- Click a preset to apply it
- Click × to delete