### PR TITLE
feat: add AccountSwitcher with recent account memory

### DIFF
--- a/frontend/src/components/v1/AccountSwitcher.css
+++ b/frontend/src/components/v1/AccountSwitcher.css
@@ -1,0 +1,67 @@
+.account-switcher {
+  position: relative;
+  display: inline-block;
+}
+
+.account-switcher__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.account-switcher__address {
+  font-family: monospace;
+}
+
+.account-switcher__chevron {
+  font-size: 0.625rem;
+}
+
+.account-switcher__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 220px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  z-index: 200;
+  padding: 0.25rem 0;
+}
+
+.account-switcher__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.account-switcher__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: none;
+  font-family: monospace;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  color: #111827;
+}
+
+.account-switcher__item:hover {
+  background: #f9fafb;
+}
+
+.account-switcher__empty {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  color: #6b7280;
+  margin: 0;
+}

--- a/frontend/src/components/v1/AccountSwitcher.tsx
+++ b/frontend/src/components/v1/AccountSwitcher.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './AccountSwitcher.css';
+
+const STORAGE_KEY = 'stellarcade.recent-accounts';
+const MAX_RECENT = 5;
+
+function truncateAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function loadRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistRecent(accounts: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts));
+  } catch {}
+}
+
+export interface AccountSwitcherProps {
+  currentAddress: string | null;
+  onSwitch: (address: string) => void;
+  testId?: string;
+}
+
+export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
+  currentAddress,
+  onSwitch,
+  testId = 'account-switcher',
+}) => {
+  const [open, setOpen] = useState(false);
+  const [recentAccounts, setRecentAccounts] = useState<string[]>(loadRecent);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Add current address to recents whenever it changes
+  useEffect(() => {
+    if (!currentAddress) return;
+    setRecentAccounts((prev) => {
+      const filtered = prev.filter((a) => a !== currentAddress);
+      const updated = [currentAddress, ...filtered].slice(0, MAX_RECENT);
+      persistRecent(updated);
+      return updated;
+    });
+  }, [currentAddress]);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const handleSwitch = useCallback((address: string) => {
+    setOpen(false);
+    onSwitch(address);
+  }, [onSwitch]);
+
+  const otherAccounts = recentAccounts.filter((a) => a !== currentAddress);
+
+  return (
+    <div className="account-switcher" ref={menuRef} data-testid={testId}>
+      <button
+        type="button"
+        className="account-switcher__trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        data-testid={`${testId}-trigger`}
+      >
+        <span className="account-switcher__address">
+          {currentAddress ? truncateAddress(currentAddress) : 'No wallet connected'}
+        </span>
+        <span className="account-switcher__chevron" aria-hidden="true">
+          {open ? '▲' : '▼'}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          className="account-switcher__menu"
+          role="listbox"
+          aria-label="Recent accounts"
+          data-testid={`${testId}-menu`}
+        >
+          {otherAccounts.length === 0 ? (
+            <p className="account-switcher__empty" data-testid={`${testId}-empty`}>
+              No recent accounts.
+            </p>
+          ) : (
+            <ul className="account-switcher__list">
+              {otherAccounts.map((addr) => (
+                <li key={addr}>
+                  <button
+                    type="button"
+                    className="account-switcher__item"
+                    role="option"
+                    aria-selected={addr === currentAddress}
+                    onClick={() => handleSwitch(addr)}
+                    data-testid={`${testId}-item-${addr}`}
+                  >
+                    {truncateAddress(addr)}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AccountSwitcher;

--- a/frontend/tests/components/v1/AccountSwitcher.test.tsx
+++ b/frontend/tests/components/v1/AccountSwitcher.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AccountSwitcher } from '@/components/v1/AccountSwitcher';
+
+describe('AccountSwitcher', () => {
+  beforeEach(() => {
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+  });
+
+  it('shows "No wallet connected" when currentAddress is null', () => {
+    render(<AccountSwitcher currentAddress={null} onSwitch={vi.fn()} />);
+    expect(screen.getByText('No wallet connected')).toBeTruthy();
+  });
+
+  it('truncates long addresses in the trigger', () => {
+    const longAddress = '0xABCDEF1234567890ABCDEF';
+    render(<AccountSwitcher currentAddress={longAddress} onSwitch={vi.fn()} />);
+    const trigger = screen.getByTestId('account-switcher-trigger');
+    // Should show truncated form: first 6 chars + … + last 4 chars
+    expect(trigger.textContent).toContain('0xABCD');
+    expect(trigger.textContent).toContain('CDEF');
+    expect(trigger.textContent).not.toBe(longAddress);
+  });
+
+  it('opens menu on trigger click', () => {
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={vi.fn()} />
+    );
+    expect(screen.queryByTestId('account-switcher-menu')).toBeNull();
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+    expect(screen.getByTestId('account-switcher-menu')).toBeTruthy();
+  });
+
+  it('shows "No recent accounts" when no other accounts exist', () => {
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={vi.fn()} />
+    );
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+    expect(screen.getByTestId('account-switcher-empty')).toBeTruthy();
+    expect(screen.getByText('No recent accounts.')).toBeTruthy();
+  });
+
+  it('clicking a recent account calls onSwitch with full address and closes menu', () => {
+    const recentAddr = '0xAAAABBBBCCCCDDDD';
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(
+      JSON.stringify([recentAddr, '0x1234567890abcdef'])
+    );
+
+    const onSwitch = vi.fn();
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={onSwitch} />
+    );
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+
+    const itemBtn = screen.getByTestId(`account-switcher-item-${recentAddr}`);
+    fireEvent.click(itemBtn);
+
+    expect(onSwitch).toHaveBeenCalledWith(recentAddr);
+    expect(screen.queryByTestId('account-switcher-menu')).toBeNull();
+  });
+
+  it('closes menu on outside click', () => {
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={vi.fn()} />
+    );
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+    expect(screen.getByTestId('account-switcher-menu')).toBeTruthy();
+
+    // Simulate mousedown outside the component
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('account-switcher-menu')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #558

## What changed
- Added AccountSwitcher component
- Persists up to 5 recent accounts in localStorage
- Dropdown menu with recent account list

## How to test
- Connect a wallet — address appears in trigger
- Switch accounts — previous address appears in recent list