### PR TITLE
feat: add ContractComparePanel for side-by-side contract metric comparison

### DIFF
--- a/frontend/src/components/v1/ContractComparePanel.css
+++ b/frontend/src/components/v1/ContractComparePanel.css
@@ -1,0 +1,69 @@
+.compare-panel {
+  display: grid;
+  grid-template-columns: 1fr;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 0.875rem;
+}
+
+.compare-panel--empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+.compare-panel__header,
+.compare-panel__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.compare-panel__header {
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+  font-weight: 600;
+}
+
+.compare-panel__row {
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.compare-panel__row:last-child {
+  border-bottom: none;
+}
+
+.compare-panel__header-cell,
+.compare-panel__cell {
+  padding: 0.625rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.compare-panel__cell--label,
+.compare-panel__header-cell--label {
+  color: #6b7280;
+  font-size: 0.8125rem;
+}
+
+.compare-panel__badge {
+  font-size: 0.625rem;
+  padding: 0.125rem 0.25rem;
+  border-radius: 3px;
+  font-weight: 700;
+}
+
+.compare-panel__badge--winner {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.compare-panel__badge--loser {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.compare-panel__placeholder {
+  color: #d1d5db;
+}

--- a/frontend/src/components/v1/ContractComparePanel.tsx
+++ b/frontend/src/components/v1/ContractComparePanel.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import './ContractComparePanel.css';
+
+export interface ContractMetric {
+  label: string;
+  value: number | string;
+  unit?: string;
+}
+
+export interface ContractMetricSnapshot {
+  contractId: string;
+  label: string;
+  metrics: ContractMetric[];
+}
+
+export interface ContractComparePanelProps {
+  left: ContractMetricSnapshot | null;
+  right: ContractMetricSnapshot | null;
+  testId?: string;
+}
+
+type DiffDirection = 'left' | 'right' | 'equal' | 'na';
+
+function diffDirection(a: number | string, b: number | string): DiffDirection {
+  const na = Number(a);
+  const nb = Number(b);
+  if (!Number.isFinite(na) || !Number.isFinite(nb)) return 'na';
+  if (na > nb) return 'left';
+  if (nb > na) return 'right';
+  return 'equal';
+}
+
+function DiffBadge({ direction, side }: { direction: DiffDirection; side: 'left' | 'right' }) {
+  if (direction === 'na' || direction === 'equal') return null;
+  const isWinner = direction === side;
+  return (
+    <span
+      className={`compare-panel__badge compare-panel__badge--${isWinner ? 'winner' : 'loser'}`}
+      aria-label={isWinner ? 'higher' : 'lower'}
+    >
+      {isWinner ? '▲' : '▼'}
+    </span>
+  );
+}
+
+export const ContractComparePanel: React.FC<ContractComparePanelProps> = ({
+  left,
+  right,
+  testId = 'contract-compare-panel',
+}) => {
+  if (!left && !right) {
+    return (
+      <div className="compare-panel compare-panel--empty" data-testid={`${testId}-empty`}>
+        <p>Select two contracts to compare.</p>
+      </div>
+    );
+  }
+
+  const allLabels = Array.from(
+    new Set([
+      ...(left?.metrics.map((m) => m.label) ?? []),
+      ...(right?.metrics.map((m) => m.label) ?? []),
+    ])
+  );
+
+  return (
+    <div className="compare-panel" data-testid={testId}>
+      {/* Header row */}
+      <div className="compare-panel__header" data-testid={`${testId}-header`}>
+        <div className="compare-panel__header-cell compare-panel__header-cell--label" />
+        <div className="compare-panel__header-cell" data-testid={`${testId}-left-label`}>
+          {left ? left.label : <span className="compare-panel__placeholder">—</span>}
+        </div>
+        <div className="compare-panel__header-cell" data-testid={`${testId}-right-label`}>
+          {right ? right.label : <span className="compare-panel__placeholder">—</span>}
+        </div>
+      </div>
+
+      {/* Metric rows */}
+      {allLabels.map((label) => {
+        const leftMetric = left?.metrics.find((m) => m.label === label);
+        const rightMetric = right?.metrics.find((m) => m.label === label);
+        const dir = leftMetric && rightMetric
+          ? diffDirection(leftMetric.value, rightMetric.value)
+          : 'na';
+
+        return (
+          <div
+            key={label}
+            className="compare-panel__row"
+            data-testid={`${testId}-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
+          >
+            <div className="compare-panel__cell compare-panel__cell--label">{label}</div>
+            <div className="compare-panel__cell">
+              {leftMetric ? (
+                <>
+                  <span data-testid={`${testId}-left-value-${label.replace(/\s+/g, '-').toLowerCase()}`}>
+                    {leftMetric.value}{leftMetric.unit ? ` ${leftMetric.unit}` : ''}
+                  </span>
+                  <DiffBadge direction={dir} side="left" />
+                </>
+              ) : <span className="compare-panel__placeholder">—</span>}
+            </div>
+            <div className="compare-panel__cell">
+              {rightMetric ? (
+                <>
+                  <span data-testid={`${testId}-right-value-${label.replace(/\s+/g, '-').toLowerCase()}`}>
+                    {rightMetric.value}{rightMetric.unit ? ` ${rightMetric.unit}` : ''}
+                  </span>
+                  <DiffBadge direction={dir} side="right" />
+                </>
+              ) : <span className="compare-panel__placeholder">—</span>}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ContractComparePanel;

--- a/frontend/tests/components/v1/ContractComparePanel.test.tsx
+++ b/frontend/tests/components/v1/ContractComparePanel.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ContractComparePanel, ContractMetricSnapshot } from '@/components/v1/ContractComparePanel';
+
+const leftSnapshot: ContractMetricSnapshot = {
+  contractId: 'contract-a',
+  label: 'Contract A',
+  metrics: [
+    { label: 'Total Volume', value: 1000, unit: 'USDC' },
+    { label: 'Active Users', value: 50 },
+    { label: 'Fee Rate', value: 'dynamic' },
+  ],
+};
+
+const rightSnapshot: ContractMetricSnapshot = {
+  contractId: 'contract-b',
+  label: 'Contract B',
+  metrics: [
+    { label: 'Total Volume', value: 800, unit: 'USDC' },
+    { label: 'Active Users', value: 75 },
+    { label: 'Fee Rate', value: 'fixed' },
+  ],
+};
+
+describe('ContractComparePanel', () => {
+  it('shows empty state when both sides are null', () => {
+    render(<ContractComparePanel left={null} right={null} />);
+    expect(screen.getByTestId('contract-compare-panel-empty')).toBeTruthy();
+    expect(screen.getByText('Select two contracts to compare.')).toBeTruthy();
+  });
+
+  it('renders left and right contract labels in the header', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    expect(screen.getByTestId('contract-compare-panel-left-label').textContent).toBe('Contract A');
+    expect(screen.getByTestId('contract-compare-panel-right-label').textContent).toBe('Contract B');
+  });
+
+  it('renders metric rows with correct values', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    const leftVolume = screen.getByTestId('contract-compare-panel-left-value-total-volume');
+    expect(leftVolume.textContent).toBe('1000 USDC');
+
+    const rightVolume = screen.getByTestId('contract-compare-panel-right-value-total-volume');
+    expect(rightVolume.textContent).toBe('800 USDC');
+  });
+
+  it('shows winner badge (▲) for the higher numeric value', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    // Total Volume: left=1000 > right=800, so left is winner
+    const volumeRow = screen.getByTestId('contract-compare-panel-row-total-volume');
+    const badges = volumeRow.querySelectorAll('[aria-label="higher"]');
+    expect(badges.length).toBe(1);
+    expect(badges[0].textContent).toBe('▲');
+    // Winner badge should be on the left cell (first badge in row)
+    expect(badges[0].closest('.compare-panel__cell')).toBeTruthy();
+  });
+
+  it('shows loser badge (▼) for the lower numeric value', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    // Total Volume: right=800 < left=1000, so right is loser
+    const volumeRow = screen.getByTestId('contract-compare-panel-row-total-volume');
+    const loserBadges = volumeRow.querySelectorAll('[aria-label="lower"]');
+    expect(loserBadges.length).toBe(1);
+    expect(loserBadges[0].textContent).toBe('▼');
+  });
+
+  it('shows placeholder when one side is missing a metric', () => {
+    const leftWithExtra: ContractMetricSnapshot = {
+      ...leftSnapshot,
+      metrics: [
+        ...leftSnapshot.metrics,
+        { label: 'Unique Metric', value: 42 },
+      ],
+    };
+    render(<ContractComparePanel left={leftWithExtra} right={rightSnapshot} />);
+    const uniqueRow = screen.getByTestId('contract-compare-panel-row-unique-metric');
+    // Right side should show placeholder since it lacks this metric
+    const cells = uniqueRow.querySelectorAll('.compare-panel__cell');
+    const rightCell = cells[2];
+    expect(rightCell.querySelector('.compare-panel__placeholder')).toBeTruthy();
+  });
+
+  it('does not render diff badges for non-numeric values', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    // Fee Rate has non-numeric string values
+    const feeRow = screen.getByTestId('contract-compare-panel-row-fee-rate');
+    const badges = feeRow.querySelectorAll('.compare-panel__badge');
+    expect(badges.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #570

## What changed
- Added ContractComparePanel component
- Side-by-side layout with diff badges
- Handles missing metrics and non-numeric values

## How to test
- Pass two ContractMetricSnapshot objects as left/right props
- Numeric metrics show ▲/▼ diff indicators