### PR TITLE
feat: add widget transition animation, filter presets, account switcher, and compare mode

### DIFF
--- a/frontend/src/components/v1/AccountSwitcher.css
+++ b/frontend/src/components/v1/AccountSwitcher.css
@@ -1,0 +1,67 @@
+.account-switcher {
+  position: relative;
+  display: inline-block;
+}
+
+.account-switcher__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.account-switcher__address {
+  font-family: monospace;
+}
+
+.account-switcher__chevron {
+  font-size: 0.625rem;
+}
+
+.account-switcher__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 220px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  z-index: 200;
+  padding: 0.25rem 0;
+}
+
+.account-switcher__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.account-switcher__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: none;
+  font-family: monospace;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  color: #111827;
+}
+
+.account-switcher__item:hover {
+  background: #f9fafb;
+}
+
+.account-switcher__empty {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  color: #6b7280;
+  margin: 0;
+}

--- a/frontend/src/components/v1/AccountSwitcher.tsx
+++ b/frontend/src/components/v1/AccountSwitcher.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './AccountSwitcher.css';
+
+const STORAGE_KEY = 'stellarcade.recent-accounts';
+const MAX_RECENT = 5;
+
+function truncateAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function loadRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistRecent(accounts: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts));
+  } catch {}
+}
+
+export interface AccountSwitcherProps {
+  currentAddress: string | null;
+  onSwitch: (address: string) => void;
+  testId?: string;
+}
+
+export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
+  currentAddress,
+  onSwitch,
+  testId = 'account-switcher',
+}) => {
+  const [open, setOpen] = useState(false);
+  const [recentAccounts, setRecentAccounts] = useState<string[]>(loadRecent);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Add current address to recents whenever it changes
+  useEffect(() => {
+    if (!currentAddress) return;
+    setRecentAccounts((prev) => {
+      const filtered = prev.filter((a) => a !== currentAddress);
+      const updated = [currentAddress, ...filtered].slice(0, MAX_RECENT);
+      persistRecent(updated);
+      return updated;
+    });
+  }, [currentAddress]);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const handleSwitch = useCallback((address: string) => {
+    setOpen(false);
+    onSwitch(address);
+  }, [onSwitch]);
+
+  const otherAccounts = recentAccounts.filter((a) => a !== currentAddress);
+
+  return (
+    <div className="account-switcher" ref={menuRef} data-testid={testId}>
+      <button
+        type="button"
+        className="account-switcher__trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        data-testid={`${testId}-trigger`}
+      >
+        <span className="account-switcher__address">
+          {currentAddress ? truncateAddress(currentAddress) : 'No wallet connected'}
+        </span>
+        <span className="account-switcher__chevron" aria-hidden="true">
+          {open ? '▲' : '▼'}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          className="account-switcher__menu"
+          role="listbox"
+          aria-label="Recent accounts"
+          data-testid={`${testId}-menu`}
+        >
+          {otherAccounts.length === 0 ? (
+            <p className="account-switcher__empty" data-testid={`${testId}-empty`}>
+              No recent accounts.
+            </p>
+          ) : (
+            <ul className="account-switcher__list">
+              {otherAccounts.map((addr) => (
+                <li key={addr}>
+                  <button
+                    type="button"
+                    className="account-switcher__item"
+                    role="option"
+                    aria-selected={addr === currentAddress}
+                    onClick={() => handleSwitch(addr)}
+                    data-testid={`${testId}-item-${addr}`}
+                  >
+                    {truncateAddress(addr)}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AccountSwitcher;

--- a/frontend/src/components/v1/ContractComparePanel.css
+++ b/frontend/src/components/v1/ContractComparePanel.css
@@ -1,0 +1,69 @@
+.compare-panel {
+  display: grid;
+  grid-template-columns: 1fr;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 0.875rem;
+}
+
+.compare-panel--empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+.compare-panel__header,
+.compare-panel__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.compare-panel__header {
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+  font-weight: 600;
+}
+
+.compare-panel__row {
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.compare-panel__row:last-child {
+  border-bottom: none;
+}
+
+.compare-panel__header-cell,
+.compare-panel__cell {
+  padding: 0.625rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.compare-panel__cell--label,
+.compare-panel__header-cell--label {
+  color: #6b7280;
+  font-size: 0.8125rem;
+}
+
+.compare-panel__badge {
+  font-size: 0.625rem;
+  padding: 0.125rem 0.25rem;
+  border-radius: 3px;
+  font-weight: 700;
+}
+
+.compare-panel__badge--winner {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.compare-panel__badge--loser {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.compare-panel__placeholder {
+  color: #d1d5db;
+}

--- a/frontend/src/components/v1/ContractComparePanel.tsx
+++ b/frontend/src/components/v1/ContractComparePanel.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import './ContractComparePanel.css';
+
+export interface ContractMetric {
+  label: string;
+  value: number | string;
+  unit?: string;
+}
+
+export interface ContractMetricSnapshot {
+  contractId: string;
+  label: string;
+  metrics: ContractMetric[];
+}
+
+export interface ContractComparePanelProps {
+  left: ContractMetricSnapshot | null;
+  right: ContractMetricSnapshot | null;
+  testId?: string;
+}
+
+type DiffDirection = 'left' | 'right' | 'equal' | 'na';
+
+function diffDirection(a: number | string, b: number | string): DiffDirection {
+  const na = Number(a);
+  const nb = Number(b);
+  if (!Number.isFinite(na) || !Number.isFinite(nb)) return 'na';
+  if (na > nb) return 'left';
+  if (nb > na) return 'right';
+  return 'equal';
+}
+
+function DiffBadge({ direction, side }: { direction: DiffDirection; side: 'left' | 'right' }) {
+  if (direction === 'na' || direction === 'equal') return null;
+  const isWinner = direction === side;
+  return (
+    <span
+      className={`compare-panel__badge compare-panel__badge--${isWinner ? 'winner' : 'loser'}`}
+      aria-label={isWinner ? 'higher' : 'lower'}
+    >
+      {isWinner ? '▲' : '▼'}
+    </span>
+  );
+}
+
+export const ContractComparePanel: React.FC<ContractComparePanelProps> = ({
+  left,
+  right,
+  testId = 'contract-compare-panel',
+}) => {
+  if (!left && !right) {
+    return (
+      <div className="compare-panel compare-panel--empty" data-testid={`${testId}-empty`}>
+        <p>Select two contracts to compare.</p>
+      </div>
+    );
+  }
+
+  const allLabels = Array.from(
+    new Set([
+      ...(left?.metrics.map((m) => m.label) ?? []),
+      ...(right?.metrics.map((m) => m.label) ?? []),
+    ])
+  );
+
+  return (
+    <div className="compare-panel" data-testid={testId}>
+      {/* Header row */}
+      <div className="compare-panel__header" data-testid={`${testId}-header`}>
+        <div className="compare-panel__header-cell compare-panel__header-cell--label" />
+        <div className="compare-panel__header-cell" data-testid={`${testId}-left-label`}>
+          {left ? left.label : <span className="compare-panel__placeholder">—</span>}
+        </div>
+        <div className="compare-panel__header-cell" data-testid={`${testId}-right-label`}>
+          {right ? right.label : <span className="compare-panel__placeholder">—</span>}
+        </div>
+      </div>
+
+      {/* Metric rows */}
+      {allLabels.map((label) => {
+        const leftMetric = left?.metrics.find((m) => m.label === label);
+        const rightMetric = right?.metrics.find((m) => m.label === label);
+        const dir = leftMetric && rightMetric
+          ? diffDirection(leftMetric.value, rightMetric.value)
+          : 'na';
+
+        return (
+          <div
+            key={label}
+            className="compare-panel__row"
+            data-testid={`${testId}-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
+          >
+            <div className="compare-panel__cell compare-panel__cell--label">{label}</div>
+            <div className="compare-panel__cell">
+              {leftMetric ? (
+                <>
+                  <span data-testid={`${testId}-left-value-${label.replace(/\s+/g, '-').toLowerCase()}`}>
+                    {leftMetric.value}{leftMetric.unit ? ` ${leftMetric.unit}` : ''}
+                  </span>
+                  <DiffBadge direction={dir} side="left" />
+                </>
+              ) : <span className="compare-panel__placeholder">—</span>}
+            </div>
+            <div className="compare-panel__cell">
+              {rightMetric ? (
+                <>
+                  <span data-testid={`${testId}-right-value-${label.replace(/\s+/g, '-').toLowerCase()}`}>
+                    {rightMetric.value}{rightMetric.unit ? ` ${rightMetric.unit}` : ''}
+                  </span>
+                  <DiffBadge direction={dir} side="right" />
+                </>
+              ) : <span className="compare-panel__placeholder">—</span>}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ContractComparePanel;

--- a/frontend/src/components/v1/FilterPresetBar.css
+++ b/frontend/src/components/v1/FilterPresetBar.css
@@ -1,0 +1,75 @@
+.filter-preset-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filter-preset-bar__save-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.filter-preset-bar__input {
+  flex: 1;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.filter-preset-bar__save-btn {
+  padding: 0.375rem 0.75rem;
+  border: none;
+  border-radius: 4px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.filter-preset-bar__save-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.filter-preset-bar__empty {
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+.filter-preset-bar__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.filter-preset-bar__item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: #f3f4f6;
+  border-radius: 4px;
+  padding: 0.25rem 0.375rem;
+}
+
+.filter-preset-bar__apply-btn {
+  background: none;
+  border: none;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  color: #1d4ed8;
+}
+
+.filter-preset-bar__delete-btn {
+  background: none;
+  border: none;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: #6b7280;
+  line-height: 1;
+  padding: 0 0.125rem;
+}

--- a/frontend/src/components/v1/FilterPresetBar.tsx
+++ b/frontend/src/components/v1/FilterPresetBar.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './FilterPresetBar.css';
+
+export interface FilterPreset<T = Record<string, unknown>> {
+  id: string;
+  name: string;
+  filters: T;
+  savedAt: number;
+}
+
+export interface FilterPresetBarProps<T = Record<string, unknown>> {
+  scope: string;
+  currentFilters: T;
+  onApply: (preset: FilterPreset<T>) => void;
+  testId?: string;
+}
+
+function storageKey(scope: string) {
+  return `stellarcade.filter-presets.${scope}`;
+}
+
+function loadPresets<T>(scope: string): FilterPreset<T>[] {
+  try {
+    const raw = localStorage.getItem(storageKey(scope));
+    return raw ? (JSON.parse(raw) as FilterPreset<T>[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function savePresets<T>(scope: string, presets: FilterPreset<T>[]): void {
+  try {
+    localStorage.setItem(storageKey(scope), JSON.stringify(presets));
+  } catch {
+    // storage full — silently ignore
+  }
+}
+
+export function FilterPresetBar<T = Record<string, unknown>>({
+  scope,
+  currentFilters,
+  onApply,
+  testId = 'filter-preset-bar',
+}: FilterPresetBarProps<T>): React.ReactElement {
+  const [presets, setPresets] = useState<FilterPreset<T>[]>(() => loadPresets<T>(scope));
+  const [inputName, setInputName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setPresets(loadPresets<T>(scope));
+  }, [scope]);
+
+  const handleSave = useCallback(() => {
+    const name = inputName.trim();
+    if (!name) return;
+    const newPreset: FilterPreset<T> = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      name,
+      filters: currentFilters,
+      savedAt: Date.now(),
+    };
+    const updated = [...presets, newPreset];
+    setPresets(updated);
+    savePresets(scope, updated);
+    setInputName('');
+    inputRef.current?.focus();
+  }, [inputName, currentFilters, presets, scope]);
+
+  const handleDelete = useCallback((id: string) => {
+    const updated = presets.filter((p) => p.id !== id);
+    setPresets(updated);
+    savePresets(scope, updated);
+  }, [presets, scope]);
+
+  const handleApply = useCallback((preset: FilterPreset<T>) => {
+    onApply(preset);
+  }, [onApply]);
+
+  return (
+    <div className="filter-preset-bar" data-testid={testId} role="region" aria-label="Filter presets">
+      <div className="filter-preset-bar__save-row">
+        <input
+          ref={inputRef}
+          className="filter-preset-bar__input"
+          type="text"
+          placeholder="Preset name…"
+          value={inputName}
+          onChange={(e) => setInputName(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); }}
+          aria-label="New preset name"
+          data-testid={`${testId}-name-input`}
+        />
+        <button
+          type="button"
+          className="filter-preset-bar__save-btn"
+          onClick={handleSave}
+          disabled={!inputName.trim()}
+          data-testid={`${testId}-save-btn`}
+        >
+          Save preset
+        </button>
+      </div>
+
+      {presets.length === 0 ? (
+        <p className="filter-preset-bar__empty" data-testid={`${testId}-empty`}>
+          No saved presets yet.
+        </p>
+      ) : (
+        <ul className="filter-preset-bar__list" data-testid={`${testId}-list`}>
+          {presets.map((preset) => (
+            <li key={preset.id} className="filter-preset-bar__item" data-testid={`${testId}-item-${preset.id}`}>
+              <button
+                type="button"
+                className="filter-preset-bar__apply-btn"
+                onClick={() => handleApply(preset)}
+                data-testid={`${testId}-apply-${preset.id}`}
+              >
+                {preset.name}
+              </button>
+              <button
+                type="button"
+                className="filter-preset-bar__delete-btn"
+                onClick={() => handleDelete(preset.id)}
+                aria-label={`Delete preset ${preset.name}`}
+                data-testid={`${testId}-delete-${preset.id}`}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default FilterPresetBar;

--- a/frontend/src/components/v1/WidgetTransitionGuard.css
+++ b/frontend/src/components/v1/WidgetTransitionGuard.css
@@ -1,0 +1,18 @@
+.widget-transition-guard {
+  position: relative;
+}
+
+@keyframes widget-populate-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.widget-transition--populate {
+  animation: widget-populate-in 280ms ease-out both;
+}

--- a/frontend/src/components/v1/WidgetTransitionGuard.tsx
+++ b/frontend/src/components/v1/WidgetTransitionGuard.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './WidgetTransitionGuard.css';
+
+export interface WidgetTransitionGuardProps {
+  populated: boolean;
+  children: React.ReactNode;
+  animationClass?: string;
+  testId?: string;
+}
+
+export const WidgetTransitionGuard: React.FC<WidgetTransitionGuardProps> = ({
+  populated,
+  children,
+  animationClass = 'widget-transition--populate',
+  testId = 'widget-transition-guard',
+}) => {
+  const [isAnimating, setIsAnimating] = useState(false);
+  const prevPopulatedRef = useRef<boolean>(populated);
+
+  useEffect(() => {
+    if (!prevPopulatedRef.current && populated) {
+      setIsAnimating(true);
+    }
+    prevPopulatedRef.current = populated;
+  }, [populated]);
+
+  const handleAnimationEnd = () => setIsAnimating(false);
+
+  const classes = ['widget-transition-guard', isAnimating ? animationClass : '']
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classes}
+      data-testid={testId}
+      data-populated={populated}
+      data-animating={isAnimating}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default WidgetTransitionGuard;

--- a/frontend/tests/components/v1/AccountSwitcher.test.tsx
+++ b/frontend/tests/components/v1/AccountSwitcher.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AccountSwitcher } from '@/components/v1/AccountSwitcher';
+
+describe('AccountSwitcher', () => {
+  beforeEach(() => {
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+  });
+
+  it('shows "No wallet connected" when currentAddress is null', () => {
+    render(<AccountSwitcher currentAddress={null} onSwitch={vi.fn()} />);
+    expect(screen.getByText('No wallet connected')).toBeTruthy();
+  });
+
+  it('truncates long addresses in the trigger', () => {
+    const longAddress = '0xABCDEF1234567890ABCDEF';
+    render(<AccountSwitcher currentAddress={longAddress} onSwitch={vi.fn()} />);
+    const trigger = screen.getByTestId('account-switcher-trigger');
+    // Should show truncated form: first 6 chars + … + last 4 chars
+    expect(trigger.textContent).toContain('0xABCD');
+    expect(trigger.textContent).toContain('CDEF');
+    expect(trigger.textContent).not.toBe(longAddress);
+  });
+
+  it('opens menu on trigger click', () => {
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={vi.fn()} />
+    );
+    expect(screen.queryByTestId('account-switcher-menu')).toBeNull();
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+    expect(screen.getByTestId('account-switcher-menu')).toBeTruthy();
+  });
+
+  it('shows "No recent accounts" when no other accounts exist', () => {
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={vi.fn()} />
+    );
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+    expect(screen.getByTestId('account-switcher-empty')).toBeTruthy();
+    expect(screen.getByText('No recent accounts.')).toBeTruthy();
+  });
+
+  it('clicking a recent account calls onSwitch with full address and closes menu', () => {
+    const recentAddr = '0xAAAABBBBCCCCDDDD';
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(
+      JSON.stringify([recentAddr, '0x1234567890abcdef'])
+    );
+
+    const onSwitch = vi.fn();
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={onSwitch} />
+    );
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+
+    const itemBtn = screen.getByTestId(`account-switcher-item-${recentAddr}`);
+    fireEvent.click(itemBtn);
+
+    expect(onSwitch).toHaveBeenCalledWith(recentAddr);
+    expect(screen.queryByTestId('account-switcher-menu')).toBeNull();
+  });
+
+  it('closes menu on outside click', () => {
+    render(
+      <AccountSwitcher currentAddress="0x1234567890abcdef" onSwitch={vi.fn()} />
+    );
+    fireEvent.click(screen.getByTestId('account-switcher-trigger'));
+    expect(screen.getByTestId('account-switcher-menu')).toBeTruthy();
+
+    // Simulate mousedown outside the component
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('account-switcher-menu')).toBeNull();
+  });
+});

--- a/frontend/tests/components/v1/ContractComparePanel.test.tsx
+++ b/frontend/tests/components/v1/ContractComparePanel.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ContractComparePanel, ContractMetricSnapshot } from '@/components/v1/ContractComparePanel';
+
+const leftSnapshot: ContractMetricSnapshot = {
+  contractId: 'contract-a',
+  label: 'Contract A',
+  metrics: [
+    { label: 'Total Volume', value: 1000, unit: 'USDC' },
+    { label: 'Active Users', value: 50 },
+    { label: 'Fee Rate', value: 'dynamic' },
+  ],
+};
+
+const rightSnapshot: ContractMetricSnapshot = {
+  contractId: 'contract-b',
+  label: 'Contract B',
+  metrics: [
+    { label: 'Total Volume', value: 800, unit: 'USDC' },
+    { label: 'Active Users', value: 75 },
+    { label: 'Fee Rate', value: 'fixed' },
+  ],
+};
+
+describe('ContractComparePanel', () => {
+  it('shows empty state when both sides are null', () => {
+    render(<ContractComparePanel left={null} right={null} />);
+    expect(screen.getByTestId('contract-compare-panel-empty')).toBeTruthy();
+    expect(screen.getByText('Select two contracts to compare.')).toBeTruthy();
+  });
+
+  it('renders left and right contract labels in the header', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    expect(screen.getByTestId('contract-compare-panel-left-label').textContent).toBe('Contract A');
+    expect(screen.getByTestId('contract-compare-panel-right-label').textContent).toBe('Contract B');
+  });
+
+  it('renders metric rows with correct values', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    const leftVolume = screen.getByTestId('contract-compare-panel-left-value-total-volume');
+    expect(leftVolume.textContent).toBe('1000 USDC');
+
+    const rightVolume = screen.getByTestId('contract-compare-panel-right-value-total-volume');
+    expect(rightVolume.textContent).toBe('800 USDC');
+  });
+
+  it('shows winner badge (▲) for the higher numeric value', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    // Total Volume: left=1000 > right=800, so left is winner
+    const volumeRow = screen.getByTestId('contract-compare-panel-row-total-volume');
+    const badges = volumeRow.querySelectorAll('[aria-label="higher"]');
+    expect(badges.length).toBe(1);
+    expect(badges[0].textContent).toBe('▲');
+    // Winner badge should be on the left cell (first badge in row)
+    expect(badges[0].closest('.compare-panel__cell')).toBeTruthy();
+  });
+
+  it('shows loser badge (▼) for the lower numeric value', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    // Total Volume: right=800 < left=1000, so right is loser
+    const volumeRow = screen.getByTestId('contract-compare-panel-row-total-volume');
+    const loserBadges = volumeRow.querySelectorAll('[aria-label="lower"]');
+    expect(loserBadges.length).toBe(1);
+    expect(loserBadges[0].textContent).toBe('▼');
+  });
+
+  it('shows placeholder when one side is missing a metric', () => {
+    const leftWithExtra: ContractMetricSnapshot = {
+      ...leftSnapshot,
+      metrics: [
+        ...leftSnapshot.metrics,
+        { label: 'Unique Metric', value: 42 },
+      ],
+    };
+    render(<ContractComparePanel left={leftWithExtra} right={rightSnapshot} />);
+    const uniqueRow = screen.getByTestId('contract-compare-panel-row-unique-metric');
+    // Right side should show placeholder since it lacks this metric
+    const cells = uniqueRow.querySelectorAll('.compare-panel__cell');
+    const rightCell = cells[2];
+    expect(rightCell.querySelector('.compare-panel__placeholder')).toBeTruthy();
+  });
+
+  it('does not render diff badges for non-numeric values', () => {
+    render(<ContractComparePanel left={leftSnapshot} right={rightSnapshot} />);
+    // Fee Rate has non-numeric string values
+    const feeRow = screen.getByTestId('contract-compare-panel-row-fee-rate');
+    const badges = feeRow.querySelectorAll('.compare-panel__badge');
+    expect(badges.length).toBe(0);
+  });
+});

--- a/frontend/tests/components/v1/FilterPresetBar.test.tsx
+++ b/frontend/tests/components/v1/FilterPresetBar.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterPresetBar } from '@/components/v1/FilterPresetBar';
+
+describe('FilterPresetBar', () => {
+  beforeEach(() => {
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+  });
+
+  it('shows empty state when no presets exist', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('filter-preset-bar-empty')).toBeTruthy();
+    expect(screen.getByText('No saved presets yet.')).toBeTruthy();
+  });
+
+  it('save button is disabled when input is empty', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    const saveBtn = screen.getByTestId('filter-preset-bar-save-btn');
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('saving a preset name adds it to the list', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{ status: 'active' }}
+        onApply={vi.fn()}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'My Preset' } });
+
+    const saveBtn = screen.getByTestId('filter-preset-bar-save-btn');
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(saveBtn);
+
+    expect(screen.getByTestId('filter-preset-bar-list')).toBeTruthy();
+    expect(screen.getByText('My Preset')).toBeTruthy();
+  });
+
+  it('applying a preset calls onApply with the correct preset', () => {
+    const onApply = vi.fn();
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{ status: 'active' }}
+        onApply={onApply}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'Active Filter' } });
+    fireEvent.click(screen.getByTestId('filter-preset-bar-save-btn'));
+
+    const list = screen.getByTestId('filter-preset-bar-list');
+    const applyBtn = list.querySelector('[data-testid^="filter-preset-bar-apply-"]') as HTMLElement;
+    fireEvent.click(applyBtn);
+
+    expect(onApply).toHaveBeenCalledOnce();
+    const calledWith = onApply.mock.calls[0][0];
+    expect(calledWith.name).toBe('Active Filter');
+    expect(calledWith.filters).toEqual({ status: 'active' });
+  });
+
+  it('deleting a preset removes it from the list', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'To Delete' } });
+    fireEvent.click(screen.getByTestId('filter-preset-bar-save-btn'));
+
+    expect(screen.getByText('To Delete')).toBeTruthy();
+
+    const list = screen.getByTestId('filter-preset-bar-list');
+    const deleteBtn = list.querySelector('[data-testid^="filter-preset-bar-delete-"]') as HTMLElement;
+    fireEvent.click(deleteBtn);
+
+    expect(screen.queryByText('To Delete')).toBeNull();
+    expect(screen.getByTestId('filter-preset-bar-empty')).toBeTruthy();
+  });
+
+  it('Enter key saves the preset', () => {
+    render(
+      <FilterPresetBar
+        scope="test"
+        currentFilters={{}}
+        onApply={vi.fn()}
+      />
+    );
+    const input = screen.getByTestId('filter-preset-bar-name-input');
+    fireEvent.change(input, { target: { value: 'Enter Preset' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByTestId('filter-preset-bar-list')).toBeTruthy();
+    expect(screen.getByText('Enter Preset')).toBeTruthy();
+  });
+});

--- a/frontend/tests/components/v1/WidgetTransitionGuard.test.tsx
+++ b/frontend/tests/components/v1/WidgetTransitionGuard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WidgetTransitionGuard } from '@/components/v1/WidgetTransitionGuard';
+
+describe('WidgetTransitionGuard', () => {
+  it('renders children', () => {
+    render(
+      <WidgetTransitionGuard populated={false}>
+        <span>child content</span>
+      </WidgetTransitionGuard>
+    );
+    expect(screen.getByText('child content')).toBeTruthy();
+  });
+
+  it('does NOT add animation class on initial render when populated=true', () => {
+    render(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).not.toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('false');
+  });
+
+  it('adds animation class when transitioning from populated=false to populated=true', () => {
+    const { rerender } = render(
+      <WidgetTransitionGuard populated={false}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).not.toContain('widget-transition--populate');
+
+    rerender(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    expect(guard.className).toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('true');
+  });
+
+  it('clears animation class after animationEnd event fires', () => {
+    const { rerender } = render(
+      <WidgetTransitionGuard populated={false}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    rerender(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).toContain('widget-transition--populate');
+
+    fireEvent.animationEnd(guard);
+    expect(guard.className).not.toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('false');
+  });
+
+  it('does NOT animate when going from populated=true to populated=false', () => {
+    const { rerender } = render(
+      <WidgetTransitionGuard populated={true}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    const guard = screen.getByTestId('widget-transition-guard');
+    expect(guard.className).not.toContain('widget-transition--populate');
+
+    rerender(
+      <WidgetTransitionGuard populated={false}>
+        <span>content</span>
+      </WidgetTransitionGuard>
+    );
+    expect(guard.className).not.toContain('widget-transition--populate');
+    expect(guard.getAttribute('data-animating')).toBe('false');
+  });
+});


### PR DESCRIPTION
Closes #543
Closes #556
Closes #558
Closes #570

## What changed

- **#543** — `WidgetTransitionGuard`: wrapper component that detects empty→populated transitions and plays a CSS fade+slide animation once; ignores populated→empty
- **#556** — `FilterPresetBar`: save/apply/delete named filter presets persisted to localStorage by scope key; keyboard-accessible with Enter-to-save
- **#558** — `AccountSwitcher`: dropdown menu showing truncated current address with up to 5 recent accounts from localStorage; closes on outside click
- **#570** — `ContractComparePanel`: side-by-side 3-column grid comparing two contract metric snapshots with numeric diff badges (▲ winner / ▼ loser)

## How to test

- Wrap a dashboard widget with `<WidgetTransitionGuard populated={bool}>` and toggle it — animation fires on false→true only
- Render `<FilterPresetBar scope="leaderboard" currentFilters={...} onApply={fn}>` — save, apply, delete presets
- Render `<AccountSwitcher currentAddress="G..." onSwitch={fn}>` — open dropdown, click a recent account
- Render `<ContractComparePanel left={snapshot} right={snapshot}>` — metrics render side by side with diff indicators

## Tests

Each component ships with a dedicated test file covering the primary success path and edge/empty-state cases.