### PR TITLE
Add accessors for season-pass, lending-pool, quest-board, achievement…

### DIFF
--- a/contracts/achievements/Cargo.toml
+++ b/contracts/achievements/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-achievements"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/achievements/src/lib.rs
+++ b/contracts/achievements/src/lib.rs
@@ -1,0 +1,56 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+
+mod storage;
+mod types;
+
+use storage::*;
+use types::*;
+
+// Contract
+
+#[contract]
+pub struct AchievementsContract;
+
+#[contractimpl]
+impl AchievementsContract {
+    // Initialize
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        set_admin(&env, &admin);
+    }
+
+    // Accessor for category completion summary
+    pub fn get_category_completion_summary(env: Env, user: Address, category: String) -> CategoryCompletionSummary {
+        let achievements = get_achievements(&env, &user);
+        let category_achievements: Vec<Achievement> = achievements.iter().filter(|a| a.category == category).collect();
+        let unlocked = category_achievements.iter().filter(|a| a.unlocked).count() as u32;
+        let total = category_achievements.len();
+        let percentage = if total > 0 { (unlocked * 100) / total } else { 0 };
+        CategoryCompletionSummary {
+            category,
+            total_achievements: total,
+            unlocked_achievements: unlocked,
+            completion_percentage: percentage,
+        }
+    }
+
+    // Accessor for next-unlock
+    pub fn get_next_unlock(env: Env, user: Address) -> Option<NextUnlock> {
+        get_next_unlock(&env, &user)
+    }
+
+    // Write functions
+    pub fn add_achievement(env: Env, user: Address, achievement: Achievement) {
+        let mut achs = get_achievements(&env, &user);
+        achs.push_back(achievement);
+        set_achievements(&env, &user, &achs);
+    }
+
+    pub fn set_next_unlock(env: Env, user: Address, unlock: NextUnlock) {
+        set_next_unlock(&env, &user, &unlock);
+    }
+}

--- a/contracts/achievements/src/storage.rs
+++ b/contracts/achievements/src/storage.rs
@@ -1,0 +1,42 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
+
+use crate::types::*;
+
+// Storage keys
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Achievements(Address), // per user achievements
+    NextUnlock(Address),
+}
+
+// Storage functions
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_achievements(env: &Env, user: &Address) -> Vec<Achievement> {
+    env.storage().persistent().get(&DataKey::Achievements(user.clone())).unwrap_or(Vec::new(&env))
+}
+
+pub fn set_achievements(env: &Env, user: &Address, achievements: &Vec<Achievement>) {
+    env.storage().persistent().set(&DataKey::Achievements(user.clone()), achievements);
+    env.storage().persistent().bump(&DataKey::Achievements(user.clone()), 518400);
+}
+
+pub fn get_next_unlock(env: &Env, user: &Address) -> Option<NextUnlock> {
+    env.storage().persistent().get(&DataKey::NextUnlock(user.clone()))
+}
+
+pub fn set_next_unlock(env: &Env, user: &Address, unlock: &NextUnlock) {
+    env.storage().persistent().set(&DataKey::NextUnlock(user.clone()), unlock);
+    env.storage().persistent().bump(&DataKey::NextUnlock(user.clone()), 518400);
+}

--- a/contracts/achievements/src/test.rs
+++ b/contracts/achievements/src/test.rs
@@ -1,0 +1,50 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Env as _};
+use soroban_sdk::{vec, Address, Env, String};
+
+#[test]
+fn test_get_category_completion_summary() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, AchievementsContract);
+    let client = AchievementsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    let ach1 = Achievement {
+        id: 1,
+        category: String::from_str(&env, "combat"),
+        title: String::from_str(&env, "First Win"),
+        unlocked: true,
+    };
+    let ach2 = Achievement {
+        id: 2,
+        category: String::from_str(&env, "combat"),
+        title: String::from_str(&env, "Second Win"),
+        unlocked: false,
+    };
+    client.add_achievement(&user, &ach1);
+    client.add_achievement(&user, &ach2);
+
+    let summary = client.get_category_completion_summary(&user, &String::from_str(&env, "combat"));
+    assert_eq!(summary.total_achievements, 2);
+    assert_eq!(summary.unlocked_achievements, 1);
+    assert_eq!(summary.completion_percentage, 50);
+}
+
+#[test]
+fn test_get_next_unlock_none() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, AchievementsContract);
+    let client = AchievementsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    let unlock = client.get_next_unlock(&user);
+    assert!(unlock.is_none());
+}

--- a/contracts/achievements/src/types.rs
+++ b/contracts/achievements/src/types.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
+
+// Types for achievements contract
+
+#[contracttype]
+pub struct Achievement {
+    pub id: u32,
+    pub category: String,
+    pub title: String,
+    pub unlocked: bool,
+}
+
+#[contracttype]
+pub struct CategoryCompletionSummary {
+    pub category: String,
+    pub total_achievements: u32,
+    pub unlocked_achievements: u32,
+    pub completion_percentage: u32,
+}
+
+#[contracttype]
+pub struct NextUnlock {
+    pub user: Address,
+    pub next_achievement: Option<Achievement>,
+    pub progress: u32,
+}

--- a/contracts/lending-pool/Cargo.toml
+++ b/contracts/lending-pool/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-lending-pool"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/lending-pool/src/lib.rs
+++ b/contracts/lending-pool/src/lib.rs
@@ -1,0 +1,56 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+mod storage;
+mod types;
+
+use storage::*;
+use types::*;
+
+// Contract
+
+#[contract]
+pub struct LendingPoolContract;
+
+#[contractimpl]
+impl LendingPoolContract {
+    // Initialize
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        set_admin(&env, &admin);
+    }
+
+    // Accessor for utilization snapshot
+    pub fn get_utilization_snapshot(env: Env) -> UtilizationSnapshot {
+        let borrowed = get_total_borrowed(&env);
+        let supplied = get_total_supplied(&env);
+        let utilization_rate = if supplied > 0 {
+            ((borrowed as u64 * 10000) / supplied as u64) as u32
+        } else {
+            0
+        };
+        UtilizationSnapshot {
+            total_borrowed: borrowed,
+            total_supplied: supplied,
+            utilization_rate,
+        }
+    }
+
+    // Accessor for liquidation buffer
+    pub fn get_liquidation_buffer(env: Env, user: Address) -> Option<LiquidationBuffer> {
+        get_liquidation_buffer(&env, &user)
+    }
+
+    // Write functions
+    pub fn update_totals(env: Env, borrowed: i128, supplied: i128) {
+        set_total_borrowed(&env, borrowed);
+        set_total_supplied(&env, supplied);
+    }
+
+    pub fn set_liquidation_buffer(env: Env, user: Address, buffer: LiquidationBuffer) {
+        set_liquidation_buffer(&env, &user, &buffer);
+    }
+}

--- a/contracts/lending-pool/src/storage.rs
+++ b/contracts/lending-pool/src/storage.rs
@@ -1,0 +1,50 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::types::*;
+
+// Storage keys
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    TotalBorrowed,
+    TotalSupplied,
+    LiquidationBuffer(Address),
+}
+
+// Storage functions
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_total_borrowed(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::TotalBorrowed).unwrap_or(0)
+}
+
+pub fn set_total_borrowed(env: &Env, amount: i128) {
+    env.storage().instance().set(&DataKey::TotalBorrowed, &amount);
+}
+
+pub fn get_total_supplied(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::TotalSupplied).unwrap_or(0)
+}
+
+pub fn set_total_supplied(env: &Env, amount: i128) {
+    env.storage().instance().set(&DataKey::TotalSupplied, &amount);
+}
+
+pub fn get_liquidation_buffer(env: &Env, user: &Address) -> Option<LiquidationBuffer> {
+    env.storage().persistent().get(&DataKey::LiquidationBuffer(user.clone()))
+}
+
+pub fn set_liquidation_buffer(env: &Env, user: &Address, buffer: &LiquidationBuffer) {
+    env.storage().persistent().set(&DataKey::LiquidationBuffer(user.clone()), buffer);
+    env.storage().persistent().bump(&DataKey::LiquidationBuffer(user.clone()), 518400);
+}

--- a/contracts/lending-pool/src/test.rs
+++ b/contracts/lending-pool/src/test.rs
@@ -1,0 +1,36 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Env as _};
+use soroban_sdk::{Address, Env};
+
+#[test]
+fn test_get_utilization_snapshot() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, LendingPoolContract);
+    let client = LendingPoolContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.update_totals(&1000, &2000);
+
+    let snapshot = client.get_utilization_snapshot();
+    assert_eq!(snapshot.total_borrowed, 1000);
+    assert_eq!(snapshot.total_supplied, 2000);
+    assert_eq!(snapshot.utilization_rate, 5000); // 50%
+}
+
+#[test]
+fn test_get_liquidation_buffer_missing() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, LendingPoolContract);
+    let client = LendingPoolContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    let buffer = client.get_liquidation_buffer(&user);
+    assert!(buffer.is_none());
+}

--- a/contracts/lending-pool/src/types.rs
+++ b/contracts/lending-pool/src/types.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+// Types for lending-pool contract
+
+#[contracttype]
+pub struct UtilizationSnapshot {
+    pub total_borrowed: i128,
+    pub total_supplied: i128,
+    pub utilization_rate: u32, // in basis points
+}
+
+#[contracttype]
+pub struct LiquidationBuffer {
+    pub user: Address,
+    pub buffer_amount: i128,
+    pub is_safe: bool,
+}

--- a/contracts/quest-board/Cargo.toml
+++ b/contracts/quest-board/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-quest-board"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/quest-board/src/lib.rs
+++ b/contracts/quest-board/src/lib.rs
@@ -1,0 +1,59 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+mod storage;
+mod types;
+
+use storage::*;
+use types::*;
+
+// Contract
+
+#[contract]
+pub struct QuestBoardContract;
+
+#[contractimpl]
+impl QuestBoardContract {
+    // Initialize
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        set_admin(&env, &admin);
+    }
+
+    // Accessor for quest-availability summary
+    pub fn get_quest_availability_summary(env: Env) -> QuestAvailabilitySummary {
+        let quests = get_quests(&env);
+        let available_quests = quests.iter().filter(|q| q.available).count() as u32;
+        QuestAvailabilitySummary {
+            total_quests: quests.len(),
+            available_quests,
+            quests,
+        }
+    }
+
+    // Accessor for reward-budget
+    pub fn get_reward_budget(env: Env) -> RewardBudget {
+        let total = get_total_budget(&env);
+        let allocated = get_allocated_budget(&env);
+        RewardBudget {
+            total_budget: total,
+            allocated_budget: allocated,
+            remaining_budget: total - allocated,
+        }
+    }
+
+    // Write functions
+    pub fn add_quest(env: Env, quest: Quest) {
+        let mut quests = get_quests(&env);
+        quests.push_back(quest);
+        set_quests(&env, &quests);
+    }
+
+    pub fn set_budget(env: Env, total: i128, allocated: i128) {
+        set_total_budget(&env, total);
+        set_allocated_budget(&env, allocated);
+    }
+}

--- a/contracts/quest-board/src/storage.rs
+++ b/contracts/quest-board/src/storage.rs
@@ -1,0 +1,49 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+use crate::types::*;
+
+// Storage keys
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Quests,
+    TotalBudget,
+    AllocatedBudget,
+}
+
+// Storage functions
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_quests(env: &Env) -> Vec<Quest> {
+    env.storage().instance().get(&DataKey::Quests).unwrap_or(Vec::new(&env))
+}
+
+pub fn set_quests(env: &Env, quests: &Vec<Quest>) {
+    env.storage().instance().set(&DataKey::Quests, quests);
+}
+
+pub fn get_total_budget(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::TotalBudget).unwrap_or(0)
+}
+
+pub fn set_total_budget(env: &Env, budget: i128) {
+    env.storage().instance().set(&DataKey::TotalBudget, &budget);
+}
+
+pub fn get_allocated_budget(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::AllocatedBudget).unwrap_or(0)
+}
+
+pub fn set_allocated_budget(env: &Env, budget: i128) {
+    env.storage().instance().set(&DataKey::AllocatedBudget, &budget);
+}

--- a/contracts/quest-board/src/test.rs
+++ b/contracts/quest-board/src/test.rs
@@ -1,0 +1,44 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Env as _};
+use soroban_sdk::{vec, Address, Env, String};
+
+#[test]
+fn test_get_quest_availability_summary() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, QuestBoardContract);
+    let client = QuestBoardContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let quest = Quest {
+        id: 1,
+        title: String::from_str(&env, "Test Quest"),
+        reward: 100,
+        available: true,
+    };
+    client.add_quest(&quest);
+
+    let summary = client.get_quest_availability_summary();
+    assert_eq!(summary.total_quests, 1);
+    assert_eq!(summary.available_quests, 1);
+}
+
+#[test]
+fn test_get_reward_budget() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, QuestBoardContract);
+    let client = QuestBoardContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.set_budget(&1000, &500);
+
+    let budget = client.get_reward_budget();
+    assert_eq!(budget.total_budget, 1000);
+    assert_eq!(budget.allocated_budget, 500);
+    assert_eq!(budget.remaining_budget, 500);
+}

--- a/contracts/quest-board/src/types.rs
+++ b/contracts/quest-board/src/types.rs
@@ -1,0 +1,27 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
+
+// Types for quest-board contract
+
+#[contracttype]
+pub struct Quest {
+    pub id: u32,
+    pub title: String,
+    pub reward: i128,
+    pub available: bool,
+}
+
+#[contracttype]
+pub struct QuestAvailabilitySummary {
+    pub total_quests: u32,
+    pub available_quests: u32,
+    pub quests: Vec<Quest>,
+}
+
+#[contracttype]
+pub struct RewardBudget {
+    pub total_budget: i128,
+    pub allocated_budget: i128,
+    pub remaining_budget: i128,
+}

--- a/contracts/season-pass/Cargo.toml
+++ b/contracts/season-pass/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-season-pass"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/season-pass/src/lib.rs
+++ b/contracts/season-pass/src/lib.rs
@@ -1,0 +1,50 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+mod storage;
+mod types;
+
+use storage::*;
+use types::*;
+
+// Contract
+
+#[contract]
+pub struct SeasonPassContract;
+
+#[contractimpl]
+impl SeasonPassContract {
+    // Initialize the contract
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        set_admin(&env, &admin);
+    }
+
+    // Accessor for entitlement snapshot
+    pub fn get_entitlement_snapshot(env: Env, user: Address) -> EntitlementSnapshot {
+        let entitlements = get_entitlements(&env, &user);
+        EntitlementSnapshot {
+            entitlements,
+            total_entitlements: entitlements.len(),
+        }
+    }
+
+    // Accessor for tier progress
+    pub fn get_tier_progress(env: Env, user: Address) -> Option<TierProgress> {
+        get_tier_progress(&env, &user)
+    }
+
+    // Some write functions for completeness
+    pub fn add_entitlement(env: Env, user: Address, entitlement: Entitlement) {
+        let mut ents = get_entitlements(&env, &user);
+        ents.push_back(entitlement);
+        set_entitlements(&env, &user, &ents);
+    }
+
+    pub fn set_tier_progress(env: Env, user: Address, progress: TierProgress) {
+        set_tier_progress(&env, &user, &progress);
+    }
+}

--- a/contracts/season-pass/src/storage.rs
+++ b/contracts/season-pass/src/storage.rs
@@ -1,0 +1,42 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::types::*;
+
+// Storage keys
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Entitlements(Address), // per user entitlements
+    TierProgress(Address), // per user tier progress
+}
+
+// Storage functions
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_entitlements(env: &Env, user: &Address) -> Vec<Entitlement> {
+    env.storage().persistent().get(&DataKey::Entitlements(user.clone())).unwrap_or(Vec::new(&env))
+}
+
+pub fn set_entitlements(env: &Env, user: &Address, entitlements: &Vec<Entitlement>) {
+    env.storage().persistent().set(&DataKey::Entitlements(user.clone()), entitlements);
+    env.storage().persistent().bump(&DataKey::Entitlements(user.clone()), 518400);
+}
+
+pub fn get_tier_progress(env: &Env, user: &Address) -> Option<TierProgress> {
+    env.storage().persistent().get(&DataKey::TierProgress(user.clone()))
+}
+
+pub fn set_tier_progress(env: &Env, user: &Address, progress: &TierProgress) {
+    env.storage().persistent().set(&DataKey::TierProgress(user.clone()), progress);
+    env.storage().persistent().bump(&DataKey::TierProgress(user.clone()), 518400);
+}

--- a/contracts/season-pass/src/test.rs
+++ b/contracts/season-pass/src/test.rs
@@ -1,0 +1,41 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Env as _};
+use soroban_sdk::{vec, Address, Env, String};
+
+#[test]
+fn test_get_entitlement_snapshot() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, SeasonPassContract);
+    let client = SeasonPassContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    let ent = Entitlement {
+        user: user.clone(),
+        entitlement_type: String::from_str(&env, "bonus"),
+        amount: 100,
+    };
+    client.add_entitlement(&user, &ent);
+
+    let snapshot = client.get_entitlement_snapshot(&user);
+    assert_eq!(snapshot.total_entitlements, 1);
+    assert_eq!(snapshot.entitlements.len(), 1);
+}
+
+#[test]
+fn test_get_tier_progress_empty() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, SeasonPassContract);
+    let client = SeasonPassContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    let progress = client.get_tier_progress(&user);
+    assert!(progress.is_none());
+}

--- a/contracts/season-pass/src/types.rs
+++ b/contracts/season-pass/src/types.rs
@@ -1,0 +1,26 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
+
+// Types for season-pass contract
+
+#[contracttype]
+pub struct Entitlement {
+    pub user: Address,
+    pub entitlement_type: String,
+    pub amount: i128,
+}
+
+#[contracttype]
+pub struct EntitlementSnapshot {
+    pub entitlements: Vec<Entitlement>,
+    pub total_entitlements: u32,
+}
+
+#[contracttype]
+pub struct TierProgress {
+    pub user: Address,
+    pub current_tier: u32,
+    pub progress: u32,
+    pub next_tier_threshold: u32,
+}


### PR DESCRIPTION
This PR implements the required read-only accessors for the following issues:

- #511: Added `get_entitlement_snapshot` and `get_tier_progress` accessors to the season-pass contract
- #512: Added `get_utilization_snapshot` and `get_liquidation_buffer` accessors to the lending-pool contract  
- #513: Added `get_quest_availability_summary` and `get_reward_budget` accessors to the quest-board contract
- #514: Added `get_category_completion_summary` and `get_next_unlock` accessors to the achievements contract

Each accessor returns structured data suitable for frontend and backend consumption, with explicit handling of empty, missing, and pre-configuration states. The accessors reuse tracked storage aggregates where possible and follow the project's storage rules.

Unit tests are included for main happy paths and edge cases (empty/missing states).

Closes #511, 
Closes #512, 
Closes #513, 
Closes #514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Achievements system with category-based progress tracking and completion summaries
  * Added Lending Pool with utilization monitoring and liquidation buffer management
  * Added Quest Board for quest and reward budget management
  * Added Season Pass with tier progression and entitlement tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->