### PR TITLE
feat: add contract accessor snapshots

### DIFF
--- a/contracts/creator-royalties/src/lib.rs
+++ b/contracts/creator-royalties/src/lib.rs
@@ -3,7 +3,7 @@
 mod storage;
 mod types;
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Vec};
 
 pub use types::{
     AccrualRecord, AccrualSummary, PayoutSchedule, PayoutScheduleEntry, RoyaltyConfig,
@@ -210,7 +210,11 @@ impl CreatorRoyalties {
     // ── Read-only accessors ────────────────────────────────────────────────────
 
     /// Returns a full accrual summary for a creator.
-    /// Returns an empty/zero summary when the creator is not configured.
+    ///
+    /// Unknown or not-yet-configured creators return a zeroed summary with
+    /// `exists = false`. In that case `token` is a placeholder value copied
+    /// from the queried creator address, so consumers must branch on `exists`
+    /// before using token-specific fields.
     pub fn accrual_summary(env: Env, creator: Address) -> AccrualSummary {
         let config_opt = storage::get_config(&env, &creator);
         let accrual_opt = storage::get_accrual(&env, &creator);
@@ -250,7 +254,11 @@ impl CreatorRoyalties {
     }
 
     /// Returns the payout schedule for a creator.
-    /// Returns an empty schedule when none has been set up.
+    ///
+    /// Unknown or not-yet-configured creators return `exists = false`,
+    /// `interval_ledgers = 0`, and an empty `pending_entries` list. Configured
+    /// creators with no scheduled entries return `exists = true` and the same
+    /// zero-value schedule fields.
     pub fn payout_schedule(env: Env, creator: Address) -> PayoutSchedule {
         let config_opt = storage::get_config(&env, &creator);
         if config_opt.is_none() {

--- a/contracts/creator-royalties/src/test.rs
+++ b/contracts/creator-royalties/src/test.rs
@@ -123,8 +123,8 @@ fn test_claim_scheduled_moves_entries_to_paid() {
 
     client.configure(&creator, &500, &token);
     client.record_accrual(&creator, &1_000_000);
-    // claimable_at_ledger=1 is in the past relative to ledger sequence 0
-    client.schedule_payout(&creator, &1, &400_000);
+    // claimable_at_ledger=0 is immediately claimable at the default ledger sequence.
+    client.schedule_payout(&creator, &0, &400_000);
     client.schedule_payout(&creator, &999_999, &600_000); // future
 
     let claimed = client.claim_scheduled(&creator);

--- a/contracts/prize-pool/src/lib.rs
+++ b/contracts/prize-pool/src/lib.rs
@@ -39,15 +39,15 @@ pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    AlreadyInitialized      = 1,
-    NotInitialized          = 2,
-    NotAuthorized           = 3,
-    InvalidAmount           = 4,
-    InsufficientFunds       = 5,
-    GameAlreadyReserved     = 6,
-    ReservationNotFound     = 7,
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+    InvalidAmount = 4,
+    InsufficientFunds = 5,
+    GameAlreadyReserved = 6,
+    ReservationNotFound = 7,
     PayoutExceedsReservation = 8,
-    Overflow                = 9,
+    Overflow = 9,
 }
 
 // ---------------------------------------------------------------------------
@@ -122,6 +122,37 @@ pub struct PrizePoolConfigSnapshot {
     pub reserved_amount: i128,
     pub payouts_count: u64,
     pub last_update_ledger: u32,
+}
+
+/// Per-game reservation summary for frontend and backend payout views.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrizeAllocationSummary {
+    pub game_id: u64,
+    /// True when a reservation currently exists for the game.
+    pub exists: bool,
+    /// Original reserved amount; `0` when missing.
+    pub total_allocated: i128,
+    /// Amount already paid out or released from the reservation.
+    pub amount_distributed: i128,
+    /// Amount still reserved for future payouts or release.
+    pub remaining_amount: i128,
+    /// True when there is no remaining balance to claim against.
+    pub fully_distributed: bool,
+}
+
+/// Aggregate payout-demand snapshot derived from tracked pool totals.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimPressure {
+    pub available_balance: i128,
+    pub reserved_amount: i128,
+    /// `available + reserved`.
+    pub tracked_balance: i128,
+    /// `reserved / tracked_balance * 10_000`, rounded down.
+    /// Returns `0` when tracked balance is zero.
+    pub reserved_share_bps: u32,
+    pub payouts_count: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -255,12 +286,7 @@ impl PrizePool {
     /// Calling reserve with a `game_id` that already has a reservation returns
     /// `GameAlreadyReserved` — this is the idempotency guard preventing a
     /// buggy game contract from double-drawing from the pool.
-    pub fn reserve(
-        env: Env,
-        admin: Address,
-        game_id: u64,
-        amount: i128,
-    ) -> Result<(), Error> {
+    pub fn reserve(env: Env, admin: Address, game_id: u64, amount: i128) -> Result<(), Error> {
         require_initialized(&env)?;
         require_admin(&env, &admin)?;
 
@@ -286,11 +312,16 @@ impl PrizePool {
             .ok_or(Error::Overflow)?;
         set_persistent_i128(&env, DataKey::TotalReserved, new_total_reserved);
 
-        let reservation = ReservationData { total: amount, remaining: amount };
+        let reservation = ReservationData {
+            total: amount,
+            remaining: amount,
+        };
         env.storage().persistent().set(&res_key, &reservation);
-        env.storage()
-            .persistent()
-            .extend_ttl(&res_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
+        env.storage().persistent().extend_ttl(
+            &res_key,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
 
         update_markers(&env);
         Reserved { game_id, amount }.publish(&env);
@@ -308,12 +339,7 @@ impl PrizePool {
     /// payout remainder, or game cancelled). A partial release (`amount <
     /// remaining`) is valid. When `remaining` reaches zero the reservation
     /// entry is removed to avoid stale storage.
-    pub fn release(
-        env: Env,
-        admin: Address,
-        game_id: u64,
-        amount: i128,
-    ) -> Result<(), Error> {
+    pub fn release(env: Env, admin: Address, game_id: u64, amount: i128) -> Result<(), Error> {
         require_initialized(&env)?;
         require_admin(&env, &admin)?;
 
@@ -351,9 +377,11 @@ impl PrizePool {
             env.storage().persistent().remove(&res_key);
         } else {
             env.storage().persistent().set(&res_key, &reservation);
-            env.storage()
-                .persistent()
-                .extend_ttl(&res_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
+            env.storage().persistent().extend_ttl(
+                &res_key,
+                PERSISTENT_BUMP_LEDGERS,
+                PERSISTENT_BUMP_LEDGERS,
+            );
         }
 
         update_markers(&env);
@@ -416,9 +444,11 @@ impl PrizePool {
             env.storage().persistent().remove(&res_key);
         } else {
             env.storage().persistent().set(&res_key, &reservation);
-            env.storage()
-                .persistent()
-                .extend_ttl(&res_key, PERSISTENT_BUMP_LEDGERS, PERSISTENT_BUMP_LEDGERS);
+            env.storage().persistent().extend_ttl(
+                &res_key,
+                PERSISTENT_BUMP_LEDGERS,
+                PERSISTENT_BUMP_LEDGERS,
+            );
         }
 
         // Increment cumulative payout counter
@@ -429,7 +459,12 @@ impl PrizePool {
         let token = get_token(&env);
         TokenClient::new(&env, &token).transfer(&env.current_contract_address(), &to, &amount);
 
-        PaidOut { to, game_id, amount }.publish(&env);
+        PaidOut {
+            to,
+            game_id,
+            amount,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -451,7 +486,8 @@ impl PrizePool {
         require_admin(&env, &admin)?;
 
         let token = get_token(&env);
-        let actual_balance = TokenClient::new(&env, &token).balance(&env.current_contract_address());
+        let actual_balance =
+            TokenClient::new(&env, &token).balance(&env.current_contract_address());
 
         let available = get_available(&env);
         let reserved = get_total_reserved(&env);
@@ -459,9 +495,11 @@ impl PrizePool {
         // Invariant: available + reserved == actual_balance
         // Delta = actual_balance - (available + reserved)
         let tracked_total = available.checked_add(reserved).ok_or(Error::Overflow)?;
-        
+
         if actual_balance > tracked_total {
-            let delta = actual_balance.checked_sub(tracked_total).ok_or(Error::Overflow)?;
+            let delta = actual_balance
+                .checked_sub(tracked_total)
+                .ok_or(Error::Overflow)?;
             let new_available = available.checked_add(delta).ok_or(Error::Overflow)?;
 
             set_persistent_i128(&env, DataKey::Available, new_available);
@@ -471,11 +509,12 @@ impl PrizePool {
                 admin: admin.clone(),
                 amount: delta,
                 new_available,
-            }.publish(&env);
+            }
+            .publish(&env);
 
             Ok(delta)
         } else {
-            // No-op if balance is already in sync or somehow lower (which shouldn't happen 
+            // No-op if balance is already in sync or somehow lower (which shouldn't happen
             // unless tokens were burned/slashed externally, which we don't handle here).
             Ok(0)
         }
@@ -516,6 +555,69 @@ impl PrizePool {
             reserved_amount: get_total_reserved(&env),
             payouts_count: get_payouts_count(&env),
             last_update_ledger: get_last_update_ledger(&env),
+        })
+    }
+
+    /// Returns a per-game reservation snapshot.
+    ///
+    /// Missing game ids return a zeroed response with `exists = false`.
+    pub fn get_prize_allocation_summary(
+        env: Env,
+        game_id: u64,
+    ) -> Result<PrizeAllocationSummary, Error> {
+        require_initialized(&env)?;
+
+        let reservation = env
+            .storage()
+            .persistent()
+            .get::<_, ReservationData>(&DataKey::Reservation(game_id));
+
+        Ok(match reservation {
+            Some(reservation) => PrizeAllocationSummary {
+                game_id,
+                exists: true,
+                total_allocated: reservation.total,
+                amount_distributed: reservation.total.saturating_sub(reservation.remaining),
+                remaining_amount: reservation.remaining,
+                fully_distributed: reservation.remaining == 0,
+            },
+            None => PrizeAllocationSummary {
+                game_id,
+                exists: false,
+                total_allocated: 0,
+                amount_distributed: 0,
+                remaining_amount: 0,
+                fully_distributed: true,
+            },
+        })
+    }
+
+    /// Returns a contract-wide payout-demand summary.
+    ///
+    /// `reserved_share_bps` uses floor rounding and returns `0` when the pool
+    /// has no tracked balance, which gives consumers a stable zero-value
+    /// convention for empty or freshly initialized state.
+    pub fn get_claim_pressure(env: Env) -> Result<ClaimPressure, Error> {
+        require_initialized(&env)?;
+
+        let available_balance = get_available(&env);
+        let reserved_amount = get_total_reserved(&env);
+        let tracked_balance = available_balance
+            .checked_add(reserved_amount)
+            .ok_or(Error::Overflow)?;
+
+        let reserved_share_bps = if tracked_balance == 0 {
+            0
+        } else {
+            ((reserved_amount * 10_000) / tracked_balance) as u32
+        };
+
+        Ok(ClaimPressure {
+            available_balance,
+            reserved_amount,
+            tracked_balance,
+            reserved_share_bps,
+            payouts_count: get_payouts_count(&env),
         })
     }
 }

--- a/contracts/prize-pool/src/test.rs
+++ b/contracts/prize-pool/src/test.rs
@@ -2,8 +2,8 @@
 
 use super::*;
 use soroban_sdk::{
-    testutils::Ledger,
     testutils::Address as _,
+    testutils::Ledger,
     token::{StellarAssetClient, TokenClient},
     Address, Env,
 };
@@ -178,8 +178,8 @@ fn test_partial_release_leaves_reservation() {
     client.release(&admin, &1u64, &200i128); // return 200, leave 400 reserved
 
     let state = client.get_pool_state();
-    assert_eq!(state.available, 600);  // 400 original + 200 released
-    assert_eq!(state.reserved, 400);   // 600 - 200
+    assert_eq!(state.available, 600); // 400 original + 200 released
+    assert_eq!(state.reserved, 400); // 600 - 200
 }
 
 #[test]
@@ -394,7 +394,7 @@ fn test_metrics_uninitialized_rejected() {
 fn test_metrics_initial_state() {
     let env = Env::default();
     let (client, _, _, _) = setup(&env);
-    
+
     let metrics = client.get_prize_pool_metrics();
     assert_eq!(metrics.available_balance, 0);
     assert_eq!(metrics.reserved_amount, 0);
@@ -423,7 +423,7 @@ fn test_metrics_after_reserve_release_payout() {
     env.mock_all_auths();
 
     client.fund(&funder, &5_000i128);
-    
+
     // Reserve
     env.ledger().set_sequence_number(200);
     client.reserve(&admin, &1u64, &2_000i128);
@@ -492,4 +492,62 @@ fn test_config_snapshot_accuracy() {
     assert_eq!(snapshot.reserved_amount, 500);
     assert_eq!(snapshot.payouts_count, 0);
     assert_eq!(snapshot.last_update_ledger, 55);
+}
+
+#[test]
+fn test_prize_allocation_summary_happy_path() {
+    let env = Env::default();
+    let (client, admin, funder, _) = setup(&env);
+    env.mock_all_auths();
+
+    client.fund(&funder, &2_000i128);
+    client.reserve(&admin, &11u64, &1_200i128);
+    client.release(&admin, &11u64, &200i128);
+
+    let summary = client.get_prize_allocation_summary(&11u64);
+    assert!(summary.exists);
+    assert_eq!(summary.total_allocated, 1_200);
+    assert_eq!(summary.amount_distributed, 200);
+    assert_eq!(summary.remaining_amount, 1_000);
+    assert!(!summary.fully_distributed);
+}
+
+#[test]
+fn test_prize_allocation_summary_missing_game_is_predictable() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+
+    let summary = client.get_prize_allocation_summary(&404u64);
+    assert!(!summary.exists);
+    assert_eq!(summary.total_allocated, 0);
+    assert_eq!(summary.remaining_amount, 0);
+    assert!(summary.fully_distributed);
+}
+
+#[test]
+fn test_claim_pressure_empty_pool_returns_zero_ratio() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+
+    let pressure = client.get_claim_pressure();
+    assert_eq!(pressure.available_balance, 0);
+    assert_eq!(pressure.reserved_amount, 0);
+    assert_eq!(pressure.tracked_balance, 0);
+    assert_eq!(pressure.reserved_share_bps, 0);
+}
+
+#[test]
+fn test_claim_pressure_tracks_reserved_share() {
+    let env = Env::default();
+    let (client, admin, funder, _) = setup(&env);
+    env.mock_all_auths();
+
+    client.fund(&funder, &1_000i128);
+    client.reserve(&admin, &5u64, &250i128);
+
+    let pressure = client.get_claim_pressure();
+    assert_eq!(pressure.available_balance, 750);
+    assert_eq!(pressure.reserved_amount, 250);
+    assert_eq!(pressure.tracked_balance, 1_000);
+    assert_eq!(pressure.reserved_share_bps, 2_500);
 }

--- a/contracts/settlement-queue/src/lib.rs
+++ b/contracts/settlement-queue/src/lib.rs
@@ -67,6 +67,49 @@ pub struct QueueMetrics {
     pub oldest_pending: Option<Symbol>,
 }
 
+/// Stable queue-backed snapshot for a settlement read.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QueuedPayoutSnapshot {
+    pub settlement_id: Symbol,
+    /// True when the settlement exists in storage.
+    pub exists: bool,
+    /// Account that will receive the payout when known.
+    pub account: Option<Address>,
+    /// Settlement amount or `0` when unknown.
+    pub amount: i128,
+    /// Settlement reason when known.
+    pub reason: Option<Symbol>,
+    /// Current stored status.
+    pub status: SettlementStatus,
+    /// Failure code, if any.
+    pub error_code: Option<u32>,
+    /// Queue index of the first still-referenced item for this settlement.
+    pub queue_index: Option<u64>,
+    /// Queue position relative to the current head, when still queued.
+    pub queue_position: Option<u64>,
+    /// True when the settlement still appears in the queue window.
+    pub in_queue: bool,
+    /// Current queue depth to help consumers size backlog pressure.
+    pub queue_depth: u64,
+}
+
+/// Read-only readiness snapshot for an off-chain signer or operator.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SignerReadiness {
+    /// True when admin and downstream contract addresses are configured.
+    pub initialized: bool,
+    /// True when the queried signer matches the configured admin.
+    pub signer_matches_admin: bool,
+    pub reward_contract_configured: bool,
+    pub treasury_contract_configured: bool,
+    /// True when the signer matches admin and the contract is initialized.
+    pub can_administer_queue: bool,
+    /// Pending queue depth at the time of the read.
+    pub queue_depth: u64,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -477,6 +520,98 @@ impl SettlementQueue {
         QueueMetrics {
             depth: Self::queue_depth(env.clone()),
             oldest_pending: Self::oldest_pending_settlement(env),
+        }
+    }
+
+    /// Returns a queue-backed snapshot for one settlement id.
+    ///
+    /// Missing settlements return a predictable empty struct with
+    /// `exists = false` and zero-value numeric fields.
+    pub fn queued_payout_snapshot(env: Env, settlement_id: Symbol) -> QueuedPayoutSnapshot {
+        let queue_depth = Self::queue_depth(env.clone());
+        let head: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::QueueHead)
+            .unwrap_or(0);
+        let tail: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::QueueTail)
+            .unwrap_or(0);
+
+        let mut queue_index: Option<u64> = None;
+        for index in head..tail {
+            let item_key = DataKey::QueueItem(index);
+            if let Some(queued_id) = env.storage().persistent().get::<_, Symbol>(&item_key) {
+                if queued_id == settlement_id {
+                    queue_index = Some(index);
+                    break;
+                }
+            }
+        }
+
+        match env
+            .storage()
+            .persistent()
+            .get::<_, SettlementData>(&DataKey::Settlement(settlement_id.clone()))
+        {
+            Some(settlement) => QueuedPayoutSnapshot {
+                settlement_id,
+                exists: true,
+                account: Some(settlement.account),
+                amount: settlement.amount,
+                reason: Some(settlement.reason),
+                status: settlement.status,
+                error_code: settlement.error_code,
+                queue_position: queue_index.map(|index| index.saturating_sub(head)),
+                queue_index,
+                in_queue: queue_index.is_some(),
+                queue_depth,
+            },
+            None => QueuedPayoutSnapshot {
+                settlement_id,
+                exists: false,
+                account: None,
+                amount: 0,
+                reason: None,
+                status: SettlementStatus::Failed,
+                error_code: None,
+                queue_index: None,
+                queue_position: None,
+                in_queue: false,
+                queue_depth,
+            },
+        }
+    }
+
+    /// Returns whether the provided signer is ready to administer the queue.
+    ///
+    /// Pre-configuration reads return all readiness flags as `false` so
+    /// callers can distinguish uninitialized state without trapping.
+    pub fn signer_readiness(env: Env, signer: Address) -> SignerReadiness {
+        let admin: Option<Address> = env.storage().instance().get(&DataKey::Admin);
+        let reward: Option<Address> = env.storage().instance().get(&DataKey::RewardContract);
+        let treasury: Option<Address> = env.storage().instance().get(&DataKey::TreasuryContract);
+
+        let initialized = admin.is_some() && reward.is_some() && treasury.is_some();
+        let signer_matches_admin = admin
+            .as_ref()
+            .map(|stored| stored == &signer)
+            .unwrap_or(false);
+        let queue_depth = if initialized {
+            Self::queue_depth(env)
+        } else {
+            0
+        };
+
+        SignerReadiness {
+            initialized,
+            signer_matches_admin,
+            reward_contract_configured: reward.is_some(),
+            treasury_contract_configured: treasury.is_some(),
+            can_administer_queue: initialized && signer_matches_admin,
+            queue_depth,
         }
     }
 

--- a/contracts/settlement-queue/src/test.rs
+++ b/contracts/settlement-queue/src/test.rs
@@ -273,3 +273,59 @@ fn test_queue_metrics_after_head_advances() {
     assert_eq!(metrics.depth, 2);
     assert_eq!(metrics.oldest_pending, Some(second));
 }
+
+#[test]
+fn test_queued_payout_snapshot_happy_path() {
+    let s = setup();
+    let user = Address::generate(&s.env);
+    let settlement_id = symbol_short!("qs1");
+
+    s.client
+        .enqueue_settlement(&settlement_id, &user, &250, &symbol_short!("rank"));
+
+    let snapshot = s.client.queued_payout_snapshot(&settlement_id);
+    assert!(snapshot.exists);
+    assert_eq!(snapshot.account, Some(user));
+    assert_eq!(snapshot.amount, 250);
+    assert_eq!(snapshot.queue_index, Some(0));
+    assert_eq!(snapshot.queue_position, Some(0));
+    assert!(snapshot.in_queue);
+    assert_eq!(snapshot.queue_depth, 1);
+}
+
+#[test]
+fn test_queued_payout_snapshot_missing_is_predictable() {
+    let s = setup();
+    let snapshot = s.client.queued_payout_snapshot(&symbol_short!("miss"));
+
+    assert!(!snapshot.exists);
+    assert_eq!(snapshot.amount, 0);
+    assert_eq!(snapshot.queue_index, None);
+    assert!(!snapshot.in_queue);
+}
+
+#[test]
+fn test_signer_readiness_happy_path() {
+    let s = setup();
+
+    let readiness = s.client.signer_readiness(&s.admin);
+    assert!(readiness.initialized);
+    assert!(readiness.signer_matches_admin);
+    assert!(readiness.reward_contract_configured);
+    assert!(readiness.treasury_contract_configured);
+    assert!(readiness.can_administer_queue);
+}
+
+#[test]
+fn test_signer_readiness_preconfiguration() {
+    let env = Env::default();
+    let contract_id = env.register(SettlementQueue, ());
+    let client = SettlementQueueClient::new(&env, &contract_id);
+    let signer = Address::generate(&env);
+
+    let readiness = client.signer_readiness(&signer);
+    assert!(!readiness.initialized);
+    assert!(!readiness.signer_matches_admin);
+    assert!(!readiness.can_administer_queue);
+    assert_eq!(readiness.queue_depth, 0);
+}

--- a/contracts/ticket-market/src/lib.rs
+++ b/contracts/ticket-market/src/lib.rs
@@ -3,9 +3,12 @@
 mod storage;
 mod types;
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
 
-pub use types::{Listing, ListingExpiry, ListingStatus, OrderbookSummary};
+pub use types::{
+    Listing, ListingDepthSummary, ListingExpiry, ListingStatus, OrderbookSummary,
+    PurchaseEligibility, PurchaseEligibilityReason,
+};
 
 const BUMP_AMOUNT: u32 = 518_400;
 const LIFETIME_THRESHOLD: u32 = BUMP_AMOUNT / 2;
@@ -88,8 +91,7 @@ impl TicketMarket {
     /// Cancel a listing (seller only).
     pub fn cancel_listing(env: Env, seller: Address, listing_id: u64) -> Result<(), Error> {
         seller.require_auth();
-        let mut listing =
-            storage::get_listing(&env, listing_id).ok_or(Error::ListingNotFound)?;
+        let mut listing = storage::get_listing(&env, listing_id).ok_or(Error::ListingNotFound)?;
         if listing.seller != seller {
             return Err(Error::CannotCancelOthersListing);
         }
@@ -111,8 +113,7 @@ impl TicketMarket {
             .ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
-        let mut listing =
-            storage::get_listing(&env, listing_id).ok_or(Error::ListingNotFound)?;
+        let mut listing = storage::get_listing(&env, listing_id).ok_or(Error::ListingNotFound)?;
         if listing.status != ListingStatus::Active {
             return Err(Error::ListingNotActive);
         }
@@ -188,6 +189,105 @@ impl TicketMarket {
                 current_ledger,
                 is_expired: false,
                 status: ListingStatus::Cancelled,
+            },
+        }
+    }
+
+    /// Returns active listing depth for one game identifier.
+    ///
+    /// Empty depth is represented with zero counts and prices so consumers do
+    /// not need to special-case missing state.
+    pub fn listing_depth_summary(env: Env, game_id: Symbol) -> ListingDepthSummary {
+        let current_ledger = env.ledger().sequence();
+        let ids = storage::get_active_ids(&env);
+
+        let mut active_count: u64 = 0;
+        let mut best_ask: i128 = i128::MAX;
+        let mut worst_ask: i128 = 0;
+        let mut total_volume: i128 = 0;
+
+        for id in ids.iter() {
+            if let Some(listing) = storage::get_listing(&env, id) {
+                if listing.game_id == game_id
+                    && listing.status == ListingStatus::Active
+                    && listing.expires_at_ledger > current_ledger
+                {
+                    active_count = active_count.saturating_add(1);
+                    if listing.price < best_ask {
+                        best_ask = listing.price;
+                    }
+                    if listing.price > worst_ask {
+                        worst_ask = listing.price;
+                    }
+                    total_volume = total_volume.saturating_add(listing.price);
+                }
+            }
+        }
+
+        if active_count == 0 {
+            best_ask = 0;
+        }
+
+        ListingDepthSummary {
+            game_id,
+            active_count,
+            best_ask,
+            worst_ask,
+            total_volume,
+            current_ledger,
+        }
+    }
+
+    /// Returns whether a buyer can purchase a listing under the current
+    /// storage-backed status and expiry rules.
+    ///
+    /// Unknown listings return `exists = false`, `can_purchase = false`, and a
+    /// `ListingMissing` reason. Expired listings remain readable and report
+    /// `ListingExpired` without mutating their stored status.
+    pub fn purchase_eligibility(env: Env, listing_id: u64, buyer: Address) -> PurchaseEligibility {
+        let current_ledger = env.ledger().sequence();
+        match storage::get_listing(&env, listing_id) {
+            Some(listing) => {
+                let seller_is_buyer = listing.seller == buyer;
+                let is_expired = listing.expires_at_ledger <= current_ledger;
+                let status = listing.status.clone();
+
+                let reason = if seller_is_buyer {
+                    PurchaseEligibilityReason::SellerCannotPurchaseOwnListing
+                } else if status != ListingStatus::Active {
+                    PurchaseEligibilityReason::ListingNotActive
+                } else if is_expired {
+                    PurchaseEligibilityReason::ListingExpired
+                } else {
+                    PurchaseEligibilityReason::Eligible
+                };
+
+                PurchaseEligibility {
+                    listing_id,
+                    exists: true,
+                    status,
+                    game_id: Some(listing.game_id),
+                    seller: Some(listing.seller),
+                    price: listing.price,
+                    current_ledger,
+                    is_expired,
+                    seller_is_buyer,
+                    can_purchase: reason == PurchaseEligibilityReason::Eligible,
+                    reason,
+                }
+            }
+            None => PurchaseEligibility {
+                listing_id,
+                exists: false,
+                status: ListingStatus::Cancelled,
+                game_id: None,
+                seller: None,
+                price: 0,
+                current_ledger,
+                is_expired: false,
+                seller_is_buyer: false,
+                can_purchase: false,
+                reason: PurchaseEligibilityReason::ListingMissing,
             },
         }
     }

--- a/contracts/ticket-market/src/test.rs
+++ b/contracts/ticket-market/src/test.rs
@@ -15,6 +15,10 @@ fn game_id(env: &Env) -> Symbol {
     Symbol::new(env, "FLIP")
 }
 
+fn other_game_id(env: &Env) -> Symbol {
+    Symbol::new(env, "RACE")
+}
+
 // ── orderbook_summary ─────────────────────────────────────────────────────────
 
 #[test]
@@ -102,6 +106,91 @@ fn test_listing_expiry_sold_listing() {
     let expiry = client.listing_expiry(&id);
     assert!(expiry.exists);
     assert_eq!(expiry.status, ListingStatus::Sold);
+}
+
+// —— listing_depth_summary ——————————————————————————————————————————————————————————————
+
+#[test]
+fn test_listing_depth_summary_filters_by_game() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, seller) = setup(&env);
+
+    client.list_ticket(&seller, &game_id(&env), &500, &200);
+    client.list_ticket(&seller, &game_id(&env), &1_500, &200);
+    client.list_ticket(&seller, &other_game_id(&env), &5_000, &200);
+
+    let summary = client.listing_depth_summary(&game_id(&env));
+    assert_eq!(summary.active_count, 2);
+    assert_eq!(summary.best_ask, 500);
+    assert_eq!(summary.worst_ask, 1_500);
+    assert_eq!(summary.total_volume, 2_000);
+}
+
+#[test]
+fn test_listing_depth_summary_empty_game_returns_zeroes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, _seller) = setup(&env);
+
+    let summary = client.listing_depth_summary(&game_id(&env));
+    assert_eq!(summary.active_count, 0);
+    assert_eq!(summary.best_ask, 0);
+    assert_eq!(summary.worst_ask, 0);
+    assert_eq!(summary.total_volume, 0);
+}
+
+// —— purchase_eligibility ———————————————————————————————————————————————————————————————
+
+#[test]
+fn test_purchase_eligibility_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, seller) = setup(&env);
+    let buyer = Address::generate(&env);
+
+    let id = client.list_ticket(&seller, &game_id(&env), &750, &500);
+    let eligibility = client.purchase_eligibility(&id, &buyer);
+
+    assert!(eligibility.exists);
+    assert!(eligibility.can_purchase);
+    assert_eq!(eligibility.reason, PurchaseEligibilityReason::Eligible);
+    assert_eq!(eligibility.price, 750);
+}
+
+#[test]
+fn test_purchase_eligibility_rejects_seller_buyback() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, seller) = setup(&env);
+
+    let id = client.list_ticket(&seller, &game_id(&env), &750, &500);
+    let eligibility = client.purchase_eligibility(&id, &seller);
+
+    assert!(eligibility.exists);
+    assert!(!eligibility.can_purchase);
+    assert!(eligibility.seller_is_buyer);
+    assert_eq!(
+        eligibility.reason,
+        PurchaseEligibilityReason::SellerCannotPurchaseOwnListing
+    );
+}
+
+#[test]
+fn test_purchase_eligibility_unknown_listing_is_predictable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, _seller) = setup(&env);
+    let buyer = Address::generate(&env);
+
+    let eligibility = client.purchase_eligibility(&999u64, &buyer);
+    assert!(!eligibility.exists);
+    assert!(!eligibility.can_purchase);
+    assert_eq!(
+        eligibility.reason,
+        PurchaseEligibilityReason::ListingMissing
+    );
+    assert_eq!(eligibility.price, 0);
 }
 
 // ── error paths ───────────────────────────────────────────────────────────────

--- a/contracts/ticket-market/src/types.rs
+++ b/contracts/ticket-market/src/types.rs
@@ -41,6 +41,24 @@ pub struct OrderbookSummary {
     pub current_ledger: u32,
 }
 
+/// Summary of active listing depth for one game or event.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ListingDepthSummary {
+    /// Game or event identifier this summary was computed for.
+    pub game_id: Symbol,
+    /// Total number of active, non-expired listings for the game.
+    pub active_count: u64,
+    /// Lowest ask price among matching listings (0 when there is no depth).
+    pub best_ask: i128,
+    /// Highest ask price among matching listings (0 when there is no depth).
+    pub worst_ask: i128,
+    /// Sum of all active listing prices for the game.
+    pub total_volume: i128,
+    /// Current ledger sequence used for the expiry check.
+    pub current_ledger: u32,
+}
+
 /// Expiry details for a single listing.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -53,4 +71,42 @@ pub struct ListingExpiry {
     /// True when expires_at_ledger <= current_ledger.
     pub is_expired: bool,
     pub status: ListingStatus,
+}
+
+/// Stable reason code returned by `purchase_eligibility`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PurchaseEligibilityReason {
+    Eligible,
+    ListingMissing,
+    ListingNotActive,
+    ListingExpired,
+    SellerCannotPurchaseOwnListing,
+}
+
+/// Read-only purchase check for a specific listing and buyer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PurchaseEligibility {
+    pub listing_id: u64,
+    /// True when the listing exists in storage.
+    pub exists: bool,
+    /// Current listing status snapshot.
+    pub status: ListingStatus,
+    /// Game or event identifier; `None` when the listing is unknown.
+    pub game_id: Option<Symbol>,
+    /// Seller address; `None` when the listing is unknown.
+    pub seller: Option<Address>,
+    /// Ask price; `0` when the listing is unknown.
+    pub price: i128,
+    /// Current ledger sequence used for expiry evaluation.
+    pub current_ledger: u32,
+    /// True when the listing has passed its expiry ledger.
+    pub is_expired: bool,
+    /// True when the buyer matches the seller address.
+    pub seller_is_buyer: bool,
+    /// Final caller-facing eligibility flag.
+    pub can_purchase: bool,
+    /// Stable machine-readable reason code.
+    pub reason: PurchaseEligibilityReason,
 }


### PR DESCRIPTION
## Description
Adds stable read accessors and summary responses across the existing marketplace, settlement queue, creator royalties, and prize pool contracts. This bundles the four backlog items into one PR and maps the issue slugs to the closest contracts that exist on `upstream/main`: `battle-pass-market` -> `ticket-market`, `payout-vault` -> `settlement-queue`, and `tournament-prizes` -> `prize-pool`.

Closes #519
Closes #518
Closes #532
Closes #534

## Changes proposed

### What were you told to do?
Implement the four contract accessor backlog items in one PR, pulling from `upstream/main` first, returning structured read models with predictable empty or missing-state behavior, keeping existing write paths unchanged, and adding unit coverage.

### What did I do?
#### Marketplace and queue accessors
- Added `listing_depth_summary` and `purchase_eligibility` to `contracts/ticket-market` with named response types and explicit zero-value behavior for empty or missing listings.
- Added `queued_payout_snapshot` and `signer_readiness` to `contracts/settlement-queue` using current queue head/tail state and configured admin contract references.
- Added focused unit tests for happy paths plus missing or pre-configuration reads in both contracts.

#### Royalties and prize summaries
- Kept the existing `contracts/creator-royalties` public reads aligned with their current storage model and clarified fallback and zero-value conventions in the contract docs.
- Fixed the `creator-royalties` scheduled-claim fixture so the happy-path test uses an actually claimable ledger.
- Added `get_prize_allocation_summary` and `get_claim_pressure` to `contracts/prize-pool` using tracked reservation totals instead of duplicated accounting state.
- Added unit tests covering populated and empty-state reads for the prize pool summaries.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `ticket-market` isolated crate test run passed locally after adding the new listing depth and purchase eligibility accessors.
- `settlement-queue` isolated crate test run passed locally after adding the queued payout snapshot and signer readiness reads.
- `prize-pool` isolated crate test run passed locally after adding prize allocation summary and claim pressure accessors.
- `creator-royalties` had an existing failing claim-schedule fixture on `upstream/main`; this PR corrects that fixture and updates the accessor fallback documentation.
- Workspace-level `cargo fmt` and `cargo test` are still blocked on `upstream/main` because `contracts/Cargo.toml` references a missing `challenge-ladder` member, so I did not mark the global lint/test checkbox as complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Prize pool contracts now expose queries for prize allocation summaries and claim pressure metrics.
  * Settlement queue adds queries for queued payout snapshots and signer readiness information.
  * Ticket market adds listing depth summaries and purchase eligibility verification queries.

* **Documentation**
  * Enhanced documentation for creator royalties functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->