### PR TITLE
feat(contracts): add season/stream/duel/bonus snapshots and readiness accessors

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 
 members = [
     "access-control",
+    "bonus-rotator",
     "anti-cheat-bounties",
     "creator-royalties",
     "achievement-badge",
@@ -29,6 +30,7 @@ members = [
     "deployment-scripts",
     "dice-roll",
     "dynamic-fee-policy",
+    "duel-engine",
     "emergency-pause",
     "epoch-scheduler",
     "escrow-marketplace",
@@ -40,6 +42,7 @@ members = [
     "gas-optimization-analysis",
     "governance",
     "governance-token",
+    "guild-season",
     "leaderboard",
     "matchmaking-queue",
     "merch-redemption",
@@ -57,6 +60,7 @@ members = [
     "referral-system",
     "revenue-split",
     "reward-distribution",
+    "reward-stream",
     "reward-vesting",
     "session-nonce-manager",
     "settlement-queue",

--- a/contracts/bonus-rotator/Cargo.toml
+++ b/contracts/bonus-rotator/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-bonus-rotator"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/bonus-rotator/src/lib.rs
+++ b/contracts/bonus-rotator/src/lib.rs
@@ -1,0 +1,81 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+mod storage;
+mod types;
+#[cfg(test)]
+mod test;
+
+pub use types::{ActiveBonusCycleSnapshot, BonusCycle};
+
+#[contract]
+pub struct BonusRotator;
+
+#[contractimpl]
+impl BonusRotator {
+    pub fn init(env: Env, admin: Address) {
+        if storage::get_admin(&env).is_none() {
+            storage::set_admin(&env, &admin);
+            storage::set_paused(&env, false);
+        }
+    }
+
+    pub fn set_paused(env: Env, admin: Address, paused: bool) {
+        admin.require_auth();
+        if storage::get_admin(&env) == Some(admin) {
+            storage::set_paused(&env, paused);
+        }
+    }
+
+    pub fn set_active_cycle(
+        env: Env,
+        admin: Address,
+        cycle_id: u64,
+        bonus_bps: u32,
+        starts_at: u64,
+        ends_at: u64,
+    ) {
+        admin.require_auth();
+        if storage::get_admin(&env) == Some(admin) {
+            storage::set_cycle(
+                &env,
+                &BonusCycle {
+                    cycle_id,
+                    bonus_bps,
+                    starts_at,
+                    ends_at,
+                },
+            );
+        }
+    }
+
+    pub fn active_bonus_cycle_snapshot(env: Env) -> ActiveBonusCycleSnapshot {
+        let now = env.ledger().timestamp();
+        if let Some(c) = storage::get_cycle(&env) {
+            ActiveBonusCycleSnapshot {
+                has_active_cycle: true,
+                paused: storage::is_paused(&env),
+                now,
+                cycle_id: c.cycle_id,
+                bonus_bps: c.bonus_bps,
+                starts_at: c.starts_at,
+                ends_at: c.ends_at,
+            }
+        } else {
+            ActiveBonusCycleSnapshot {
+                has_active_cycle: false,
+                paused: storage::is_paused(&env),
+                now,
+                cycle_id: 0,
+                bonus_bps: 0,
+                starts_at: 0,
+                ends_at: 0,
+            }
+        }
+    }
+
+    pub fn next_rollover_at(env: Env) -> u64 {
+        storage::get_cycle(&env).map(|c| c.ends_at).unwrap_or(0)
+    }
+}

--- a/contracts/bonus-rotator/src/storage.rs
+++ b/contracts/bonus-rotator/src/storage.rs
@@ -1,0 +1,26 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+use crate::types::BonusCycle;
+
+const ADMIN: Symbol = symbol_short!("admin");
+const PAUSED: Symbol = symbol_short!("paused");
+const CYCLE: Symbol = symbol_short!("cycle");
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&ADMIN, admin);
+}
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&ADMIN)
+}
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&PAUSED, &paused);
+}
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED).unwrap_or(false)
+}
+pub fn set_cycle(env: &Env, cycle: &BonusCycle) {
+    env.storage().instance().set(&CYCLE, cycle);
+}
+pub fn get_cycle(env: &Env) -> Option<BonusCycle> {
+    env.storage().instance().get(&CYCLE)
+}

--- a/contracts/bonus-rotator/src/test.rs
+++ b/contracts/bonus-rotator/src/test.rs
@@ -1,0 +1,35 @@
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{BonusRotator, BonusRotatorClient};
+
+#[test]
+fn cycle_snapshot_and_rollover_success_path() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(BonusRotator, ());
+    let client = BonusRotatorClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    client.set_active_cycle(&admin, &5, &1250, &100, &600);
+    let snap = client.active_bonus_cycle_snapshot();
+    assert!(snap.has_active_cycle);
+    assert_eq!(snap.cycle_id, 5);
+    assert_eq!(client.next_rollover_at(), 600);
+}
+
+#[test]
+fn empty_cycle_returns_zero_rollover() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(BonusRotator, ());
+    let client = BonusRotatorClient::new(&env, &id);
+    env.mock_all_auths();
+    client.init(&admin);
+
+    let snap = client.active_bonus_cycle_snapshot();
+    assert!(!snap.has_active_cycle);
+    assert_eq!(client.next_rollover_at(), 0);
+}

--- a/contracts/bonus-rotator/src/types.rs
+++ b/contracts/bonus-rotator/src/types.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BonusCycle {
+    pub cycle_id: u64,
+    pub bonus_bps: u32,
+    pub starts_at: u64,
+    pub ends_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActiveBonusCycleSnapshot {
+    pub has_active_cycle: bool,
+    pub paused: bool,
+    pub now: u64,
+    pub cycle_id: u64,
+    pub bonus_bps: u32,
+    pub starts_at: u64,
+    pub ends_at: u64,
+}

--- a/contracts/duel-engine/Cargo.toml
+++ b/contracts/duel-engine/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-duel-engine"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/duel-engine/src/lib.rs
+++ b/contracts/duel-engine/src/lib.rs
@@ -1,0 +1,87 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+mod storage;
+mod types;
+#[cfg(test)]
+mod test;
+
+pub use types::{OpenDuelSummary, ResolutionReadiness};
+
+#[contract]
+pub struct DuelEngine;
+
+#[contractimpl]
+impl DuelEngine {
+    pub fn init(env: Env, admin: Address) {
+        if storage::get_admin(&env).is_none() {
+            storage::set_admin(&env, &admin);
+            storage::set_open_count(&env, 0);
+            storage::set_oldest(&env, 0);
+            storage::set_newest(&env, 0);
+        }
+    }
+
+    pub fn create_duel(env: Env, admin: Address, duel_id: u64) {
+        admin.require_auth();
+        if storage::get_admin(&env) != Some(admin) || storage::is_paused(&env) {
+            return;
+        }
+        if storage::get_duel_open(&env, duel_id).is_some() {
+            return;
+        }
+        let count = storage::get_open_count(&env);
+        storage::set_duel_open(&env, duel_id, true);
+        storage::set_open_count(&env, count + 1);
+        if storage::get_oldest(&env) == 0 {
+            storage::set_oldest(&env, duel_id);
+        }
+        storage::set_newest(&env, duel_id);
+    }
+
+    pub fn resolve_duel(env: Env, admin: Address, duel_id: u64) {
+        admin.require_auth();
+        if storage::get_admin(&env) != Some(admin) {
+            return;
+        }
+        if storage::get_duel_open(&env, duel_id) == Some(true) {
+            let count = storage::get_open_count(&env);
+            storage::set_duel_open(&env, duel_id, false);
+            storage::set_open_count(&env, count.saturating_sub(1));
+        }
+    }
+
+    pub fn set_paused(env: Env, admin: Address, paused: bool) {
+        admin.require_auth();
+        if storage::get_admin(&env) == Some(admin) {
+            storage::set_paused(&env, paused);
+        }
+    }
+
+    pub fn open_duel_summary(env: Env) -> OpenDuelSummary {
+        OpenDuelSummary {
+            open_count: storage::get_open_count(&env),
+            oldest_open_duel_id: storage::get_oldest(&env),
+            newest_open_duel_id: storage::get_newest(&env),
+            paused: storage::is_paused(&env),
+        }
+    }
+
+    pub fn resolution_readiness(env: Env, duel_id: u64) -> ResolutionReadiness {
+        match storage::get_duel_open(&env, duel_id) {
+            Some(is_open) => ResolutionReadiness {
+                duel_id,
+                exists: true,
+                is_open,
+                is_ready_to_resolve: is_open && !storage::is_paused(&env),
+            },
+            None => ResolutionReadiness {
+                duel_id,
+                exists: false,
+                is_open: false,
+                is_ready_to_resolve: false,
+            },
+        }
+    }
+}

--- a/contracts/duel-engine/src/storage.rs
+++ b/contracts/duel-engine/src/storage.rs
@@ -1,0 +1,45 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+const ADMIN: Symbol = symbol_short!("admin");
+const PAUSED: Symbol = symbol_short!("paused");
+const OPEN_COUNT: Symbol = symbol_short!("ocount");
+const OLDEST: Symbol = symbol_short!("oldest");
+const NEWEST: Symbol = symbol_short!("newest");
+const DUEL_PREFIX: Symbol = symbol_short!("duel");
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&ADMIN, admin);
+}
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&ADMIN)
+}
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&PAUSED, &paused);
+}
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED).unwrap_or(false)
+}
+pub fn set_open_count(env: &Env, count: u32) {
+    env.storage().instance().set(&OPEN_COUNT, &count);
+}
+pub fn get_open_count(env: &Env) -> u32 {
+    env.storage().instance().get(&OPEN_COUNT).unwrap_or(0)
+}
+pub fn set_oldest(env: &Env, id: u64) {
+    env.storage().instance().set(&OLDEST, &id);
+}
+pub fn get_oldest(env: &Env) -> u64 {
+    env.storage().instance().get(&OLDEST).unwrap_or(0)
+}
+pub fn set_newest(env: &Env, id: u64) {
+    env.storage().instance().set(&NEWEST, &id);
+}
+pub fn get_newest(env: &Env) -> u64 {
+    env.storage().instance().get(&NEWEST).unwrap_or(0)
+}
+pub fn set_duel_open(env: &Env, duel_id: u64, is_open: bool) {
+    env.storage().persistent().set(&(DUEL_PREFIX, duel_id), &is_open);
+}
+pub fn get_duel_open(env: &Env, duel_id: u64) -> Option<bool> {
+    env.storage().persistent().get(&(DUEL_PREFIX, duel_id))
+}

--- a/contracts/duel-engine/src/test.rs
+++ b/contracts/duel-engine/src/test.rs
@@ -1,0 +1,37 @@
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{DuelEngine, DuelEngineClient};
+
+#[test]
+fn open_summary_and_resolution_ready_path() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(DuelEngine, ());
+    let client = DuelEngineClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    client.create_duel(&admin, &10);
+    client.create_duel(&admin, &11);
+    let summary = client.open_duel_summary();
+    assert_eq!(summary.open_count, 2);
+    assert_eq!(summary.oldest_open_duel_id, 10);
+    assert_eq!(summary.newest_open_duel_id, 11);
+    assert!(client.resolution_readiness(&10).is_ready_to_resolve);
+}
+
+#[test]
+fn missing_duel_readiness_is_stable() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(DuelEngine, ());
+    let client = DuelEngineClient::new(&env, &id);
+    env.mock_all_auths();
+    client.init(&admin);
+
+    let readiness = client.resolution_readiness(&404);
+    assert!(!readiness.exists);
+    assert!(!readiness.is_ready_to_resolve);
+}

--- a/contracts/duel-engine/src/types.rs
+++ b/contracts/duel-engine/src/types.rs
@@ -1,0 +1,21 @@
+#![allow(dead_code)]
+
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OpenDuelSummary {
+    pub open_count: u32,
+    pub oldest_open_duel_id: u64,
+    pub newest_open_duel_id: u64,
+    pub paused: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolutionReadiness {
+    pub duel_id: u64,
+    pub exists: bool,
+    pub is_open: bool,
+    pub is_ready_to_resolve: bool,
+}

--- a/contracts/guild-season/Cargo.toml
+++ b/contracts/guild-season/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-guild-season"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/guild-season/src/lib.rs
+++ b/contracts/guild-season/src/lib.rs
@@ -1,0 +1,88 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+mod storage;
+mod types;
+#[cfg(test)]
+mod test;
+
+pub use types::{ActiveSeasonSnapshot, SeasonData};
+
+#[contract]
+pub struct GuildSeason;
+
+#[contractimpl]
+impl GuildSeason {
+    pub fn init(env: Env, admin: Address) {
+        if storage::get_admin(&env).is_none() {
+            storage::set_admin(&env, &admin);
+            storage::set_paused(&env, false);
+        }
+    }
+
+    pub fn set_paused(env: Env, admin: Address, paused: bool) {
+        admin.require_auth();
+        if storage::get_admin(&env) == Some(admin) {
+            storage::set_paused(&env, paused);
+        }
+    }
+
+    pub fn set_active_season(
+        env: Env,
+        admin: Address,
+        season_id: u64,
+        reward_threshold: u64,
+        starts_at: u64,
+        ends_at: u64,
+        guild_count: u32,
+    ) {
+        admin.require_auth();
+        if storage::get_admin(&env) == Some(admin) {
+            storage::set_active_season(
+                &env,
+                &SeasonData {
+                    season_id,
+                    reward_threshold,
+                    starts_at,
+                    ends_at,
+                    guild_count,
+                },
+            );
+        }
+    }
+
+    pub fn active_season_snapshot(env: Env) -> ActiveSeasonSnapshot {
+        let now = env.ledger().timestamp();
+        if let Some(season) = storage::get_active_season(&env) {
+            ActiveSeasonSnapshot {
+                has_active_season: true,
+                is_paused: storage::is_paused(&env),
+                now,
+                season_id: season.season_id,
+                reward_threshold: season.reward_threshold,
+                starts_at: season.starts_at,
+                ends_at: season.ends_at,
+                guild_count: season.guild_count,
+            }
+        } else {
+            ActiveSeasonSnapshot {
+                has_active_season: false,
+                is_paused: storage::is_paused(&env),
+                now,
+                season_id: 0,
+                reward_threshold: 0,
+                starts_at: 0,
+                ends_at: 0,
+                guild_count: 0,
+            }
+        }
+    }
+
+    pub fn reward_threshold(env: Env, season_id: u64) -> u64 {
+        storage::get_active_season(&env)
+            .filter(|s| s.season_id == season_id)
+            .map(|s| s.reward_threshold)
+            .unwrap_or(0)
+    }
+}

--- a/contracts/guild-season/src/storage.rs
+++ b/contracts/guild-season/src/storage.rs
@@ -1,0 +1,37 @@
+use soroban_sdk::{contracttype, symbol_short, Env, Symbol};
+
+use crate::types::SeasonData;
+
+const ACTIVE_SEASON: Symbol = symbol_short!("active");
+const PAUSED: Symbol = symbol_short!("paused");
+const ADMIN: Symbol = symbol_short!("admin");
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    ActiveSeason,
+}
+
+pub fn set_admin(env: &Env, admin: &soroban_sdk::Address) {
+    env.storage().instance().set(&ADMIN, admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<soroban_sdk::Address> {
+    env.storage().instance().get(&ADMIN)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&PAUSED, &paused);
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED).unwrap_or(false)
+}
+
+pub fn set_active_season(env: &Env, data: &SeasonData) {
+    env.storage().instance().set(&ACTIVE_SEASON, data);
+}
+
+pub fn get_active_season(env: &Env) -> Option<SeasonData> {
+    env.storage().instance().get(&ACTIVE_SEASON)
+}

--- a/contracts/guild-season/src/test.rs
+++ b/contracts/guild-season/src/test.rs
@@ -1,0 +1,35 @@
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{GuildSeason, GuildSeasonClient};
+
+#[test]
+fn active_snapshot_and_threshold_read() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(GuildSeason, ());
+    let client = GuildSeasonClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    client.set_active_season(&admin, &7, &250, &100, &300, &11);
+    let snap = client.active_season_snapshot();
+    assert!(snap.has_active_season);
+    assert_eq!(snap.season_id, 7);
+    assert_eq!(client.reward_threshold(&7), 250);
+}
+
+#[test]
+fn empty_snapshot_is_predictable() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(GuildSeason, ());
+    let client = GuildSeasonClient::new(&env, &id);
+    env.mock_all_auths();
+    client.init(&admin);
+
+    let snap = client.active_season_snapshot();
+    assert!(!snap.has_active_season);
+    assert_eq!(client.reward_threshold(&999), 0);
+}

--- a/contracts/guild-season/src/types.rs
+++ b/contracts/guild-season/src/types.rs
@@ -1,0 +1,26 @@
+#![allow(dead_code)]
+
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeasonData {
+    pub season_id: u64,
+    pub reward_threshold: u64,
+    pub starts_at: u64,
+    pub ends_at: u64,
+    pub guild_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActiveSeasonSnapshot {
+    pub has_active_season: bool,
+    pub is_paused: bool,
+    pub now: u64,
+    pub season_id: u64,
+    pub reward_threshold: u64,
+    pub starts_at: u64,
+    pub ends_at: u64,
+    pub guild_count: u32,
+}

--- a/contracts/reward-stream/Cargo.toml
+++ b/contracts/reward-stream/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-reward-stream"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/reward-stream/src/lib.rs
+++ b/contracts/reward-stream/src/lib.rs
@@ -1,0 +1,98 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+mod storage;
+mod types;
+#[cfg(test)]
+mod test;
+
+pub use types::{StreamData, StreamHealthSummary, WithdrawalReadiness};
+
+#[contract]
+pub struct RewardStream;
+
+#[contractimpl]
+impl RewardStream {
+    pub fn init(env: Env, admin: Address) {
+        if storage::get_admin(&env).is_none() {
+            storage::set_admin(&env, &admin);
+        }
+    }
+
+    pub fn configure_stream(
+        env: Env,
+        admin: Address,
+        stream_id: u64,
+        total_allocated: i128,
+        total_withdrawn: i128,
+        unlock_time: u64,
+        paused: bool,
+    ) {
+        admin.require_auth();
+        if storage::get_admin(&env) == Some(admin) {
+            storage::set_stream(
+                &env,
+                &StreamData {
+                    stream_id,
+                    total_allocated,
+                    total_withdrawn,
+                    unlock_time,
+                    paused,
+                },
+            );
+        }
+    }
+
+    pub fn stream_health_summary(env: Env) -> StreamHealthSummary {
+        if let Some(s) = storage::get_stream(&env) {
+            StreamHealthSummary {
+                is_configured: true,
+                stream_id: s.stream_id,
+                total_allocated: s.total_allocated,
+                total_withdrawn: s.total_withdrawn,
+                remaining: (s.total_allocated - s.total_withdrawn).max(0),
+                paused: s.paused,
+            }
+        } else {
+            StreamHealthSummary {
+                is_configured: false,
+                stream_id: 0,
+                total_allocated: 0,
+                total_withdrawn: 0,
+                remaining: 0,
+                paused: false,
+            }
+        }
+    }
+
+    pub fn withdrawal_readiness(env: Env, now: u64) -> WithdrawalReadiness {
+        if let Some(s) = storage::get_stream(&env) {
+            let remaining = (s.total_allocated - s.total_withdrawn).max(0);
+            let unlocked = now >= s.unlock_time;
+            let ready = !s.paused && unlocked && remaining > 0;
+            let blocked_reason_code = if s.paused {
+                1
+            } else if !unlocked {
+                2
+            } else if remaining == 0 {
+                3
+            } else {
+                0
+            };
+            WithdrawalReadiness {
+                stream_id: s.stream_id,
+                is_ready: ready,
+                claimable_now: if ready { remaining } else { 0 },
+                blocked_reason_code,
+            }
+        } else {
+            WithdrawalReadiness {
+                stream_id: 0,
+                is_ready: false,
+                claimable_now: 0,
+                blocked_reason_code: 4,
+            }
+        }
+    }
+}

--- a/contracts/reward-stream/src/storage.rs
+++ b/contracts/reward-stream/src/storage.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+use crate::types::StreamData;
+
+const ADMIN: Symbol = symbol_short!("admin");
+const STREAM: Symbol = symbol_short!("stream");
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&ADMIN, admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&ADMIN)
+}
+
+pub fn set_stream(env: &Env, stream: &StreamData) {
+    env.storage().instance().set(&STREAM, stream);
+}
+
+pub fn get_stream(env: &Env) -> Option<StreamData> {
+    env.storage().instance().get(&STREAM)
+}

--- a/contracts/reward-stream/src/test.rs
+++ b/contracts/reward-stream/src/test.rs
@@ -1,0 +1,38 @@
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{RewardStream, RewardStreamClient};
+
+#[test]
+fn stream_health_and_readiness_success_path() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    client.configure_stream(&admin, &12, &1_000, &250, &100, &false);
+    let summary = client.stream_health_summary();
+    assert!(summary.is_configured);
+    assert_eq!(summary.remaining, 750);
+
+    let readiness = client.withdrawal_readiness(&150);
+    assert!(readiness.is_ready);
+    assert_eq!(readiness.claimable_now, 750);
+}
+
+#[test]
+fn readiness_reports_missing_state() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+    env.mock_all_auths();
+    client.init(&admin);
+
+    let readiness = client.withdrawal_readiness(&10);
+    assert!(!readiness.is_ready);
+    assert_eq!(readiness.blocked_reason_code, 4);
+}

--- a/contracts/reward-stream/src/types.rs
+++ b/contracts/reward-stream/src/types.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamData {
+    pub stream_id: u64,
+    pub total_allocated: i128,
+    pub total_withdrawn: i128,
+    pub unlock_time: u64,
+    pub paused: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamHealthSummary {
+    pub is_configured: bool,
+    pub stream_id: u64,
+    pub total_allocated: i128,
+    pub total_withdrawn: i128,
+    pub remaining: i128,
+    pub paused: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WithdrawalReadiness {
+    pub stream_id: u64,
+    pub is_ready: bool,
+    pub claimable_now: i128,
+    pub blocked_reason_code: u32,
+}


### PR DESCRIPTION
## Summary
- Add new `guild-season` contract reads for active season snapshot and reward-threshold accessor.
- Add new `reward-stream` reads for stream health summary and withdrawal-readiness accessor.
- Add new `duel-engine` reads for open-duel summary and resolution-readiness accessor.
- Add new `bonus-rotator` reads for active cycle snapshot and next-rollover accessor.
- Wire all four modules into `contracts/Cargo.toml` workspace membership and include unit tests covering success + missing/empty state paths.

## Notes
- Each accessor returns explicit zero/default state for not-configured data to keep frontend/backend consumers deterministic.
- Existing mutation flows are preserved through dedicated admin-only setters used by tests.

## Validation
- Attempted targeted `cargo test` for the new modules, but the existing workspace currently fails earlier due to missing `contracts/challenge-ladder/Cargo.toml` in the repository baseline.

## Closes
- Closes #592
- Closes #593
- Closes #594
- Closes #597

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added four new smart contract modules to the platform: bonus rotation management, duel engine operations, guild season tracking, and reward stream distribution
* Each module includes admin-controlled pause functionality and comprehensive state management
* Supports active cycle/season tracking with timestamp-based rollover and readiness checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->