### PR TITLE
Frontend dashboard UX pack: spotlight, sparse shells, reconnect progress, action tray

### DIFF
--- a/frontend/src/components/v1/CampaignRewardsSpotlightCard.css
+++ b/frontend/src/components/v1/CampaignRewardsSpotlightCard.css
@@ -1,0 +1,43 @@
+.campaign-rewards-spotlight {
+  border: 1px solid var(--glass-border);
+  border-radius: 1rem;
+  padding: 1rem;
+  background:
+    radial-gradient(circle at top right, rgba(125, 226, 209, 0.12), transparent 45%),
+    rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.campaign-rewards-spotlight__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.campaign-rewards-spotlight__header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.campaign-rewards-spotlight__metrics {
+  margin: 0;
+  color: var(--text-dim);
+}
+
+.campaign-rewards-spotlight__actions {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.campaign-rewards-spotlight__actions button {
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  cursor: pointer;
+}

--- a/frontend/src/components/v1/CampaignRewardsSpotlightCard.tsx
+++ b/frontend/src/components/v1/CampaignRewardsSpotlightCard.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { StatusPill } from "./StatusPill";
+import "./CampaignRewardsSpotlightCard.css";
+
+export interface CampaignRewardsSpotlightCardProps {
+  activeCampaigns: number;
+  pendingRewardsLabel: string;
+  onViewCampaigns?: () => void;
+  onClaimRewards?: () => void;
+  testId?: string;
+}
+
+export const CampaignRewardsSpotlightCard: React.FC<
+  CampaignRewardsSpotlightCardProps
+> = ({
+  activeCampaigns,
+  pendingRewardsLabel,
+  onViewCampaigns,
+  onClaimRewards,
+  testId = "campaign-rewards-spotlight",
+}) => {
+  const hasCampaigns = activeCampaigns > 0;
+  return (
+    <section className="campaign-rewards-spotlight" data-testid={testId}>
+      <div className="campaign-rewards-spotlight__header">
+        <h2>Campaign Spotlight</h2>
+        <StatusPill
+          tone={hasCampaigns ? "success" : "neutral"}
+          label={hasCampaigns ? "Active campaigns" : "No active campaigns"}
+          size="compact"
+        />
+      </div>
+
+      <p className="campaign-rewards-spotlight__metrics">
+        <strong>{activeCampaigns}</strong> running campaign
+        {activeCampaigns === 1 ? "" : "s"} • <span>{pendingRewardsLabel}</span>{" "}
+        pending rewards
+      </p>
+
+      <div className="campaign-rewards-spotlight__actions">
+        <button type="button" onClick={onViewCampaigns}>
+          View campaigns
+        </button>
+        <button type="button" onClick={onClaimRewards}>
+          Claim rewards
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default CampaignRewardsSpotlightCard;

--- a/frontend/src/components/v1/DashboardEmptyPanelShell.css
+++ b/frontend/src/components/v1/DashboardEmptyPanelShell.css
@@ -1,0 +1,41 @@
+.dashboard-empty-panel-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 1rem;
+  border: 1px dashed var(--glass-border);
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.dashboard-empty-panel-shell__chip {
+  width: fit-content;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+}
+
+.dashboard-empty-panel-shell__title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.dashboard-empty-panel-shell__description {
+  margin: 0;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
+.dashboard-empty-panel-shell__action {
+  width: fit-content;
+  border: 1px solid var(--glass-border);
+  background: rgba(125, 226, 209, 0.16);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  cursor: pointer;
+}

--- a/frontend/src/components/v1/DashboardEmptyPanelShell.tsx
+++ b/frontend/src/components/v1/DashboardEmptyPanelShell.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import "./DashboardEmptyPanelShell.css";
+
+export interface DashboardEmptyPanelShellProps {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  testId?: string;
+}
+
+export const DashboardEmptyPanelShell: React.FC<DashboardEmptyPanelShellProps> = ({
+  title,
+  description,
+  actionLabel = "Configure module",
+  onAction,
+  testId = "dashboard-empty-panel-shell",
+}) => {
+  return (
+    <section className="dashboard-empty-panel-shell" data-testid={testId}>
+      <div className="dashboard-empty-panel-shell__chip" aria-hidden="true">
+        Sparse module
+      </div>
+      <h3 className="dashboard-empty-panel-shell__title">{title}</h3>
+      <p className="dashboard-empty-panel-shell__description">{description}</p>
+      <button
+        type="button"
+        className="dashboard-empty-panel-shell__action"
+        onClick={onAction}
+      >
+        {actionLabel}
+      </button>
+    </section>
+  );
+};
+
+export default DashboardEmptyPanelShell;

--- a/frontend/src/components/v1/PinnedWalletActionTray.css
+++ b/frontend/src/components/v1/PinnedWalletActionTray.css
@@ -1,0 +1,42 @@
+.pinned-wallet-action-tray {
+  position: sticky;
+  bottom: 0.75rem;
+  z-index: 20;
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--glass-border);
+  background: rgba(10, 18, 31, 0.88);
+  backdrop-filter: blur(8px);
+}
+
+.pinned-wallet-action-tray__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.pinned-wallet-action-tray__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pinned-wallet-action-tray__actions button {
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  cursor: pointer;
+}
+
+.pinned-wallet-action-tray__actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/v1/PinnedWalletActionTray.tsx
+++ b/frontend/src/components/v1/PinnedWalletActionTray.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import "./PinnedWalletActionTray.css";
+
+export interface WalletActionItem {
+  id: string;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export interface PinnedWalletActionTrayProps {
+  actions: WalletActionItem[];
+  testId?: string;
+}
+
+export const PinnedWalletActionTray: React.FC<PinnedWalletActionTrayProps> = ({
+  actions,
+  testId = "pinned-wallet-action-tray",
+}) => {
+  return (
+    <aside className="pinned-wallet-action-tray" data-testid={testId}>
+      <span className="pinned-wallet-action-tray__label">Quick wallet actions</span>
+      <div className="pinned-wallet-action-tray__actions">
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            type="button"
+            disabled={action.disabled}
+            onClick={action.onClick}
+            data-testid={`${testId}-${action.id}`}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+};
+
+export default PinnedWalletActionTray;

--- a/frontend/src/components/v1/WalletStatusCard.css
+++ b/frontend/src/components/v1/WalletStatusCard.css
@@ -271,6 +271,33 @@
   cursor: not-allowed;
 }
 
+.wallet-status-card__reconnect-progress {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.wallet-status-card__reconnect-progress-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #1e40af;
+}
+
+.wallet-status-card__reconnect-progress-track {
+  height: 0.35rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.15);
+  overflow: hidden;
+}
+
+.wallet-status-card__reconnect-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #3b82f6, #1d4ed8);
+  transition: width 0.2s ease-in-out;
+}
+
 .wallet-status-card__action-btn {
   padding: 0.5rem 1rem;
   font-size: 0.875rem;

--- a/frontend/src/components/v1/WalletStatusCard.tsx
+++ b/frontend/src/components/v1/WalletStatusCard.tsx
@@ -203,6 +203,8 @@ interface DroppedSessionBannerProps {
   onReconnect?: () => void | Promise<void>;
   pending?: boolean;
   label?: string;
+  progress?: number;
+  progressLabel?: string;
 }
 
 /**
@@ -214,11 +216,14 @@ function DroppedSessionBanner({
   onReconnect,
   pending = false,
   label = "Reconnect",
+  progress = 0,
+  progressLabel = "Recovering wallet session",
 }: DroppedSessionBannerProps): React.JSX.Element {
   const handleReconnect = useCallback(
     () => safeCall(onReconnect, "onReconnect"),
     [onReconnect],
   );
+  const safeProgress = Math.max(0, Math.min(100, Math.round(progress)));
 
   return (
     <div
@@ -240,6 +245,26 @@ function DroppedSessionBanner({
       >
         {pending ? "Reconnecting..." : label}
       </button>
+      {pending && (
+        <div
+          className="wallet-status-card__reconnect-progress"
+          data-testid="wallet-reconnect-progress"
+        >
+          <div className="wallet-status-card__reconnect-progress-row">
+            <span>{progressLabel}</span>
+            <strong>{safeProgress}%</strong>
+          </div>
+          <div
+            className="wallet-status-card__reconnect-progress-track"
+            aria-hidden="true"
+          >
+            <div
+              className="wallet-status-card__reconnect-progress-bar"
+              style={{ width: `${safeProgress}%` }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -495,6 +520,8 @@ export const WalletStatusCard: React.FC<WalletStatusCardProps> = ({
   onReconnect,
   reconnectPending = false,
   reconnectLabel,
+  reconnectProgress = 0,
+  reconnectProgressLabel,
   lastUpdatedAt = null,
   isRefreshing = false,
   diagnostics,
@@ -671,6 +698,8 @@ export const WalletStatusCard: React.FC<WalletStatusCardProps> = ({
           onReconnect={onReconnect}
           pending={reconnectPending}
           label={reconnectLabel}
+          progress={reconnectProgress}
+          progressLabel={reconnectProgressLabel}
         />
       )}
 

--- a/frontend/src/components/v1/WalletStatusCard.types.ts
+++ b/frontend/src/components/v1/WalletStatusCard.types.ts
@@ -227,6 +227,17 @@ export interface WalletStatusCardProps extends WalletStatusCardCallbacks {
   reconnectLabel?: string;
 
   /**
+   * Optional progress value for wallet reconnect recovery flows.
+   * Expected range: 0..100. Values outside range are clamped by the component.
+   */
+  reconnectProgress?: number;
+
+  /**
+   * Optional inline progress text for reconnect recovery (e.g. "Re-authorizing session").
+   */
+  reconnectProgressLabel?: string;
+
+  /**
    * Timestamp (ms since epoch) of the last successful balance/session refresh.
    * When provided, a human-readable "Updated X ago" label is shown.
    */

--- a/frontend/src/components/v1/index.ts
+++ b/frontend/src/components/v1/index.ts
@@ -190,6 +190,29 @@ export type {
 } from "./AnalyticsRangeSwitcher";
 
 export {
+  DashboardEmptyPanelShell,
+  default as DashboardEmptyPanelShellDefault,
+} from "./DashboardEmptyPanelShell";
+export type { DashboardEmptyPanelShellProps } from "./DashboardEmptyPanelShell";
+
+export {
+  CampaignRewardsSpotlightCard,
+  default as CampaignRewardsSpotlightCardDefault,
+} from "./CampaignRewardsSpotlightCard";
+export type {
+  CampaignRewardsSpotlightCardProps,
+} from "./CampaignRewardsSpotlightCard";
+
+export {
+  PinnedWalletActionTray,
+  default as PinnedWalletActionTrayDefault,
+} from "./PinnedWalletActionTray";
+export type {
+  PinnedWalletActionTrayProps,
+  WalletActionItem,
+} from "./PinnedWalletActionTray";
+
+export {
   AuditSnapshotCard,
   default as AuditSnapshotCardDefault,
 } from "./AuditSnapshotCard";

--- a/frontend/src/pages/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/AnalyticsDashboard.tsx
@@ -6,6 +6,8 @@
 
 import React, { useState } from 'react';
 import { AnalyticsRangeSwitcher, type TimeRange } from '../components/v1/AnalyticsRangeSwitcher';
+import { CampaignRewardsSpotlightCard } from '../components/v1/CampaignRewardsSpotlightCard';
+import { DashboardEmptyPanelShell } from '../components/v1/DashboardEmptyPanelShell';
 import { StatusPill } from '../components/v1/StatusPill';
 
 interface ChartData {
@@ -75,6 +77,18 @@ const AnalyticsDashboard: React.FC = () => {
   };
 
   const chartData = getChartData(selectedRange);
+  const sparseModules = [
+    {
+      id: 'campaign-latency',
+      title: 'Campaign latency monitor',
+      description: 'No campaign latency snapshots are available yet for this range.',
+    },
+    {
+      id: 'reward-anomalies',
+      title: 'Reward anomaly tracker',
+      description: 'Reward outlier tracking is waiting for enough payout samples.',
+    },
+  ];
 
   const formatValue = (value: number, label: string): string => {
     if (label.includes('Revenue')) {
@@ -100,6 +114,14 @@ const AnalyticsDashboard: React.FC = () => {
           Monitor platform performance and user engagement metrics
         </p>
       </header>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <CampaignRewardsSpotlightCard
+          activeCampaigns={3}
+          pendingRewardsLabel="12 claims"
+          onViewCampaigns={() => setSelectedRange('30d')}
+          onClaimRewards={() => setSelectedRange('7d')}
+        />
+      </div>
 
       <div style={{ marginBottom: '2rem' }}>
         <div style={{ 
@@ -205,6 +227,27 @@ const AnalyticsDashboard: React.FC = () => {
           ))}
         </div>
       </div>
+      <section style={{ marginTop: '2rem' }} aria-label="Sparse dashboard modules">
+        <h2 style={{ marginBottom: '0.75rem' }}>Sparse Modules</h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+            gap: '1rem',
+          }}
+        >
+          {sparseModules.map((module) => (
+            <DashboardEmptyPanelShell
+              key={module.id}
+              title={module.title}
+              description={module.description}
+              actionLabel="Backfill module"
+              onAction={() => setSelectedRange('90d')}
+              testId={`sparse-module-${module.id}`}
+            />
+          ))}
+        </div>
+      </section>
 
       <div style={{ 
         marginTop: '3rem',

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { EmptyStateBlock } from "../components/v1/EmptyStateBlock";
+import { CampaignRewardsSpotlightCard } from "../components/v1/CampaignRewardsSpotlightCard";
+import { PinnedWalletActionTray } from "../components/v1/PinnedWalletActionTray";
 import {
   PageSkeletonOrchestrator,
   SkeletonBase,
@@ -40,6 +42,7 @@ export interface PortfolioState {
 
 export interface PortfolioProps {
   state?: PortfolioState;
+  activeCampaignsCount?: number;
   onOpenWallet?: () => void;
   onBrowseRewards?: () => void;
   onBrowseCollectibles?: () => void;
@@ -122,6 +125,7 @@ function SectionError({
 
 export const Portfolio: React.FC<PortfolioProps> = ({
   state = DEFAULT_PORTFOLIO_STATE,
+  activeCampaignsCount = 0,
   onOpenWallet,
   onBrowseRewards,
   onBrowseCollectibles,
@@ -247,6 +251,12 @@ export const Portfolio: React.FC<PortfolioProps> = ({
         </div>
         <StatusPill tone="neutral" label="Portfolio beta" />
       </header>
+      <CampaignRewardsSpotlightCard
+        activeCampaigns={activeCampaignsCount}
+        pendingRewardsLabel={`${state.rewards.items.length}`}
+        onViewCampaigns={onBrowseRewards}
+        onClaimRewards={onOpenWallet}
+      />
 
       <div className="portfolio-page__grid">
         <PageSkeletonOrchestrator
@@ -342,6 +352,25 @@ export const Portfolio: React.FC<PortfolioProps> = ({
           ]}
         />
       </div>
+      <PinnedWalletActionTray
+        actions={[
+          {
+            id: "wallet",
+            label: "Open wallet",
+            onClick: onOpenWallet ?? (() => {}),
+          },
+          {
+            id: "rewards",
+            label: "Browse rewards",
+            onClick: onBrowseRewards ?? (() => {}),
+          },
+          {
+            id: "collectibles",
+            label: "Browse collectibles",
+            onClick: onBrowseCollectibles ?? (() => {}),
+          },
+        ]}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/WalletDetail.tsx
+++ b/frontend/src/pages/WalletDetail.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState } from 'react';
 import { QuickPivotLinks, type PivotLink } from '../components/v1/QuickPivotLinks';
+import { PinnedWalletActionTray } from '../components/v1/PinnedWalletActionTray';
 import { StatusPill } from '../components/v1/StatusPill';
 
 interface WalletDetailProps {
@@ -144,6 +145,27 @@ const WalletDetail: React.FC<WalletDetailProps> = ({ walletId = 'wallet_123' }) 
       </div>
 
       {renderContent()}
+      <div style={{ marginTop: '1.5rem' }}>
+        <PinnedWalletActionTray
+          actions={[
+            {
+              id: 'refresh-session',
+              label: 'Refresh session',
+              onClick: () => console.log('refresh wallet session'),
+            },
+            {
+              id: 'repeat-last-transfer',
+              label: 'Repeat last transfer',
+              onClick: () => console.log('repeat last transfer'),
+            },
+            {
+              id: 'reconnect-wallet',
+              label: 'Reconnect wallet',
+              onClick: () => console.log('reconnect wallet'),
+            },
+          ]}
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/tests/components/AnalyticsDashboard.test.tsx
+++ b/frontend/tests/components/AnalyticsDashboard.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AnalyticsDashboard from "../../src/pages/AnalyticsDashboard";
+
+describe("AnalyticsDashboard page", () => {
+  it("renders sparse dashboard empty shells", () => {
+    render(<AnalyticsDashboard />);
+
+    expect(
+      screen.getByTestId("sparse-module-campaign-latency"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("sparse-module-reward-anomalies"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/Portfolio.test.tsx
+++ b/frontend/tests/components/Portfolio.test.tsx
@@ -149,4 +149,18 @@ describe("Portfolio page", () => {
     expect(onBrowseRewards).toHaveBeenCalledTimes(1);
     expect(onBrowseCollectibles).toHaveBeenCalledTimes(1);
   });
+
+  it("renders spotlight card and pinned wallet action tray", () => {
+    render(
+      <Portfolio
+        activeCampaignsCount={3}
+        onOpenWallet={vi.fn()}
+        onBrowseRewards={vi.fn()}
+        onBrowseCollectibles={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("campaign-rewards-spotlight")).toBeInTheDocument();
+    expect(screen.getByTestId("pinned-wallet-action-tray")).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/v1/CampaignRewardsSpotlightCard.test.tsx
+++ b/frontend/tests/components/v1/CampaignRewardsSpotlightCard.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { CampaignRewardsSpotlightCard } from "../../../src/components/v1/CampaignRewardsSpotlightCard";
+
+describe("CampaignRewardsSpotlightCard", () => {
+  it("renders active campaign and rewards copy", () => {
+    render(
+      <CampaignRewardsSpotlightCard
+        activeCampaigns={4}
+        pendingRewardsLabel="18 claims"
+      />,
+    );
+
+    expect(screen.getByTestId("campaign-rewards-spotlight")).toBeInTheDocument();
+    expect(screen.getByText(/4 running campaigns/i)).toBeInTheDocument();
+    expect(screen.getByText(/18 claims pending rewards/i)).toBeInTheDocument();
+  });
+
+  it("handles empty campaign state", () => {
+    render(
+      <CampaignRewardsSpotlightCard
+        activeCampaigns={0}
+        pendingRewardsLabel="0 claims"
+      />,
+    );
+    expect(screen.getByText("No active campaigns")).toBeInTheDocument();
+  });
+
+  it("fires action callbacks", () => {
+    const onViewCampaigns = vi.fn();
+    const onClaimRewards = vi.fn();
+    render(
+      <CampaignRewardsSpotlightCard
+        activeCampaigns={1}
+        pendingRewardsLabel="2 claims"
+        onViewCampaigns={onViewCampaigns}
+        onClaimRewards={onClaimRewards}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View campaigns" }));
+    fireEvent.click(screen.getByRole("button", { name: "Claim rewards" }));
+
+    expect(onViewCampaigns).toHaveBeenCalledTimes(1);
+    expect(onClaimRewards).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/components/v1/DashboardEmptyPanelShell.test.tsx
+++ b/frontend/tests/components/v1/DashboardEmptyPanelShell.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DashboardEmptyPanelShell } from "../../../src/components/v1/DashboardEmptyPanelShell";
+
+describe("DashboardEmptyPanelShell", () => {
+  it("renders sparse shell content", () => {
+    render(
+      <DashboardEmptyPanelShell
+        title="Rewards anomaly stream"
+        description="No sparse samples yet."
+      />,
+    );
+
+    expect(screen.getByText("Sparse module")).toBeInTheDocument();
+    expect(screen.getByText("Rewards anomaly stream")).toBeInTheDocument();
+    expect(screen.getByText("No sparse samples yet.")).toBeInTheDocument();
+  });
+
+  it("invokes CTA action", () => {
+    const onAction = vi.fn();
+    render(
+      <DashboardEmptyPanelShell
+        title="Module"
+        description="Description"
+        actionLabel="Load fallback"
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load fallback" }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/components/v1/PinnedWalletActionTray.test.tsx
+++ b/frontend/tests/components/v1/PinnedWalletActionTray.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PinnedWalletActionTray } from "../../../src/components/v1/PinnedWalletActionTray";
+
+describe("PinnedWalletActionTray", () => {
+  it("renders wallet repeat action buttons", () => {
+    render(
+      <PinnedWalletActionTray
+        actions={[
+          { id: "a", label: "Repeat transfer", onClick: vi.fn() },
+          { id: "b", label: "Reconnect", onClick: vi.fn() },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("pinned-wallet-action-tray")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Repeat transfer" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
+  });
+
+  it("honors disabled states", () => {
+    render(
+      <PinnedWalletActionTray
+        actions={[{ id: "a", label: "Repeat transfer", onClick: vi.fn(), disabled: true }]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Repeat transfer" })).toBeDisabled();
+  });
+
+  it("fires selected action callbacks", () => {
+    const onClick = vi.fn();
+    render(
+      <PinnedWalletActionTray
+        actions={[{ id: "a", label: "Repeat transfer", onClick }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Repeat transfer" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/components/v1/WalletStatusCard.test.tsx
+++ b/frontend/tests/components/v1/WalletStatusCard.test.tsx
@@ -702,6 +702,22 @@ describe("WalletStatusCard", () => {
     });
   });
 
+  describe("Reconnect progress banner", () => {
+    it("renders reconnect-progress banner details while reconnect is pending", () => {
+      renderCard({
+        status: "RECONNECTING",
+        droppedSession: true,
+        reconnectPending: true,
+        reconnectProgress: 42,
+        reconnectProgressLabel: "Re-authorizing wallet session",
+      });
+
+      expect(screen.getByTestId("wallet-reconnect-progress")).toBeInTheDocument();
+      expect(screen.getByText("Re-authorizing wallet session")).toBeInTheDocument();
+      expect(screen.getByText("42%")).toBeInTheDocument();
+    });
+  });
+
   // ── Snapshots ─────────────────────────────────────────────────────────────────
   describe("Snapshots", () => {
     it("matches snapshot for connected state", () => {


### PR DESCRIPTION
## Summary
- add a new campaign/rewards dashboard spotlight card and wire it into the analytics and portfolio flows
- introduce a shared sparse dashboard empty-panel shell for low-data modules and cover it with tests
- extend wallet recovery UX with reconnect progress banner support and add a pinned action tray for repeat wallet operations
- add targeted tests for spotlight card, sparse panel shell, pinned action tray, wallet reconnect progress, and page integration points

## Test plan
- `pnpm install` in `frontend/`
- `pnpm test -- tests/components/v1/CampaignRewardsSpotlightCard.test.tsx tests/components/v1/DashboardEmptyPanelShell.test.tsx tests/components/v1/PinnedWalletActionTray.test.tsx tests/components/v1/WalletStatusCard.test.tsx tests/components/Portfolio.test.tsx tests/components/AnalyticsDashboard.test.tsx`

Closes #617
Closes #618
Closes #619
Closes #620

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Campaign spotlight card displaying active campaigns and pending rewards with action buttons
  * Pinned wallet action tray providing quick access to wallet operations
  * Empty state panels for sparse dashboard modules with customizable actions
  * Reconnect progress indicator during wallet session recovery

* **Tests**
  * Added comprehensive test coverage for new components and enhanced features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->