### PR TITLE
feat: add wallet reconnect context and queued notifications

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,152 +1,59 @@
-import React, { Suspense, lazy } from 'react';
-import GameLobby from './pages/GameLobby';
-import { RouteErrorBoundary } from './components/v1/RouteErrorBoundary';
-import ProfileSettings from './pages/ProfileSettings';
-import Portfolio from './pages/Portfolio';
-import { I18nProvider, useI18n } from './i18n/provider';
-import LocaleSwitcher from './components/LocaleSwitcher';
-import Breadcrumbs from './components/BreadCrumbs';
-import AppSidebar from './components/v1/AppSidebar';
-
-import { ModalStackProvider } from './components/v1/modal-stack';
-import { FeatureFlagsProvider } from './services/feature-flags';
-import CommandPalette, { type Command } from './components/v1/CommandPalette';
-import { BrowserRouter, useNavigate } from 'react-router-dom';
-import { useErrorStore } from './store/errorStore';
+import React, { Suspense, lazy } from "react";
+import { BrowserRouter, useNavigate } from "react-router-dom";
+import GameLobby from "./pages/GameLobby";
+import { RouteErrorBoundary } from "./components/v1/RouteErrorBoundary";
+import ProfileSettings from "./pages/ProfileSettings";
+import Portfolio from "./pages/Portfolio";
+import { I18nProvider, useI18n } from "./i18n/provider";
+import LocaleSwitcher from "./components/LocaleSwitcher";
+import Breadcrumbs from "./components/BreadCrumbs";
+import AppSidebar from "./components/v1/AppSidebar";
+import NotificationCenter from "./components/v1/NotificationCenter";
+import { ModalStackProvider } from "./components/v1/modal-stack";
+import { FeatureFlagsProvider } from "./services/feature-flags";
+import CommandPalette, { type Command } from "./components/v1/CommandPalette";
 
 const DevContractCallSimulatorPanel = import.meta.env.DEV
   ? lazy(() =>
-      import('./components/dev/ContractCallSimulatorPanel').then((m) => ({
-        default: m.ContractCallSimulatorPanel,
+      import("./components/dev/ContractCallSimulatorPanel").then((module) => ({
+        default: module.ContractCallSimulatorPanel,
       })),
     )
   : undefined;
 
-const toneLabelMap = {
-  success: 'Success',
-  info: 'Info',
-  warning: 'Warning',
-  error: 'Error',
-} as const;
+const MAIN_CONTENT_ID = "main-content";
 
-const MAIN_CONTENT_ID = 'main-content';
-
-/* ───────────────── Notification Center ───────────────── */
-
-function NotificationCenter(): React.JSX.Element | null {
-  const toasts = useErrorStore((state) => state.toasts);
-  const toastHistory = useErrorStore((state) => state.toastHistory);
-  const dismissToast = useErrorStore((state) => state.dismissToast);
-  const clearToastHistory = useErrorStore((state) => state.clearToastHistory);
-  const [historyOpen, setHistoryOpen] = React.useState(false);
-
-  if (toasts.length === 0 && toastHistory.length === 0) {
-    return null;
-  }
-
-  return (
-    <aside className="toast-center" aria-label="Notifications">
-      <div className="toast-center__stack">
-        {toasts.map((toast) => (
-          <section
-            key={toast.id}
-            className={`toast-center__toast toast-center__toast--${toast.tone}`}
-            role="status"
-            aria-live="polite"
-          >
-            <div className="toast-center__toast-header">
-              <span className="toast-center__tone">{toneLabelMap[toast.tone]}</span>
-
-              <button
-                type="button"
-                className="toast-center__dismiss"
-                aria-label={`Dismiss ${toast.title}`}
-                onClick={() => dismissToast(toast.id)}
-              >
-                Dismiss
-              </button>
-            </div>
-
-            <strong className="toast-center__title">{toast.title}</strong>
-            <p className="toast-center__message">{toast.message}</p>
-          </section>
-        ))}
-      </div>
-
-      {toastHistory.length > 0 && (
-        <div className="toast-center__history">
-          <button
-            type="button"
-            className="toast-center__history-toggle"
-            aria-expanded={historyOpen}
-            onClick={() => setHistoryOpen((c) => !c)}
-          >
-            {historyOpen ? 'Hide recent notifications' : 'Show recent notifications'}
-          </button>
-
-          {historyOpen && (
-            <div className="toast-center__history-panel">
-              <div className="toast-center__history-header">
-                <strong>Recent notifications</strong>
-
-                <button
-                  type="button"
-                  className="toast-center__history-clear"
-                  onClick={clearToastHistory}
-                >
-                  Clear
-                </button>
-              </div>
-
-              <ul className="toast-center__history-list">
-                {toastHistory.map((toast) => (
-                  <li key={toast.id} className="toast-center__history-item">
-                    <span>{toast.title}</span>
-                    <span>{toast.message}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-      )}
-    </aside>
-  );
-}
-
-/* ───────────────── App Content ───────────────── */
-
-type AppRoute = 'lobby' | 'games' | 'portfolio' | 'profile';
+type AppRoute = "lobby" | "games" | "portfolio" | "profile";
 
 const AppContent: React.FC = () => {
   const { t } = useI18n();
-  const [route, setRoute] = React.useState<AppRoute>('lobby');
+  const [route, setRoute] = React.useState<AppRoute>("lobby");
   const navigate = useNavigate();
 
   const commands: Command[] = [
     {
-      id: 'go-lobby',
-      label: 'Go to Lobby',
-      description: 'Open the game lobby',
-      action: () => navigate('/'),
+      id: "go-lobby",
+      label: "Go to Lobby",
+      description: "Open the game lobby",
+      action: () => navigate("/"),
     },
     {
-      id: 'go-games',
-      label: 'Go to Games',
-      description: 'Open the games section',
-      action: () => setRoute('games'),
+      id: "go-games",
+      label: "Go to Games",
+      description: "Open the games section",
+      action: () => setRoute("games"),
     },
     {
-      id: 'go-profile',
-      label: 'Go to Profile Settings',
-      description: 'Open the profile settings page',
-      action: () => navigate('/profile'),
+      id: "go-profile",
+      label: "Go to Profile Settings",
+      description: "Open the profile settings page",
+      action: () => navigate("/profile"),
     },
     {
-      id: 'go-portfolio',
-      label: 'Go to Portfolio',
-      description: 'Open wallet, rewards, and collectibles',
-      action: () => setRoute('portfolio'),
+      id: "go-portfolio",
+      label: "Go to Portfolio",
+      description: "Open wallet, rewards, and collectibles",
+      action: () => setRoute("portfolio"),
     },
   ];
 
@@ -164,7 +71,7 @@ const AppContent: React.FC = () => {
 
           event.preventDefault();
           mainContent.focus();
-          mainContent.scrollIntoView?.({ block: 'start' });
+          mainContent.scrollIntoView?.({ block: "start" });
         }}
       >
         Skip to main content
@@ -174,7 +81,7 @@ const AppContent: React.FC = () => {
 
       <div className="app-main-layout">
         <header className="app-header">
-          <div className="logo">{t('app.title')}</div>
+          <div className="logo">{t("app.title")}</div>
           <LocaleSwitcher />
         </header>
 
@@ -182,13 +89,13 @@ const AppContent: React.FC = () => {
 
         <main className="app-content" id={MAIN_CONTENT_ID} tabIndex={-1}>
           <RouteErrorBoundary>
-            {route === 'profile' ? (
+            {route === "profile" ? (
               <ProfileSettings />
-            ) : route === 'portfolio' ? (
+            ) : route === "portfolio" ? (
               <Portfolio
-                onOpenWallet={() => setRoute('profile')}
-                onBrowseRewards={() => setRoute('games')}
-                onBrowseCollectibles={() => setRoute('games')}
+                onOpenWallet={() => setRoute("profile")}
+                onBrowseRewards={() => setRoute("games")}
+                onBrowseCollectibles={() => setRoute("games")}
               />
             ) : (
               <GameLobby />
@@ -198,11 +105,11 @@ const AppContent: React.FC = () => {
 
         <footer className="app-footer">
           <div className="footer-content">
-            <p>{t('footer.copyright')}</p>
+            <p>{t("footer.copyright")}</p>
 
             <div className="footer-links">
-              <a href="/terms">{t('footer.terms')}</a>
-              <a href="/privacy">{t('footer.privacy')}</a>
+              <a href="/terms">{t("footer.terms")}</a>
+              <a href="/privacy">{t("footer.privacy")}</a>
             </div>
           </div>
         </footer>
@@ -216,8 +123,6 @@ const AppContent: React.FC = () => {
     </div>
   );
 };
-
-/* ───────────────── App Root ───────────────── */
 
 const App: React.FC = () => {
   return (
@@ -233,6 +138,6 @@ const App: React.FC = () => {
   );
 };
 
-export { Drawer } from './components/v1/Drawer';
+export { Drawer } from "./components/v1/Drawer";
 
 export default App;

--- a/frontend/src/components/v1/NotificationCenter.css
+++ b/frontend/src/components/v1/NotificationCenter.css
@@ -1,0 +1,122 @@
+.toast-center {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1200;
+  width: min(26rem, calc(100vw - 2rem));
+}
+
+.toast-center__panel {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(7, 10, 14, 0.94);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+}
+
+.toast-center__toolbar {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.toast-center__subtitle,
+.toast-center__message,
+.toast-center__empty,
+.toast-center__meta,
+.toast-center__list-item p {
+  margin: 0;
+  color: var(--text-dim, #a0a0a0);
+  line-height: 1.45;
+}
+
+.toast-center__switcher {
+  width: fit-content;
+}
+
+.toast-center__stack,
+.toast-center__list {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.toast-center__toast,
+.toast-center__list-item {
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(10, 14, 18, 0.92);
+}
+
+.toast-center__toast--success {
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.toast-center__toast--info {
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.toast-center__toast--warning {
+  border-color: rgba(245, 158, 11, 0.45);
+}
+
+.toast-center__toast--error {
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.toast-center__toast-header,
+.toast-center__list-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.toast-center__tone {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent, #00ffcc);
+}
+
+.toast-center__title {
+  display: block;
+  margin-top: 0.35rem;
+  margin-bottom: 0.25rem;
+}
+
+.toast-center__dismiss,
+.toast-center__utility,
+.toast-center__list-item button {
+  border: 0;
+  background: transparent;
+  color: var(--text-main, #ffffff);
+  cursor: pointer;
+  font: inherit;
+}
+
+.toast-center__utility {
+  justify-self: flex-start;
+  padding: 0;
+}
+
+.toast-center__history-time {
+  color: var(--text-dim, #a0a0a0);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .toast-center {
+    top: auto;
+    bottom: 1rem;
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+  }
+}

--- a/frontend/src/components/v1/NotificationCenter.tsx
+++ b/frontend/src/components/v1/NotificationCenter.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { useErrorStore } from "../../store/errorStore";
+import { SegmentedControl } from "./SegmentedControl";
+import "./NotificationCenter.css";
+
+type NotificationView = "active" | "deferred" | "history";
+
+const toneLabelMap = {
+  success: "Success",
+  info: "Info",
+  warning: "Warning",
+  error: "Error",
+} as const;
+
+export function NotificationCenter(): React.JSX.Element | null {
+  const toasts = useErrorStore((state) => state.toasts);
+  const deferredToasts = useErrorStore((state) => state.deferredToasts);
+  const toastHistory = useErrorStore((state) => state.toastHistory);
+  const dismissToast = useErrorStore((state) => state.dismissToast);
+  const clearToasts = useErrorStore((state) => state.clearToasts);
+  const clearDeferredToasts = useErrorStore((state) => state.clearDeferredToasts);
+  const clearToastHistory = useErrorStore((state) => state.clearToastHistory);
+  const [view, setView] = React.useState<NotificationView>("active");
+
+  const hasContent =
+    toasts.length > 0 || deferredToasts.length > 0 || toastHistory.length > 0;
+
+  React.useEffect(() => {
+    if (view === "active" && toasts.length > 0) return;
+    if (view === "deferred" && deferredToasts.length > 0) return;
+    if (view === "history" && toastHistory.length > 0) return;
+
+    if (toasts.length > 0) {
+      setView("active");
+    } else if (deferredToasts.length > 0) {
+      setView("deferred");
+    } else if (toastHistory.length > 0) {
+      setView("history");
+    }
+  }, [deferredToasts.length, toastHistory.length, toasts.length, view]);
+
+  if (!hasContent) {
+    return null;
+  }
+
+  return (
+    <aside
+      className="toast-center"
+      aria-label="Notifications"
+      data-testid="notification-center"
+    >
+      <div className="toast-center__panel">
+        <div className="toast-center__toolbar">
+          <div>
+            <strong>Notifications</strong>
+            <p className="toast-center__subtitle">
+              Deferred events wait here until the active stack has room.
+            </p>
+          </div>
+          <SegmentedControl
+            label="Notification views"
+            options={[
+              { value: "active", label: "Active", count: toasts.length },
+              { value: "deferred", label: "Deferred", count: deferredToasts.length },
+              { value: "history", label: "Recent", count: toastHistory.length },
+            ]}
+            value={view}
+            onChange={(nextView) => setView(nextView)}
+            className="toast-center__switcher"
+            testId="notification-center-view"
+          />
+        </div>
+
+        {view === "active" ? (
+          <>
+            {toasts.length > 0 ? (
+              <div className="toast-center__stack">
+                {toasts.map((toast) => (
+                  <section
+                    key={toast.id}
+                    className={`toast-center__toast toast-center__toast--${toast.tone}`}
+                    role="status"
+                    aria-live="polite"
+                  >
+                    <div className="toast-center__toast-header">
+                      <span className="toast-center__tone">
+                        {toneLabelMap[toast.tone]}
+                      </span>
+                      <button
+                        type="button"
+                        className="toast-center__dismiss"
+                        aria-label={`Dismiss ${toast.title}`}
+                        onClick={() => dismissToast(toast.id)}
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                    <strong className="toast-center__title">{toast.title}</strong>
+                    <p className="toast-center__message">{toast.message}</p>
+                  </section>
+                ))}
+              </div>
+            ) : (
+              <p className="toast-center__empty">No active notifications right now.</p>
+            )}
+
+            {deferredToasts.length > 0 ? (
+              <p
+                className="toast-center__meta"
+                data-testid="notification-center-queued-summary"
+              >
+                {deferredToasts.length} deferred event
+                {deferredToasts.length === 1 ? "" : "s"} waiting for display.
+              </p>
+            ) : null}
+
+            {toasts.length > 0 ? (
+              <button
+                type="button"
+                className="toast-center__utility"
+                onClick={clearToasts}
+              >
+                Dismiss active
+              </button>
+            ) : null}
+          </>
+        ) : null}
+
+        {view === "deferred" ? (
+          deferredToasts.length > 0 ? (
+            <>
+              <ul
+                className="toast-center__list"
+                data-testid="notification-center-deferred-list"
+              >
+                {deferredToasts.map((toast) => (
+                  <li key={toast.id} className="toast-center__list-item">
+                    <div>
+                      <strong>{toast.title}</strong>
+                      <p>{toast.message}</p>
+                    </div>
+                    <button type="button" onClick={() => dismissToast(toast.id)}>
+                      Dismiss
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                className="toast-center__utility"
+                onClick={clearDeferredToasts}
+              >
+                Clear deferred
+              </button>
+            </>
+          ) : (
+            <p className="toast-center__empty">No deferred notifications queued.</p>
+          )
+        ) : null}
+
+        {view === "history" ? (
+          toastHistory.length > 0 ? (
+            <>
+              <ul
+                className="toast-center__list"
+                data-testid="notification-center-history-list"
+              >
+                {toastHistory.map((toast) => (
+                  <li key={toast.id} className="toast-center__list-item">
+                    <div>
+                      <strong>{toast.title}</strong>
+                      <p>{toast.message}</p>
+                    </div>
+                    <span className="toast-center__history-time">
+                      {toast.dismissedAt
+                        ? new Date(toast.dismissedAt).toLocaleTimeString()
+                        : "Dismissed"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                className="toast-center__utility"
+                onClick={clearToastHistory}
+              >
+                Clear recent
+              </button>
+            </>
+          ) : (
+            <p className="toast-center__empty">No recent notification history yet.</p>
+          )
+        ) : null}
+      </div>
+    </aside>
+  );
+}
+
+export default NotificationCenter;

--- a/frontend/src/components/v1/PendingActionResumeChip.css
+++ b/frontend/src/components/v1/PendingActionResumeChip.css
@@ -1,0 +1,79 @@
+.pending-action-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  padding: 0.85rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 158, 11, 0.32);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--text-main, #ffffff);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.14);
+  flex-wrap: wrap;
+}
+
+.pending-action-chip__copy {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.pending-action-chip__eyebrow {
+  color: #fbbf24;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pending-action-chip__label {
+  font-size: 0.95rem;
+}
+
+.pending-action-chip__detail {
+  color: var(--text-dim, #a0a0a0);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.pending-action-chip__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pending-action-chip__button {
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.45rem 0.85rem;
+}
+
+.pending-action-chip__button--primary {
+  background: #fbbf24;
+  color: #111827;
+  font-weight: 700;
+}
+
+.pending-action-chip__button--dismiss {
+  background: transparent;
+  color: var(--text-dim, #a0a0a0);
+}
+
+.pending-action-chip__button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+@media (max-width: 640px) {
+  .pending-action-chip {
+    border-radius: 1rem;
+    align-items: flex-start;
+  }
+
+  .pending-action-chip__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/components/v1/PendingActionResumeChip.tsx
+++ b/frontend/src/components/v1/PendingActionResumeChip.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import "./PendingActionResumeChip.css";
+
+export interface PendingActionResumeChipProps {
+  label: string;
+  detail?: string;
+  onResume: () => void;
+  onDismiss?: () => void;
+  disabled?: boolean;
+  className?: string;
+  testId?: string;
+}
+
+export function PendingActionResumeChip({
+  label,
+  detail,
+  onResume,
+  onDismiss,
+  disabled = false,
+  className,
+  testId = "pending-action-resume-chip",
+}: PendingActionResumeChipProps): React.JSX.Element {
+  return (
+    <div
+      className={["pending-action-chip", className].filter(Boolean).join(" ")}
+      role="status"
+      aria-live="polite"
+      data-testid={testId}
+    >
+      <div className="pending-action-chip__copy">
+        <span className="pending-action-chip__eyebrow">Pending action</span>
+        <strong className="pending-action-chip__label">{label}</strong>
+        {detail ? <span className="pending-action-chip__detail">{detail}</span> : null}
+      </div>
+
+      <div className="pending-action-chip__actions">
+        <button
+          type="button"
+          className="pending-action-chip__button pending-action-chip__button--primary"
+          onClick={onResume}
+          disabled={disabled}
+          data-testid={`${testId}-resume-btn`}
+        >
+          {disabled ? "Resuming..." : "Resume"}
+        </button>
+
+        {onDismiss ? (
+          <button
+            type="button"
+            className="pending-action-chip__button pending-action-chip__button--dismiss"
+            onClick={onDismiss}
+            data-testid={`${testId}-dismiss-btn`}
+            aria-label="Dismiss pending action"
+          >
+            Dismiss
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default PendingActionResumeChip;

--- a/frontend/src/components/v1/ResumeTaskBanner.tsx
+++ b/frontend/src/components/v1/ResumeTaskBanner.tsx
@@ -52,3 +52,5 @@ export const ResumeTaskBanner: React.FC<ResumeTaskBannerProps> = ({
     </div>
   );
 };
+
+export default ResumeTaskBanner;

--- a/frontend/src/components/v1/SegmentedControl.css
+++ b/frontend/src/components/v1/SegmentedControl.css
@@ -1,0 +1,49 @@
+.segmented-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  flex-wrap: wrap;
+}
+
+.segmented-control__button {
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-dim, #a0a0a0);
+  cursor: pointer;
+  font: inherit;
+  padding: 0.4rem 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.segmented-control__button:hover,
+.segmented-control__button:focus-visible {
+  color: var(--text-main, #ffffff);
+  outline: none;
+}
+
+.segmented-control__button.is-active {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text-main, #ffffff);
+}
+
+.segmented-control__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.segmented-control__count {
+  min-width: 1.3rem;
+  padding: 0.05rem 0.35rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.24);
+  font-size: 0.76rem;
+  text-align: center;
+}

--- a/frontend/src/components/v1/SegmentedControl.tsx
+++ b/frontend/src/components/v1/SegmentedControl.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "./SegmentedControl.css";
+
+export interface SegmentedControlOption<T extends string> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+  count?: number;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  label: string;
+  options: Array<SegmentedControlOption<T>>;
+  value: T;
+  onChange: (value: T) => void;
+  className?: string;
+  testId?: string;
+}
+
+export function SegmentedControl<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  className,
+  testId = "segmented-control",
+}: SegmentedControlProps<T>): React.JSX.Element {
+  return (
+    <div
+      className={["segmented-control", className].filter(Boolean).join(" ")}
+      role="group"
+      aria-label={label}
+      data-testid={testId}
+    >
+      {options.map((option) => {
+        const isActive = option.value === value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={[
+              "segmented-control__button",
+              isActive ? "is-active" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            aria-pressed={isActive}
+            disabled={option.disabled}
+            onClick={() => onChange(option.value)}
+            data-testid={`${testId}-${option.value}`}
+          >
+            <span>{option.label}</span>
+            {typeof option.count === "number" ? (
+              <span className="segmented-control__count" aria-hidden="true">
+                {option.count}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default SegmentedControl;

--- a/frontend/src/components/v1/index.ts
+++ b/frontend/src/components/v1/index.ts
@@ -108,6 +108,12 @@ export {
 export type { ResumeTaskBannerProps } from "./ResumeTaskBanner";
 
 export {
+  PendingActionResumeChip,
+  default as PendingActionResumeChipDefault,
+} from "./PendingActionResumeChip";
+export type { PendingActionResumeChipProps } from "./PendingActionResumeChip";
+
+export {
   NotificationPreferencesPanel,
   default as NotificationPreferencesPanelDefault,
 } from "./NotificationPreferencesPanel";

--- a/frontend/src/components/v1/index.ts
+++ b/frontend/src/components/v1/index.ts
@@ -88,6 +88,26 @@ export {
 export type { SessionTimeoutModalProps } from "./SessionTimeoutModal";
 
 export {
+  SegmentedControl,
+  default as SegmentedControlDefault,
+} from "./SegmentedControl";
+export type {
+  SegmentedControlOption,
+  SegmentedControlProps,
+} from "./SegmentedControl";
+
+export {
+  NotificationCenter,
+  default as NotificationCenterDefault,
+} from "./NotificationCenter";
+
+export {
+  ResumeTaskBanner,
+  default as ResumeTaskBannerDefault,
+} from "./ResumeTaskBanner";
+export type { ResumeTaskBannerProps } from "./ResumeTaskBanner";
+
+export {
   NotificationPreferencesPanel,
   default as NotificationPreferencesPanelDefault,
 } from "./NotificationPreferencesPanel";

--- a/frontend/src/hooks/v1/useWalletStatus.ts
+++ b/frontend/src/hooks/v1/useWalletStatus.ts
@@ -1,31 +1,21 @@
-/**
- * useWalletStatus — unified wallet connection state hook (v1).
- *
- * Wraps WalletSessionService and exposes a normalized WalletStatus,
- * capability flags, typed error info, and action callbacks.
- *
- * @module hooks/v1/useWalletStatus
- */
-
-import { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import WalletSessionService, {
   WalletProviderAdapter,
 } from "../../services/wallet-session-service";
 import {
-  WalletSessionState,
-  WalletSessionError,
   ProviderNotFoundError,
   RejectedSignatureError,
   StaleSessionError,
+  WalletSessionError,
+  WalletSessionRefreshPhase,
+  WalletSessionState,
 } from "../../types/wallet-session";
-import type { WalletSessionMeta, WalletProviderInfo } from "../../types/wallet-session";
+import type {
+  WalletSessionMeta,
+  WalletProviderInfo,
+  WalletSessionRefreshState,
+} from "../../types/wallet-session";
 
-// ── Public types ───────────────────────────────────────────────────────────────
-
-/**
- * Normalized wallet status that extends the internal session state with
- * specific error states so consumers can react without inspecting raw errors.
- */
 export type WalletStatus =
   | "DISCONNECTED"
   | "CONNECTING"
@@ -36,20 +26,16 @@ export type WalletStatus =
   | "STALE_SESSION"
   | "ERROR";
 
-/** Derived boolean flags for common UI conditions. */
 export interface WalletCapabilities {
   isConnected: boolean;
   isConnecting: boolean;
   isReconnecting: boolean;
-  /** True when it makes sense to offer a connect action to the user. */
   canConnect: boolean;
 }
 
-/** Typed error surface exposed by the hook. */
 export interface WalletStatusError {
   code: string;
   message: string;
-  /** Whether retrying (e.g. re-connecting) may resolve the error. */
   recoverable: boolean;
 }
 
@@ -60,20 +46,18 @@ export interface UseWalletStatusReturn {
   provider: WalletProviderInfo | null;
   capabilities: WalletCapabilities;
   error: WalletStatusError | null;
-  /** Timestamp (ms since epoch) of the last successful balance/session refresh. */
   lastUpdatedAt: number | null;
-  /** True while a manual refresh triggered by the user is in progress. */
   isRefreshing: boolean;
+  refreshState: WalletSessionRefreshState;
+  sessionDropped: boolean;
+  lastReconnectAt: number | null;
   connect: (
     adapter?: WalletProviderAdapter,
     opts?: { network?: string },
   ) => Promise<void>;
   disconnect: () => Promise<void>;
-  /** Re-validates and restores a stored session (wraps service.reconnect). */
   refresh: () => Promise<void>;
 }
-
-// ── Internal helpers ───────────────────────────────────────────────────────────
 
 function deriveStatus(
   sessionState: WalletSessionState,
@@ -87,7 +71,6 @@ function deriveStatus(
     case WalletSessionState.RECONNECTING:
       return "RECONNECTING";
     default:
-      // DISCONNECTED — refine with error type
       if (!error) return "DISCONNECTED";
       if (error instanceof ProviderNotFoundError) return "PROVIDER_MISSING";
       if (error instanceof RejectedSignatureError) return "PERMISSION_DENIED";
@@ -131,30 +114,6 @@ function mapToStatusError(error: Error | null): WalletStatusError | null {
   };
 }
 
-// ── Hook ───────────────────────────────────────────────────────────────────────
-
-/**
- * Unified wallet connection state hook.
- *
- * @param service - Optional pre-constructed WalletSessionService. When omitted
- *   a new instance is created and owned by the hook.
- *
- * @example
- * ```tsx
- * function WalletButton() {
- *   const { status, address, capabilities, connect, disconnect } = useWalletStatus();
- *
- *   if (capabilities.isConnected) {
- *     return <button onClick={disconnect}>Disconnect {address}</button>;
- *   }
- *   return (
- *     <button disabled={!capabilities.canConnect} onClick={() => connect(freighterAdapter)}>
- *       Connect Wallet
- *     </button>
- *   );
- * }
- * ```
- */
 export function useWalletStatus(
   service?: WalletSessionService,
 ): UseWalletStatusReturn {
@@ -174,16 +133,41 @@ export function useWalletStatus(
     svcRef.current.getMeta()?.lastActiveAt ?? null,
   );
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshState, setRefreshState] = useState<WalletSessionRefreshState>(
+    svcRef.current.getRefreshState(),
+  );
+  const [sessionDropped, setSessionDropped] = useState(
+    svcRef.current.getSessionDropped(),
+  );
+  const [lastReconnectAt, setLastReconnectAt] = useState<number | null>(
+    svcRef.current.getRefreshState().lastSucceededAt ?? null,
+  );
 
   useEffect(() => {
-    const unsubscribe = svcRef.current!.subscribe((s, m, e) => {
-      setSessionState(s);
-      setMeta(m ?? null);
-      setError(e ?? null);
-      if (m?.lastActiveAt) {
-        setLastUpdatedAt(m.lastActiveAt);
-      }
-    });
+    const unsubscribe = svcRef.current!.subscribe(
+      (state, nextMeta, nextError, nextRefreshState, dropped) => {
+        setSessionState(state);
+        setMeta(nextMeta ?? null);
+        setError(nextError ?? null);
+        setSessionDropped(Boolean(dropped));
+
+        if (nextRefreshState) {
+          setRefreshState(nextRefreshState);
+          if (
+            nextRefreshState.trigger === "manual" &&
+            nextRefreshState.phase === WalletSessionRefreshPhase.IDLE &&
+            typeof nextRefreshState.lastSucceededAt === "number"
+          ) {
+            setLastReconnectAt(nextRefreshState.lastSucceededAt);
+          }
+        }
+
+        if (nextMeta?.lastActiveAt) {
+          setLastUpdatedAt(nextMeta.lastActiveAt);
+        }
+      },
+    );
+
     return () => unsubscribe();
   }, []);
 
@@ -191,9 +175,7 @@ export function useWalletStatus(
     () => deriveStatus(sessionState, error),
     [sessionState, error],
   );
-
   const capabilities = useMemo(() => deriveCapabilities(status), [status]);
-
   const statusError = useMemo(() => mapToStatusError(error), [error]);
 
   const connect = useCallback(
@@ -201,7 +183,9 @@ export function useWalletStatus(
       adapter?: WalletProviderAdapter,
       opts?: { network?: string },
     ): Promise<void> => {
-      if (adapter) svcRef.current!.setProviderAdapter(adapter);
+      if (adapter) {
+        svcRef.current!.setProviderAdapter(adapter);
+      }
       await svcRef.current!.connect(opts);
     },
     [],
@@ -230,6 +214,9 @@ export function useWalletStatus(
     error: statusError,
     lastUpdatedAt,
     isRefreshing,
+    refreshState,
+    sessionDropped,
+    lastReconnectAt,
     connect,
     disconnect,
     refresh,

--- a/frontend/src/pages/GameLobby.tsx
+++ b/frontend/src/pages/GameLobby.tsx
@@ -11,6 +11,7 @@ import { commandStore } from "../components/v1/CommandPalette";
 import { DashboardMissionStrip } from "../components/v1/DashboardMissionStrip";
 import { QuickActionSurface } from "../components/v1/QuickActionSurface";
 import { RecoverableErrorPanel } from "../components/v1/RecoverableErrorPanel";
+import { PendingActionResumeChip } from "../components/v1/PendingActionResumeChip";
 import { ResumeTaskBanner } from "../components/v1/ResumeTaskBanner";
 import { SegmentedControl } from "../components/v1/SegmentedControl";
 import { WalletSessionActivityRail } from "../components/v1/WalletSessionActivityRail";
@@ -131,6 +132,7 @@ export const GameLobby: React.FC = () => {
   );
   const [pendingResumeContext, setPendingResumeContext] =
     useState<LobbyContext | null>(null);
+  const [pendingActionChipDismissed, setPendingActionChipDismissed] = useState(false);
   const wallet = useWalletStatus();
   const globalStoreRef = useRef<GlobalStateStore | null>(null);
   const walletSectionRef = useRef<HTMLDivElement | null>(null);
@@ -252,6 +254,12 @@ export const GameLobby: React.FC = () => {
       setPendingTransaction(state.pendingTransaction ?? null);
     });
   }, []);
+
+  useEffect(() => {
+    if (pendingTransaction) {
+      setPendingActionChipDismissed(false);
+    }
+  }, [pendingTransaction?.txHash, pendingTransaction?.updatedAt]);
 
   const retryNetworkCheck = useCallback(async () => {
     if (networkCheckPending) return;
@@ -685,6 +693,19 @@ export const GameLobby: React.FC = () => {
               onDismiss={() => setPendingResumeContext(null)}
               className="lobby-resume-banner"
               testId="lobby-resume-context-banner"
+            />
+          ) : null}
+
+          {pendingTransaction && !isTransactionDrawerOpen && !pendingActionChipDismissed ? (
+            <PendingActionResumeChip
+              label={pendingTransaction.operation.replace(/\./g, " ")}
+              detail={`${pendingTransaction.phase.toLowerCase().replace(/_/g, " ")} in progress`}
+              onResume={() => {
+                setIsTransactionDrawerOpen(true);
+                setPendingActionChipDismissed(false);
+              }}
+              onDismiss={() => setPendingActionChipDismissed(true)}
+              testId="lobby-pending-action-chip"
             />
           ) : null}
 

--- a/frontend/src/pages/GameLobby.tsx
+++ b/frontend/src/pages/GameLobby.tsx
@@ -1,6 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ApiClient } from "../services/typed-api-sdk";
-import { Game } from "../types/api-client";
 import StatusCard from "../components/v1/StatusCard";
 import NetworkGuardBanner from "../components/v1/NetworkGuardBanner";
 import WalletStatusCard from "../components/v1/WalletStatusCard";
@@ -13,21 +11,39 @@ import { commandStore } from "../components/v1/CommandPalette";
 import { DashboardMissionStrip } from "../components/v1/DashboardMissionStrip";
 import { QuickActionSurface } from "../components/v1/QuickActionSurface";
 import { RecoverableErrorPanel } from "../components/v1/RecoverableErrorPanel";
+import { ResumeTaskBanner } from "../components/v1/ResumeTaskBanner";
+import { SegmentedControl } from "../components/v1/SegmentedControl";
 import { WalletSessionActivityRail } from "../components/v1/WalletSessionActivityRail";
-import { isSupportedNetwork } from "../utils/v1/useNetworkGuard";
 import { useWalletStatus } from "../hooks/v1/useWalletStatus";
+import { ApiClient } from "../services/typed-api-sdk";
 import GlobalStateStore, {
-  ONBOARDING_CHECKLIST_DISMISSED_FLAG,
   getTableDensityPreference,
+  ONBOARDING_CHECKLIST_DISMISSED_FLAG,
   persistTableDensityPreference,
   type TableDensityPreference,
 } from "../services/global-state-store";
+import { isSupportedNetwork } from "../utils/v1/useNetworkGuard";
+import type { Game } from "../types/api-client";
 import type { PendingTransactionSnapshot } from "../types/global-state";
 import "./GameLobbyDashboard.css";
 
 const DASHBOARD_DENSITY_SCOPE = "dashboard-surfaces";
 const DASHBOARD_COMMAND_SURFACE_USED_KEY = "stc_dashboard_command_surface_used_v1";
 const DASHBOARD_SESSION_KEY = "stc_dashboard_session_seen_v1";
+const DASHBOARD_LAST_CONTEXT_KEY = "stc_dashboard_last_context_v1";
+
+type LobbyContext =
+  | "wallet-panel"
+  | "live-arena"
+  | "leaderboard"
+  | "activity-rail";
+
+const LOBBY_CONTEXT_LABELS: Record<LobbyContext, string> = {
+  "wallet-panel": "Wallet and network status",
+  "live-arena": "Live Arena",
+  leaderboard: "Active Games Leaderboard",
+  "activity-rail": "Wallet activity rail",
+};
 
 interface LeaderboardRow {
   rank: number;
@@ -54,6 +70,28 @@ function formatPendingTxLabel(
     return "No pending tx";
   }
   return pendingTransaction.phase.replace(/_/g, " ");
+}
+
+function readStoredLobbyContext(): LobbyContext | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const stored = sessionStorage.getItem(DASHBOARD_LAST_CONTEXT_KEY);
+    if (
+      stored === "wallet-panel" ||
+      stored === "live-arena" ||
+      stored === "leaderboard" ||
+      stored === "activity-rail"
+    ) {
+      return stored;
+    }
+  } catch {
+    // no-op
+  }
+
+  return null;
 }
 
 export const GameLobby: React.FC = () => {
@@ -91,11 +129,16 @@ export const GameLobby: React.FC = () => {
   const [tableDensity, setTableDensity] = useState<TableDensityPreference>(() =>
     getTableDensityPreference(DASHBOARD_DENSITY_SCOPE),
   );
+  const [pendingResumeContext, setPendingResumeContext] =
+    useState<LobbyContext | null>(null);
   const wallet = useWalletStatus();
   const globalStoreRef = useRef<GlobalStateStore | null>(null);
   const walletSectionRef = useRef<HTMLDivElement | null>(null);
   const gamesSectionRef = useRef<HTMLElement | null>(null);
   const activityRailRef = useRef<HTMLDivElement | null>(null);
+  const leaderboardSectionRef = useRef<HTMLElement | null>(null);
+  const previousWalletStatusRef = useRef(wallet.status);
+  const previousReconnectAtRef = useRef(wallet.lastReconnectAt);
 
   if (!globalStoreRef.current) {
     globalStoreRef.current = new GlobalStateStore();
@@ -124,6 +167,7 @@ export const GameLobby: React.FC = () => {
 
   const networkMismatch =
     wallet.capabilities.isConnected && !networkSupport.isSupported;
+
   const walletDiagnostics = useMemo(
     () => [
       {
@@ -148,6 +192,10 @@ export const GameLobby: React.FC = () => {
         tone: networkCheckPending ? ("warning" as const) : ("neutral" as const),
       },
       {
+        label: "Reconnect phase",
+        value: wallet.refreshState.phase.toLowerCase().replace(/_/g, " "),
+      },
+      {
         label: "Last wallet sync",
         value: wallet.lastUpdatedAt
           ? new Date(wallet.lastUpdatedAt).toLocaleTimeString()
@@ -159,7 +207,8 @@ export const GameLobby: React.FC = () => {
       networkSupport.isSupported,
       networkSupport.normalizedActual,
       wallet.lastUpdatedAt,
-      wallet.provider,
+      wallet.provider?.name,
+      wallet.refreshState.phase,
     ],
   );
 
@@ -212,7 +261,7 @@ export const GameLobby: React.FC = () => {
     } finally {
       setNetworkCheckPending(false);
     }
-  }, [wallet, networkCheckPending]);
+  }, [networkCheckPending, wallet]);
 
   const recoverNetwork = useCallback(async () => {
     await retryNetworkCheck();
@@ -221,6 +270,39 @@ export const GameLobby: React.FC = () => {
   const scrollToElement = useCallback((element: HTMLElement | null) => {
     element?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
+
+  const persistLobbyContext = useCallback((context: LobbyContext) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    try {
+      sessionStorage.setItem(DASHBOARD_LAST_CONTEXT_KEY, context);
+    } catch {
+      // no-op
+    }
+  }, []);
+
+  const scrollToContext = useCallback(
+    (context: LobbyContext) => {
+      persistLobbyContext(context);
+
+      switch (context) {
+        case "wallet-panel":
+          scrollToElement(walletSectionRef.current);
+          break;
+        case "live-arena":
+          scrollToElement(gamesSectionRef.current);
+          break;
+        case "leaderboard":
+          scrollToElement(leaderboardSectionRef.current);
+          break;
+        case "activity-rail":
+          scrollToElement(activityRailRef.current);
+          break;
+      }
+    },
+    [persistLobbyContext, scrollToElement],
+  );
 
   const markQuickActionsUsed = useCallback(() => {
     setQuickActionsUsed(true);
@@ -316,10 +398,31 @@ export const GameLobby: React.FC = () => {
     [activeGames.length, totalPrizeSignal],
   );
 
-  const handleDensityChange = useCallback((density: TableDensityPreference) => {
-    setTableDensity(density);
-    persistTableDensityPreference(DASHBOARD_DENSITY_SCOPE, density);
-  }, []);
+  const handleDensityChange = useCallback(
+    (density: TableDensityPreference) => {
+      setTableDensity(density);
+      persistTableDensityPreference(DASHBOARD_DENSITY_SCOPE, density);
+      persistLobbyContext("leaderboard");
+    },
+    [persistLobbyContext],
+  );
+
+  useEffect(() => {
+    const previousStatus = previousWalletStatusRef.current;
+    const previousReconnectAt = previousReconnectAtRef.current;
+
+    if (
+      previousStatus === "RECONNECTING" &&
+      wallet.status === "CONNECTED" &&
+      wallet.lastReconnectAt !== null &&
+      wallet.lastReconnectAt !== previousReconnectAt
+    ) {
+      setPendingResumeContext(readStoredLobbyContext());
+    }
+
+    previousWalletStatusRef.current = wallet.status;
+    previousReconnectAtRef.current = wallet.lastReconnectAt;
+  }, [wallet.lastReconnectAt, wallet.status]);
 
   const missionItems = useMemo(
     () => [
@@ -330,7 +433,7 @@ export const GameLobby: React.FC = () => {
           "Open the wallet panel to connect or verify the current network before you start a match.",
         complete: wallet.capabilities.isConnected,
         actionLabel: "Open wallet panel",
-        onAction: () => scrollToElement(walletSectionRef.current),
+        onAction: () => scrollToContext("wallet-panel"),
       },
       {
         id: "scan-live-games",
@@ -339,7 +442,7 @@ export const GameLobby: React.FC = () => {
           "Jump to the active game grid and confirm which matches are open right now.",
         complete: games.length > 0,
         actionLabel: "Jump to games",
-        onAction: () => scrollToElement(gamesSectionRef.current),
+        onAction: () => scrollToContext("live-arena"),
       },
       {
         id: "learn-commands",
@@ -355,7 +458,7 @@ export const GameLobby: React.FC = () => {
       games.length,
       openCommandCenter,
       quickActionsUsed,
-      scrollToElement,
+      scrollToContext,
       wallet.capabilities.isConnected,
     ],
   );
@@ -375,7 +478,7 @@ export const GameLobby: React.FC = () => {
         description: "Jump to wallet status, provider details, and network diagnostics.",
         onSelect: () => {
           markQuickActionsUsed();
-          scrollToElement(walletSectionRef.current);
+          scrollToContext("wallet-panel");
         },
       },
       {
@@ -391,11 +494,11 @@ export const GameLobby: React.FC = () => {
         description: "Review the latest wallet-session sync, tx, and lobby refresh events.",
         onSelect: () => {
           markQuickActionsUsed();
-          scrollToElement(activityRailRef.current);
+          scrollToContext("activity-rail");
         },
       },
     ],
-    [handleRefreshLobby, markQuickActionsUsed, openCommandCenter, retrying, scrollToElement],
+    [handleRefreshLobby, markQuickActionsUsed, openCommandCenter, retrying, scrollToContext],
   );
 
   const activityItems = useMemo(() => {
@@ -507,7 +610,7 @@ export const GameLobby: React.FC = () => {
         retryDisabled={retrying}
         secondaryAction={{
           label: "Review wallet panel",
-          onClick: () => scrollToElement(walletSectionRef.current),
+          onClick: () => scrollToContext("wallet-panel"),
         }}
         testId="lobby-error"
       />
@@ -524,10 +627,7 @@ export const GameLobby: React.FC = () => {
         />
       ) : null}
 
-      <section
-        aria-label="Wallet and network status"
-        className="lobby-dashboard"
-      >
+      <section aria-label="Wallet and network status" className="lobby-dashboard">
         <div className="lobby-dashboard__col" ref={walletSectionRef}>
           <NetworkGuardBanner
             network={wallet.network}
@@ -552,6 +652,11 @@ export const GameLobby: React.FC = () => {
             onConnect={() => wallet.connect()}
             onDisconnect={wallet.disconnect}
             onRetry={wallet.refresh}
+            onReconnect={wallet.refresh}
+            droppedSession={wallet.sessionDropped}
+            reconnectPending={wallet.status === "RECONNECTING"}
+            reconnectProgress={wallet.status === "RECONNECTING" ? 65 : 0}
+            reconnectProgressLabel="Restoring your wallet session"
             networkMismatch={networkMismatch}
             networkRecoveryPending={networkCheckPending}
             onRecoverNetwork={recoverNetwork}
@@ -569,6 +674,19 @@ export const GameLobby: React.FC = () => {
           </div>
 
           <QuickActionSurface actions={quickActions} />
+
+          {pendingResumeContext ? (
+            <ResumeTaskBanner
+              taskName={LOBBY_CONTEXT_LABELS[pendingResumeContext]}
+              onResume={() => {
+                scrollToContext(pendingResumeContext);
+                setPendingResumeContext(null);
+              }}
+              onDismiss={() => setPendingResumeContext(null)}
+              className="lobby-resume-banner"
+              testId="lobby-resume-context-banner"
+            />
+          ) : null}
 
           <div className="lobby-kpi-strip" data-testid="lobby-kpi-strip">
             <StatusCard
@@ -637,9 +755,7 @@ export const GameLobby: React.FC = () => {
               compact={true}
               state={prizePoolState}
               statusLabel={
-                prizePoolState
-                  ? "Prize pool signal live"
-                  : "Awaiting prize-pool data"
+                prizePoolState ? "Prize pool signal live" : "Awaiting prize-pool data"
               }
               footerMeta={
                 activeGames.length > 0
@@ -683,36 +799,23 @@ export const GameLobby: React.FC = () => {
           <section
             aria-labelledby="leaderboard-heading"
             className="leaderboard-section"
+            ref={leaderboardSectionRef}
           >
             <SectionHeader
               titleId="leaderboard-heading"
               title="Active Games Leaderboard"
               description="Switch between standard and compact density to scan live tables faster."
               actions={
-                <div
-                  className="density-toggle"
-                  role="group"
-                  aria-label="Table density"
-                >
-                  <button
-                    type="button"
-                    className={`density-toggle__button ${tableDensity === "standard" ? "is-active" : ""}`.trim()}
-                    onClick={() => handleDensityChange("standard")}
-                    aria-pressed={tableDensity === "standard"}
-                    data-testid="leaderboard-density-standard"
-                  >
-                    Standard
-                  </button>
-                  <button
-                    type="button"
-                    className={`density-toggle__button ${tableDensity === "compact" ? "is-active" : ""}`.trim()}
-                    onClick={() => handleDensityChange("compact")}
-                    aria-pressed={tableDensity === "compact"}
-                    data-testid="leaderboard-density-compact"
-                  >
-                    Compact
-                  </button>
-                </div>
+                <SegmentedControl
+                  label="Table density"
+                  value={tableDensity}
+                  onChange={handleDensityChange}
+                  options={[
+                    { value: "standard", label: "Standard" },
+                    { value: "compact", label: "Compact" },
+                  ]}
+                  testId="leaderboard-density"
+                />
               }
             />
 

--- a/frontend/src/pages/GameLobbyDashboard.css
+++ b/frontend/src/pages/GameLobbyDashboard.css
@@ -239,6 +239,10 @@
   margin-top: 1rem;
 }
 
+.lobby-resume-banner {
+  margin-top: 1rem;
+}
+
 @media (max-width: 600px) {
   .dashboard-mission-strip__header,
   .quick-action-surface__header,

--- a/frontend/src/store/errorStore.ts
+++ b/frontend/src/store/errorStore.ts
@@ -13,6 +13,8 @@ import type { AppError } from '../types/errors';
 /** Maximum number of errors retained in history before the oldest is dropped. */
 const MAX_HISTORY = 50;
 const MAX_TOAST_HISTORY = 20;
+const MAX_ACTIVE_TOASTS = 3;
+const MAX_DEFERRED_TOASTS = 12;
 const DEFAULT_TOAST_DURATION_MS = 5000;
 
 export type ToastTone = 'success' | 'info' | 'warning' | 'error';
@@ -46,6 +48,8 @@ interface ErrorState {
   history: AppError[];
   /** Active toast notifications in display order. */
   toasts: ToastNotification[];
+  /** Deferred notifications waiting for an open slot in the active stack. */
+  deferredToasts: ToastNotification[];
   /** Recently dismissed notifications, newest first, capped at MAX_TOAST_HISTORY. */
   toastHistory: ToastNotification[];
   /** Record an error as current and prepend it to history. */
@@ -60,6 +64,8 @@ interface ErrorState {
   dismissToast: (id: string) => void;
   /** Clears all active toasts and any pending dismiss timers. */
   clearToasts: () => void;
+  /** Clears deferred notifications without promoting them. */
+  clearDeferredToasts: () => void;
   /** Clears dismissed toast history. */
   clearToastHistory: () => void;
 }
@@ -68,6 +74,7 @@ export const useErrorStore = create<ErrorState>()((set) => ({
   current: null,
   history: [],
   toasts: [],
+  deferredToasts: [],
   toastHistory: [],
 
   setError: (error) =>
@@ -79,13 +86,13 @@ export const useErrorStore = create<ErrorState>()((set) => ({
         source: error.domain,
         durationMs: DEFAULT_TOAST_DURATION_MS,
       });
-      scheduleToastDismissal(toast.id, toast.durationMs);
+      const nextToastState = appendToast(state, toast);
 
       return {
         current: error,
         // Prepend newest; cap at MAX_HISTORY to bound memory usage.
         history: [error, ...state.history].slice(0, MAX_HISTORY),
-        toasts: [...state.toasts, toast],
+        ...nextToastState,
       };
     }),
 
@@ -95,39 +102,70 @@ export const useErrorStore = create<ErrorState>()((set) => ({
 
   enqueueToast: (toastInput) => {
     const toast = createToast(toastInput);
-    scheduleToastDismissal(toast.id, toast.durationMs);
-    set((state) => ({
-      toasts: [...state.toasts, toast],
-    }));
+    set((state) => appendToast(state, toast));
     return toast.id;
   },
 
   dismissToast: (id) =>
     set((state) => {
       const toast = state.toasts.find((entry) => entry.id === id);
-      if (!toast) {
+      const deferredToast = state.deferredToasts.find((entry) => entry.id === id);
+      if (!toast && !deferredToast) {
         clearDismissalTimer(id);
         return state;
       }
 
       clearDismissalTimer(id);
+      const remainingActive = toast
+        ? state.toasts.filter((entry) => entry.id !== id)
+        : state.toasts;
+      const remainingDeferred = deferredToast
+        ? state.deferredToasts.filter((entry) => entry.id !== id)
+        : state.deferredToasts;
+      const promoted = !deferredToast ? remainingDeferred[0] : undefined;
+
+      if (promoted) {
+        scheduleToastDismissal(promoted.id, promoted.durationMs);
+      }
+
       return {
-        toasts: state.toasts.filter((entry) => entry.id !== id),
-        toastHistory: [{ ...toast, dismissedAt: Date.now() }, ...state.toastHistory].slice(
-          0,
-          MAX_TOAST_HISTORY,
-        ),
+        toasts: promoted ? [...remainingActive, promoted] : remainingActive,
+        deferredToasts: promoted ? remainingDeferred.slice(1) : remainingDeferred,
+        toastHistory: [
+          { ...(toast ?? deferredToast)!, dismissedAt: Date.now() },
+          ...state.toastHistory,
+        ].slice(0, MAX_TOAST_HISTORY),
       };
     }),
 
   clearToasts: () =>
     set((state) => {
       state.toasts.forEach((toast) => clearDismissalTimer(toast.id));
-      return { toasts: [] };
+      return { toasts: [], deferredToasts: [] };
     }),
+
+  clearDeferredToasts: () => set({ deferredToasts: [] }),
 
   clearToastHistory: () => set({ toastHistory: [] }),
 }));
+
+function appendToast(
+  state: Pick<ErrorState, "toasts" | "deferredToasts">,
+  toast: ToastNotification,
+) {
+  if (state.toasts.length < MAX_ACTIVE_TOASTS) {
+    scheduleToastDismissal(toast.id, toast.durationMs);
+    return {
+      toasts: [...state.toasts, toast],
+      deferredToasts: state.deferredToasts,
+    };
+  }
+
+  return {
+    toasts: state.toasts,
+    deferredToasts: [...state.deferredToasts, toast].slice(-MAX_DEFERRED_TOASTS),
+  };
+}
 
 function createToast(toast: ToastInput): ToastNotification {
   toastCounter += 1;

--- a/frontend/tests/components/GameLobby.test.tsx
+++ b/frontend/tests/components/GameLobby.test.tsx
@@ -200,4 +200,68 @@ describe("GameLobby", () => {
     fireEvent.click(screen.getByTestId("lobby-resume-context-banner-dismiss-btn"));
     expect(screen.queryByTestId("lobby-resume-context-banner")).not.toBeInTheDocument();
   });
+
+  it("shows a pending-action resume chip for interrupted transaction flows", async () => {
+    localStorage.setItem(
+      "stc_global_state_v1",
+      JSON.stringify({
+        auth: { isAuthenticated: false },
+        flags: {},
+        pendingTransaction: {
+          operation: "wallet.deposit",
+          phase: "SUBMITTING",
+          txHash: "abc1234567890",
+          startedAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_500,
+        },
+        storedAt: Date.now(),
+      }),
+    );
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [{ id: "g1", name: "Game One", status: "active", wager: 25 }],
+    });
+
+    render(<GameLobby />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("lobby-pending-action-chip")).toHaveTextContent(
+        /wallet deposit/i,
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("lobby-pending-action-chip-resume-btn"));
+    expect(screen.getByTestId("transaction-detail-drawer")).toBeInTheDocument();
+  });
+
+  it("lets the user dismiss the pending-action chip", async () => {
+    localStorage.setItem(
+      "stc_global_state_v1",
+      JSON.stringify({
+        auth: { isAuthenticated: false },
+        flags: {},
+        pendingTransaction: {
+          operation: "wallet.deposit",
+          phase: "SUBMITTING",
+          txHash: "abc1234567890",
+          startedAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_500,
+        },
+        storedAt: Date.now(),
+      }),
+    );
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [{ id: "g1", name: "Game One", status: "active", wager: 25 }],
+    });
+
+    render(<GameLobby />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("lobby-pending-action-chip")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("lobby-pending-action-chip-dismiss-btn"));
+    expect(screen.queryByTestId("lobby-pending-action-chip")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/GameLobby.test.tsx
+++ b/frontend/tests/components/GameLobby.test.tsx
@@ -2,25 +2,43 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
 import { commandStore } from "../../src/components/v1/CommandPalette";
 import GameLobby from "../../src/pages/GameLobby";
-import { ApiClient } from "../../src/services/typed-api-sdk";
 import { ONBOARDING_CHECKLIST_DISMISSED_FLAG } from "../../src/services/global-state-store";
+import { ApiClient } from "../../src/services/typed-api-sdk";
 
 vi.mock("../../src/services/typed-api-sdk");
-vi.mock("../../src/hooks/v1/useWalletStatus", () => ({
-  useWalletStatus: () => ({
-    status: "disconnected",
-    address: null,
-    network: null,
-    provider: null,
-    capabilities: { isConnected: false },
-    error: null,
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    refresh: vi.fn(),
-    isRefreshing: false,
-    lastUpdatedAt: null,
-  }),
+
+const walletState = vi.hoisted(() => ({
+  status: "DISCONNECTED",
+  address: null,
+  network: null,
+  provider: null,
+  capabilities: {
+    isConnected: false,
+    isConnecting: false,
+    isReconnecting: false,
+    canConnect: true,
+  },
+  error: null,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  refresh: vi.fn(),
+  isRefreshing: false,
+  lastUpdatedAt: null,
+  refreshState: {
+    phase: "IDLE",
+    trigger: "silent",
+    attempt: 0,
+    maxAttempts: 1,
+    terminal: false,
+  },
+  sessionDropped: false,
+  lastReconnectAt: null as number | null,
 }));
+
+vi.mock("../../src/hooks/v1/useWalletStatus", () => ({
+  useWalletStatus: () => walletState,
+}));
+
 vi.mock("../../src/utils/v1/useNetworkGuard", () => ({
   isSupportedNetwork: () => ({
     isSupported: true,
@@ -33,16 +51,37 @@ beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
   commandStore.dispatch({ type: "COMMAND_PALETTE_CLOSE" });
+  walletState.status = "DISCONNECTED";
+  walletState.address = null;
+  walletState.network = null;
+  walletState.provider = null;
+  walletState.capabilities = {
+    isConnected: false,
+    isConnecting: false,
+    isReconnecting: false,
+    canConnect: true,
+  };
+  walletState.error = null;
+  walletState.connect = vi.fn();
+  walletState.disconnect = vi.fn();
+  walletState.refresh = vi.fn();
+  walletState.isRefreshing = false;
+  walletState.lastUpdatedAt = null;
+  walletState.refreshState = {
+    phase: "IDLE",
+    trigger: "silent",
+    attempt: 0,
+    maxAttempts: 1,
+    terminal: false,
+  };
+  walletState.sessionDropped = false;
+  walletState.lastReconnectAt = null;
 });
 
 test("renders GameLobby and fetches games", async () => {
-  const mockGames = [
-    { id: "123456789", name: "Elite Clash", status: "active", wager: 50 },
-  ];
-
   (ApiClient as any).prototype.getGames.mockResolvedValue({
     success: true,
-    data: mockGames,
+    data: [{ id: "123456789", name: "Elite Clash", status: "active", wager: 50 }],
   });
 
   render(<GameLobby />);
@@ -56,95 +95,7 @@ test("renders GameLobby and fetches games", async () => {
   });
 });
 
-describe("GameLobby layout", () => {
-  it("renders the lobby dashboard container", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [],
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(container.querySelector(".lobby-dashboard")).toBeTruthy();
-    });
-  });
-
-  it("renders two dashboard columns", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [],
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(container.querySelectorAll(".lobby-dashboard__col").length).toBe(2);
-    });
-  });
-
-  it("renders the games grid when games are present", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [{ id: "abc123", name: "Test Game", status: "active", wager: 10 }],
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(container.querySelector(".games-grid")).toBeTruthy();
-    });
-  });
-
-  it("renders empty state when no games", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [],
-    });
-
-    render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/No games active/i)).toBeDefined();
-    });
-  });
-
-  it("renders KPI cards with full metric data", async () => {
-    localStorage.setItem(
-      "stc_global_state_v1",
-      JSON.stringify({
-        auth: { isAuthenticated: false },
-        flags: {},
-        pendingTransaction: {
-          operation: "wallet.deposit",
-          phase: "SUBMITTING",
-          txHash: "abc1234567890",
-          startedAt: 1_700_000_000_000,
-          updatedAt: 1_700_000_000_000,
-        },
-        storedAt: Date.now(),
-      }),
-    );
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [
-        { id: "g1", name: "Game One", status: "active", wager: 25 },
-        { id: "g2", name: "Game Two", status: "active", wager: 10 },
-      ],
-    });
-
-    render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("lobby-kpi-strip")).toBeInTheDocument();
-      expect(screen.getByText(/No wallet connected/i)).toBeInTheDocument();
-      expect(screen.getAllByText(/SUBMITTING/i).length).toBeGreaterThan(0);
-      expect(screen.getByTestId("lobby-prize-pool-kpi-balance")).toHaveTextContent("35.00");
-    });
-  });
-});
-
-describe("GameLobby onboarding strip", () => {
+describe("GameLobby", () => {
   it("renders the mission strip for a first-time dashboard session", async () => {
     (ApiClient as any).prototype.getGames.mockResolvedValue({ success: true, data: [] });
 
@@ -174,22 +125,6 @@ describe("GameLobby onboarding strip", () => {
     });
   });
 
-  it("persists dismissal when the mission strip is dismissed", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({ success: true, data: [] });
-
-    render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("dashboard-mission-strip")).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByTestId("dashboard-mission-strip-dismiss"));
-
-    expect(screen.queryByTestId("dashboard-mission-strip")).not.toBeInTheDocument();
-    const stored = JSON.parse(localStorage.getItem("stc_global_state_v1") ?? "{}");
-    expect(stored.flags?.[ONBOARDING_CHECKLIST_DISMISSED_FLAG]).toBe(true);
-  });
-
   it("marks the command mission complete after using the quick-action surface", async () => {
     (ApiClient as any).prototype.getGames.mockResolvedValue({ success: true, data: [] });
 
@@ -205,216 +140,6 @@ describe("GameLobby onboarding strip", () => {
     expect(screen.getByTestId("dashboard-mission-strip-learn-commands")).toHaveTextContent(/complete/i);
   });
 
-  it("exposes the strip as a complementary landmark", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({ success: true, data: [] });
-
-    render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("complementary", { name: /onboarding mission strip/i }),
-      ).toBeInTheDocument();
-    });
-  });
-});
-
-describe("GameLobby recovery and activity", () => {
-  it("renders error state with a recoverable error panel", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: false,
-      error: { message: "Network error" },
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      const errorEl = container.querySelector('[data-testid="lobby-error"]');
-      expect(errorEl).toBeTruthy();
-      expect(errorEl?.getAttribute("role")).toBe("alert");
-      expect(errorEl?.getAttribute("aria-live")).toBe("polite");
-    });
-  });
-
-  it("offers an inline retry affordance on recoverable errors", async () => {
-    (ApiClient as any).prototype.getGames
-      .mockResolvedValueOnce({
-        success: false,
-        error: { message: "Network error" },
-      })
-      .mockResolvedValueOnce({
-        success: true,
-        data: [],
-      });
-
-    render(<GameLobby />);
-
-    const retryBtn = await screen.findByTestId("lobby-error-retry");
-    const callsBefore = (ApiClient as any).prototype.getGames.mock.calls.length;
-    fireEvent.click(retryBtn);
-
-    await waitFor(() => {
-      expect((ApiClient as any).prototype.getGames.mock.calls.length).toBe(callsBefore + 1);
-    });
-  });
-
-  it("renders the wallet-session activity rail with recent summaries", async () => {
-    localStorage.setItem(
-      "stc_global_state_v1",
-      JSON.stringify({
-        auth: { isAuthenticated: false },
-        flags: {},
-        pendingTransaction: {
-          operation: "wallet.deposit",
-          phase: "SUBMITTING",
-          txHash: "abc1234567890",
-          startedAt: 1_700_000_000_000,
-          updatedAt: 1_700_000_000_500,
-        },
-        storedAt: Date.now(),
-      }),
-    );
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [{ id: "g1", name: "Game One", status: "active", wager: 25 }],
-    });
-
-    render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("wallet-session-activity-rail")).toBeInTheDocument();
-    });
-
-    expect(screen.getByTestId("wallet-session-activity-rail-games-refresh")).toHaveTextContent(/lobby refreshed/i);
-    expect(screen.getByTestId("wallet-session-activity-rail-pending-transaction")).toHaveTextContent(/wallet deposit/i);
-  });
-});
-
-describe("GameLobby accessibility landmarks", () => {
-  it("renders loading state with role=status and aria-live", () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue(new Promise(() => {}));
-
-    const { container } = render(<GameLobby />);
-    const loadingEl = container.querySelector(".lobby-loading");
-    expect(loadingEl).toBeTruthy();
-    expect(loadingEl?.getAttribute("role")).toBe("status");
-    expect(loadingEl?.getAttribute("aria-live")).toBe("polite");
-    expect(screen.getByTestId("skeleton-preset-detail")).toBeInTheDocument();
-  });
-
-  it("renders dashboard as a section with aria-label", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [],
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      const dashboard = container.querySelector(".lobby-dashboard");
-      expect(dashboard).toBeTruthy();
-      expect(dashboard?.tagName).toBe("SECTION");
-      expect(dashboard?.getAttribute("aria-label")).toBe("Wallet and network status");
-    });
-  });
-
-  it("exposes the lobby page title as the top-level heading", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [],
-    });
-
-    render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { level: 1, name: "Live Arena" })).toBeInTheDocument();
-    });
-  });
-
-  it("renders games section with aria-labelledby referencing heading", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [{ id: "g1", name: "Game One", status: "active", wager: 25 }],
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      const gamesSection = container.querySelector(".games-section");
-      expect(gamesSection).toBeTruthy();
-      expect(gamesSection?.tagName).toBe("SECTION");
-      expect(gamesSection?.getAttribute("aria-labelledby")).toBe("games-heading");
-    });
-  });
-
-  it("renders games grid with role=region and aria-label", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [{ id: "g2", name: "Game Two", status: "active", wager: 10 }],
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      const grid = container.querySelector(".games-grid");
-      expect(grid).toBeTruthy();
-      expect(grid?.getAttribute("role")).toBe("region");
-      expect(grid?.getAttribute("aria-label")).toBe("Active games");
-    });
-  });
-
-  it("renders empty state with role=status and aria-live", async () => {
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [],
-    });
-
-    const { container } = render(<GameLobby />);
-
-    await waitFor(() => {
-      const emptyEl = container.querySelector(".lobby-empty");
-      expect(emptyEl).toBeTruthy();
-      expect(emptyEl?.getAttribute("role")).toBe("status");
-      expect(emptyEl?.getAttribute("aria-live")).toBe("polite");
-    });
-  });
-
-  it("opens a transaction detail slide-over from the summary card", async () => {
-    localStorage.setItem(
-      "stc_global_state_v1",
-      JSON.stringify({
-        auth: { isAuthenticated: false },
-        flags: {},
-        pendingTransaction: {
-          operation: "wallet.deposit",
-          phase: "SUBMITTING",
-          txHash: "abc1234567890",
-          startedAt: 1_700_000_000_000,
-          updatedAt: 1_700_000_000_500,
-        },
-        storedAt: Date.now(),
-      }),
-    );
-    (ApiClient as any).prototype.getGames.mockResolvedValue({
-      success: true,
-      data: [{ id: "g1", name: "Game One", status: "active", wager: 25 }],
-    });
-
-    render(<GameLobby />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("transaction-detail-trigger")).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByTestId("transaction-detail-trigger"));
-
-    expect(screen.getByTestId("transaction-detail-drawer")).toBeInTheDocument();
-    expect(screen.getAllByText(/wallet deposit/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/abc1234567890/i)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("transaction-detail-drawer-close"));
-    expect(screen.getByTestId("transaction-detail-drawer")).not.toHaveClass("drawer--open");
-  });
-
   it("restores compact leaderboard density from persisted preference", async () => {
     localStorage.setItem("stc_table_density_v1_dashboard-surfaces", "compact");
     (ApiClient as any).prototype.getGames.mockResolvedValue({
@@ -428,6 +153,51 @@ describe("GameLobby accessibility landmarks", () => {
       expect(screen.getByTestId("leaderboard-table")).toHaveClass("data-table--compact");
     });
 
-    expect(screen.getByTestId("leaderboard-density-compact")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("leaderboard-density-compact")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("prompts the user to return to the last context after reconnecting", async () => {
+    sessionStorage.setItem("stc_dashboard_last_context_v1", "activity-rail");
+    walletState.status = "RECONNECTING";
+    walletState.capabilities = {
+      isConnected: false,
+      isConnecting: false,
+      isReconnecting: true,
+      canConnect: false,
+    };
+    walletState.lastReconnectAt = 1_700_000_000_000;
+
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [{ id: "g1", name: "Game One", status: "active", wager: 25 }],
+    });
+
+    const { rerender } = render(<GameLobby />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Live Arena")).toBeInTheDocument();
+    });
+
+    walletState.status = "CONNECTED";
+    walletState.capabilities = {
+      isConnected: true,
+      isConnecting: false,
+      isReconnecting: false,
+      canConnect: false,
+    };
+    walletState.lastReconnectAt = 1_700_000_000_500;
+    rerender(<GameLobby />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("lobby-resume-context-banner")).toHaveTextContent(
+        /wallet activity rail/i,
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("lobby-resume-context-banner-dismiss-btn"));
+    expect(screen.queryByTestId("lobby-resume-context-banner")).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/v1/NotificationCenter.test.tsx
+++ b/frontend/tests/components/v1/NotificationCenter.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import NotificationCenter from "../../../src/components/v1/NotificationCenter";
+import { useErrorStore } from "../../../src/store/errorStore";
+
+beforeEach(() => {
+  useErrorStore.getState().clearToasts();
+  useErrorStore.getState().clearToastHistory();
+  useErrorStore.getState().clearDeferredToasts();
+  useErrorStore.setState({
+    current: null,
+    history: [],
+    toasts: [],
+    deferredToasts: [],
+    toastHistory: [],
+  });
+});
+
+describe("NotificationCenter", () => {
+  it("renders nothing when there are no notifications", () => {
+    const { container } = render(<NotificationCenter />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows deferred notifications in the queued view", () => {
+    for (let index = 0; index < 4; index += 1) {
+      useErrorStore.getState().enqueueToast({
+        tone: index % 2 === 0 ? "success" : "error",
+        message: `toast-${index}`,
+        durationMs: 60_000,
+      });
+    }
+
+    render(<NotificationCenter />);
+    fireEvent.click(screen.getByTestId("notification-center-view-deferred"));
+
+    expect(screen.getByTestId("notification-center-deferred-list")).toHaveTextContent(
+      "toast-3",
+    );
+  });
+});

--- a/frontend/tests/components/v1/PendingActionResumeChip.test.tsx
+++ b/frontend/tests/components/v1/PendingActionResumeChip.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PendingActionResumeChip from "../../../src/components/v1/PendingActionResumeChip";
+
+describe("PendingActionResumeChip", () => {
+  it("renders the pending action copy and calls resume", () => {
+    const onResume = vi.fn();
+    render(
+      <PendingActionResumeChip
+        label="wallet deposit"
+        detail="submitting in progress"
+        onResume={onResume}
+      />,
+    );
+
+    expect(screen.getByTestId("pending-action-resume-chip")).toHaveTextContent(
+      /wallet deposit/i,
+    );
+
+    fireEvent.click(screen.getByTestId("pending-action-resume-chip-resume-btn"));
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the dismiss action when not provided", () => {
+    render(<PendingActionResumeChip label="wallet deposit" onResume={() => undefined} />);
+    expect(
+      screen.queryByTestId("pending-action-resume-chip-dismiss-btn"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/v1/SegmentedControl.test.tsx
+++ b/frontend/tests/components/v1/SegmentedControl.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SegmentedControl } from "../../../src/components/v1/SegmentedControl";
+
+describe("SegmentedControl", () => {
+  it("marks the active segment and keeps the others inactive", () => {
+    render(
+      <SegmentedControl
+        label="Density"
+        value="standard"
+        onChange={() => undefined}
+        options={[
+          { value: "standard", label: "Standard" },
+          { value: "compact", label: "Compact" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("segmented-control-standard")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("segmented-control-compact")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("calls onChange when a new segment is selected", () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        label="Density"
+        value="standard"
+        onChange={onChange}
+        options={[
+          { value: "standard", label: "Standard" },
+          { value: "compact", label: "Compact" },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("segmented-control-compact"));
+    expect(onChange).toHaveBeenCalledWith("compact");
+  });
+});

--- a/frontend/tests/errorStore.test.ts
+++ b/frontend/tests/errorStore.test.ts
@@ -1,268 +1,101 @@
-/**
- * Tests for the Zustand error store (errorStore.ts).
- *
- * The store is tested by calling its actions directly via `getState()` so
- * that we do not depend on React or any rendering environment.
- */
+import { beforeEach, describe, expect, it } from "vitest";
+import { useErrorStore } from "../src/store/errorStore";
+import { ErrorDomain, ErrorSeverity } from "../src/types/errors";
+import type { AppError } from "../src/types/errors";
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { useErrorStore } from '../src/store/errorStore';
-import { ErrorDomain, ErrorSeverity } from '../src/types/errors';
-import type { AppError } from '../src/types/errors';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeError(code: string, message = 'test error'): AppError {
+function makeError(code: string, message = "test error"): AppError {
   return {
-    code: code as AppError['code'],
+    code: code as AppError["code"],
     domain: ErrorDomain.UNKNOWN,
     severity: ErrorSeverity.TERMINAL,
     message,
   };
 }
 
-// Reset store to initial state before every test.
 beforeEach(() => {
   useErrorStore.getState().clearToasts();
-  useErrorStore.setState({ current: null, history: [], toasts: [], toastHistory: [] });
-});
-
-// ---------------------------------------------------------------------------
-// Initial state
-// ---------------------------------------------------------------------------
-
-describe('initial state', () => {
-  it('current is null', () => {
-    expect(useErrorStore.getState().current).toBeNull();
-  });
-
-  it('history is empty', () => {
-    expect(useErrorStore.getState().history).toHaveLength(0);
+  useErrorStore.setState({
+    current: null,
+    history: [],
+    toasts: [],
+    deferredToasts: [],
+    toastHistory: [],
   });
 });
 
-// ---------------------------------------------------------------------------
-// setError
-// ---------------------------------------------------------------------------
-
-describe('setError', () => {
-  it('sets current to the provided error', () => {
-    const err = makeError('UNKNOWN', 'first error');
-    useErrorStore.getState().setError(err);
-    expect(useErrorStore.getState().current).toBe(err);
-  });
-
-  it('prepends the error to history', () => {
-    const a = makeError('UNKNOWN', 'a');
-    const b = makeError('UNKNOWN', 'b');
+describe("error store", () => {
+  it("tracks the latest current error and prepends history", () => {
+    const a = makeError("UNKNOWN", "a");
+    const b = makeError("UNKNOWN", "b");
     useErrorStore.getState().setError(a);
     useErrorStore.getState().setError(b);
-    const { history } = useErrorStore.getState();
-    expect(history[0]).toBe(b);
-    expect(history[1]).toBe(a);
-  });
 
-  it('replaces current when called multiple times', () => {
-    const a = makeError('UNKNOWN', 'a');
-    const b = makeError('UNKNOWN', 'b');
-    useErrorStore.getState().setError(a);
-    useErrorStore.getState().setError(b);
     expect(useErrorStore.getState().current).toBe(b);
+    expect(useErrorStore.getState().history[0]).toBe(b);
+    expect(useErrorStore.getState().history[1]).toBe(a);
   });
 
-  it('history accumulates all errors', () => {
-    for (let i = 0; i < 5; i++) {
-      useErrorStore.getState().setError(makeError('UNKNOWN', `error-${i}`));
+  it("caps error history at 50 items", () => {
+    for (let index = 0; index < 55; index += 1) {
+      useErrorStore.getState().setError(makeError("UNKNOWN", `error-${index}`));
     }
-    expect(useErrorStore.getState().history).toHaveLength(5);
-  });
 
-  it('caps history at MAX_HISTORY (50)', () => {
-    for (let i = 0; i < 60; i++) {
-      useErrorStore.getState().setError(makeError('UNKNOWN', `error-${i}`));
-    }
     expect(useErrorStore.getState().history).toHaveLength(50);
+    expect(useErrorStore.getState().history[0].message).toBe("error-54");
   });
+});
 
-  it('retains the 50 most recent errors when cap is exceeded', () => {
-    for (let i = 0; i < 55; i++) {
-      useErrorStore.getState().setError(makeError('UNKNOWN', `error-${i}`));
+describe("toast queueing", () => {
+  it("keeps a bounded active toast stack and defers overflow", () => {
+    for (let index = 0; index < 4; index += 1) {
+      useErrorStore.getState().enqueueToast({
+        tone: "info",
+        message: `toast-${index}`,
+        durationMs: 60_000,
+      });
     }
-    // Most recent (i=54) should be at index 0.
-    expect(useErrorStore.getState().history[0].message).toBe('error-54');
-    // Oldest retained (i=5) should be at index 49.
-    expect(useErrorStore.getState().history[49].message).toBe('error-5');
-  });
-
-  it('preserves all AppError fields unchanged', () => {
-    const err: AppError = {
-      code: 'RPC_NODE_UNAVAILABLE',
-      domain: ErrorDomain.RPC,
-      severity: ErrorSeverity.RETRYABLE,
-      message: 'node is down',
-      retryAfterMs: 3000,
-      context: { endpoint: 'https://rpc.example.com' },
-      originalError: new Error('raw'),
-    };
-    useErrorStore.getState().setError(err);
-    const stored = useErrorStore.getState().current!;
-    expect(stored.code).toBe('RPC_NODE_UNAVAILABLE');
-    expect(stored.domain).toBe(ErrorDomain.RPC);
-    expect(stored.severity).toBe(ErrorSeverity.RETRYABLE);
-    expect(stored.retryAfterMs).toBe(3000);
-    expect(stored.context).toEqual({ endpoint: 'https://rpc.example.com' });
-    expect(stored.originalError).toBeInstanceOf(Error);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// clearError
-// ---------------------------------------------------------------------------
-
-describe('clearError', () => {
-  it('sets current to null', () => {
-    useErrorStore.getState().setError(makeError('UNKNOWN'));
-    useErrorStore.getState().clearError();
-    expect(useErrorStore.getState().current).toBeNull();
-  });
-
-  it('does not affect history', () => {
-    useErrorStore.getState().setError(makeError('UNKNOWN', 'keep me'));
-    useErrorStore.getState().clearError();
-    expect(useErrorStore.getState().history).toHaveLength(1);
-    expect(useErrorStore.getState().history[0].message).toBe('keep me');
-  });
-
-  it('is safe to call when current is already null', () => {
-    expect(() => useErrorStore.getState().clearError()).not.toThrow();
-    expect(useErrorStore.getState().current).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// clearHistory
-// ---------------------------------------------------------------------------
-
-describe('clearHistory', () => {
-  it('empties the history array', () => {
-    useErrorStore.getState().setError(makeError('UNKNOWN', 'a'));
-    useErrorStore.getState().setError(makeError('UNKNOWN', 'b'));
-    useErrorStore.getState().clearHistory();
-    expect(useErrorStore.getState().history).toHaveLength(0);
-  });
-
-  it('does not affect current', () => {
-    const err = makeError('UNKNOWN', 'current');
-    useErrorStore.getState().setError(err);
-    useErrorStore.getState().clearHistory();
-    expect(useErrorStore.getState().current).toBe(err);
-  });
-
-  it('is safe to call on an already-empty history', () => {
-    expect(() => useErrorStore.getState().clearHistory()).not.toThrow();
-    expect(useErrorStore.getState().history).toHaveLength(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Interaction between actions
-// ---------------------------------------------------------------------------
-
-describe('action interactions', () => {
-  it('setError after clearError re-populates current', () => {
-    const a = makeError('UNKNOWN', 'a');
-    const b = makeError('UNKNOWN', 'b');
-    useErrorStore.getState().setError(a);
-    useErrorStore.getState().clearError();
-    useErrorStore.getState().setError(b);
-    expect(useErrorStore.getState().current).toBe(b);
-  });
-
-  it('setError after clearHistory continues building history from zero', () => {
-    useErrorStore.getState().setError(makeError('UNKNOWN', 'old'));
-    useErrorStore.getState().clearHistory();
-    useErrorStore.getState().setError(makeError('UNKNOWN', 'new'));
-    expect(useErrorStore.getState().history).toHaveLength(1);
-    expect(useErrorStore.getState().history[0].message).toBe('new');
-  });
-
-  it('full reset via clearError + clearHistory yields initial state', () => {
-    useErrorStore.getState().setError(makeError('UNKNOWN', 'x'));
-    useErrorStore.getState().clearError();
-    useErrorStore.getState().clearHistory();
-    const { current, history } = useErrorStore.getState();
-    expect(current).toBeNull();
-    expect(history).toHaveLength(0);
-  });
-});
-
-describe('toast notifications', () => {
-  it('enqueueToast adds a visible toast', () => {
-    useErrorStore.getState().enqueueToast({
-      tone: 'info',
-      title: 'Queued',
-      message: 'Background refresh started',
-      durationMs: 60_000,
-    });
-
-    const { toasts } = useErrorStore.getState();
-    expect(toasts).toHaveLength(1);
-    expect(toasts[0].message).toBe('Background refresh started');
-  });
-
-  it('dismissToast archives the toast in bounded history', () => {
-    const id = useErrorStore.getState().enqueueToast({
-      tone: 'warning',
-      title: 'Heads up',
-      message: 'Retry queued',
-      durationMs: 60_000,
-    });
-
-    useErrorStore.getState().dismissToast(id);
-    const { toasts, toastHistory } = useErrorStore.getState();
-    expect(toasts).toHaveLength(0);
-    expect(toastHistory).toHaveLength(1);
-    expect(toastHistory[0].title).toBe('Heads up');
-  });
-
-  it('preserves queue ordering under rapid bursts', () => {
-    useErrorStore.getState().enqueueToast({
-      tone: 'info',
-      message: 'First',
-      durationMs: 60_000,
-    });
-    useErrorStore.getState().enqueueToast({
-      tone: 'success',
-      message: 'Second',
-      durationMs: 60_000,
-    });
-    useErrorStore.getState().enqueueToast({
-      tone: 'error',
-      message: 'Third',
-      durationMs: 60_000,
-    });
 
     expect(useErrorStore.getState().toasts.map((toast) => toast.message)).toEqual([
-      'First',
-      'Second',
-      'Third',
+      "toast-0",
+      "toast-1",
+      "toast-2",
     ]);
+    expect(
+      useErrorStore.getState().deferredToasts.map((toast) => toast.message),
+    ).toEqual(["toast-3"]);
   });
 
-  it('keeps toast history bounded', () => {
-    for (let i = 0; i < 25; i++) {
+  it("promotes the next deferred toast when an active toast is dismissed", () => {
+    const ids = Array.from({ length: 4 }, (_, index) =>
+      useErrorStore.getState().enqueueToast({
+        tone: "success",
+        message: `toast-${index}`,
+        durationMs: 60_000,
+      }),
+    );
+
+    useErrorStore.getState().dismissToast(ids[0]);
+
+    expect(useErrorStore.getState().toasts.map((toast) => toast.message)).toEqual([
+      "toast-1",
+      "toast-2",
+      "toast-3",
+    ]);
+    expect(useErrorStore.getState().deferredToasts).toHaveLength(0);
+    expect(useErrorStore.getState().toastHistory[0].message).toBe("toast-0");
+  });
+
+  it("keeps dismissed history bounded", () => {
+    for (let index = 0; index < 25; index += 1) {
       const id = useErrorStore.getState().enqueueToast({
-        tone: 'info',
-        message: `toast-${i}`,
+        tone: "warning",
+        message: `toast-${index}`,
         durationMs: 60_000,
       });
       useErrorStore.getState().dismissToast(id);
     }
 
     expect(useErrorStore.getState().toastHistory).toHaveLength(20);
-    expect(useErrorStore.getState().toastHistory[0].message).toBe('toast-24');
-    expect(useErrorStore.getState().toastHistory[19].message).toBe('toast-5');
+    expect(useErrorStore.getState().toastHistory[0].message).toBe("toast-24");
   });
 });


### PR DESCRIPTION
## Description
Adds a reusable queued notification center, a shared segmented control primitive, a return-to-last-context prompt after wallet session reconnects, and a pending-action resume chip for interrupted user flows so contributors can recover their place in the lobby without losing compact, accessible navigation patterns.

Closes #569
Closes #571
Closes #572
Closes #668

## Changes proposed

### What were you told to do?
Implement four frontend UX/platform tickets in one grouped PR:
- add a queued-notification center for deferred success and failure events
- add a segmented control primitive for compact mode switches
- add a return-to-last-context prompt after reconnecting wallet sessions
- add a pending-action resume chip for interrupted user flows

### What did I do?
#### Shared UI primitives
- added a reusable `SegmentedControl` component for compact mode switches
- added a reusable `NotificationCenter` component with active, deferred, and recent views
- added a reusable `PendingActionResumeChip` component for compact interrupted-flow recovery entry points
- exported the new shared components through the v1 component barrel

#### Notification and reconnect flows
- updated the global error store to keep a bounded active toast stack plus a deferred queue
- promoted deferred notifications deterministically when active toasts are dismissed
- extended wallet status state with reconnect metadata for UI polling and reconnect success detection
- added a lobby resume prompt that offers to return the user to their last saved context after a reconnect

#### Interrupted-flow recovery and tests
- exposed pending wallet transaction work through a compact resume chip when the transaction drawer is closed
- let users dismiss the chip while keeping the underlying interrupted flow intact
- replaced the lobby-only density toggle with the shared segmented control
- added focused tests for the notification queue, segmented control, notification center, reconnect prompt flow, and pending-action chip behavior

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Ran `corepack pnpm exec eslint --fix` on the touched frontend source and test files.
- Ran `corepack pnpm exec vitest run tests/errorStore.test.ts tests/components/v1/SegmentedControl.test.tsx tests/components/v1/NotificationCenter.test.tsx tests/components/GameLobby.test.tsx` and all targeted tests passed.
- Ran `corepack pnpm exec vitest run tests/components/v1/PendingActionResumeChip.test.tsx tests/components/GameLobby.test.tsx` after adding the pending-action chip and all targeted tests passed.
- `corepack pnpm build` still fails due pre-existing workspace issues outside this PR, including missing `react-router-dom` resolution and unrelated existing TypeScript errors in other pages/tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification center with Active/Deferred/History views and improved toast queueing
  * New Segmented Control component with count badges
  * Pending-action resume chip to reopen pending transactions
  * Resume banner and session persistence to restore prior lobby context after reconnects
  * Enhanced wallet reconnect tracking and diagnostics; leaderboard density now persists

* **Tests**
  * New and updated tests covering notification center, segmented control, resume chip, lobby resume, and error-store behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->