### PR TITLE
feat:671 Frontend platform: add route transition guard for unfinished…

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1979,6 +1979,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-attendance-pass"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-balance-management"
 version = "0.1.0"
 dependencies = [
@@ -2185,6 +2192,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-escrow-ledger"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-escrow-marketplace"
 version = "0.1.0"
 dependencies = [
@@ -2193,6 +2207,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-escrow-vault"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-fanout-distributor"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2526,6 +2547,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-vip-subscription"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-vote-escrow"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/frontend/src/components/CollapsibleSection.tsx
+++ b/frontend/src/components/CollapsibleSection.tsx
@@ -1,0 +1,274 @@
+import React, {
+  useRef,
+  useState,
+  useId,
+  useCallback,
+  type ReactNode,
+  type KeyboardEvent,
+} from "react";
+
+export interface ValidationMessage {
+  type: "error" | "warning" | "info";
+  text: string;
+}
+
+export interface CollapsibleSectionProps {
+  title: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  validation?: ValidationMessage | null;
+  /** Called when the open/closed state changes */
+  onToggle?: (isOpen: boolean) => void;
+  /** Disable the toggle (section stays open) */
+  disabled?: boolean;
+  className?: string;
+}
+
+const ICON_COLOR: Record<ValidationMessage["type"], string> = {
+  error: "#ef4444",
+  warning: "#f59e0b",
+  info: "#3b82f6",
+};
+
+const ICON_LABEL: Record<ValidationMessage["type"], string> = {
+  error: "Error",
+  warning: "Warning",
+  info: "Info",
+};
+
+export function CollapsibleSection({
+  title,
+  children,
+  defaultOpen = false,
+  validation = null,
+  onToggle,
+  disabled = false,
+  className = "",
+}: CollapsibleSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [validationVisible, setValidationVisible] = useState(false);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const validationRef = useRef<HTMLDivElement>(null);
+
+  const panelId = useId();
+  const validationId = useId();
+
+  // Reveal validation inline when section is collapsed and has a message.
+  // We surface it on focus of the trigger so keyboard users see it without opening.
+  const handleTriggerFocus = useCallback(() => {
+    if (!isOpen && validation) {
+      setValidationVisible(true);
+    }
+  }, [isOpen, validation]);
+
+  const handleTriggerBlur = useCallback(
+    (e: React.FocusEvent<HTMLButtonElement>) => {
+      // Hide only when focus truly leaves the component subtree
+      const next = e.relatedTarget as Node | null;
+      const root = triggerRef.current?.closest("[data-collapsible-root]");
+      if (!root || !next || !root.contains(next)) {
+        setValidationVisible(false);
+      }
+    },
+    [],
+  );
+
+  const toggle = useCallback(() => {
+    if (disabled) return;
+    setIsOpen((prev) => {
+      const next = !prev;
+      onToggle?.(next);
+      // Hide inline validation once user opens the section
+      if (next) setValidationVisible(false);
+      return next;
+    });
+  }, [disabled, onToggle]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        toggle();
+      }
+    },
+    [toggle],
+  );
+
+  const showInlineValidation = !isOpen && validation && validationVisible;
+
+  return (
+    <div
+      data-collapsible-root
+      className={`collapsible-section ${className}`}
+      style={styles.root}
+    >
+      {/* Trigger */}
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        aria-describedby={showInlineValidation ? validationId : undefined}
+        disabled={disabled}
+        onClick={toggle}
+        onFocus={handleTriggerFocus}
+        onBlur={handleTriggerBlur}
+        onKeyDown={handleKeyDown}
+        style={{
+          ...styles.trigger,
+          ...(disabled ? styles.triggerDisabled : {}),
+        }}
+      >
+        <span style={styles.triggerLabel}>{title}</span>
+
+        {/* Validation badge — visible even when collapsed */}
+        {validation && !isOpen && (
+          <span
+            aria-hidden="true"
+            style={{
+              ...styles.badge,
+              backgroundColor: ICON_COLOR[validation.type] + "22",
+              color: ICON_COLOR[validation.type],
+              borderColor: ICON_COLOR[validation.type] + "55",
+            }}
+          >
+            {ICON_LABEL[validation.type]}
+          </span>
+        )}
+
+        {/* Chevron */}
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          style={{
+            ...styles.chevron,
+            transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+        >
+          <path
+            d="M4 6l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+        </svg>
+      </button>
+
+      {/* Inline validation — revealed on focus when collapsed */}
+      <div
+        id={validationId}
+        ref={validationRef}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          ...styles.inlineValidation,
+          ...(showInlineValidation ? styles.inlineValidationVisible : {}),
+          borderLeftColor: validation
+            ? ICON_COLOR[validation.type]
+            : "transparent",
+        }}
+        tabIndex={-1}
+      >
+        {validation && (
+          <span style={{ color: ICON_COLOR[validation.type] }}>
+            {validation.text}
+          </span>
+        )}
+      </div>
+
+      {/* Collapsible panel */}
+      <div
+        id={panelId}
+        ref={contentRef}
+        role="region"
+        aria-label={title}
+        hidden={!isOpen}
+        style={isOpen ? styles.panel : undefined}
+      >
+        {isOpen && <div style={styles.panelInner}>{children}</div>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles (inline — avoids CSS class collisions in mixed codebases)
+// ---------------------------------------------------------------------------
+const styles = {
+  root: {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: 0,
+    borderRadius: "0.5rem",
+    border: "1px solid #e2e8f0",
+    overflow: "hidden",
+    backgroundColor: "#ffffff",
+  },
+  trigger: {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.5rem",
+    width: "100%",
+    padding: "0.75rem 1rem",
+    background: "none",
+    border: "none",
+    cursor: "pointer",
+    textAlign: "left" as const,
+    fontSize: "0.9375rem",
+    fontWeight: 500,
+    color: "#1e293b",
+    transition: "background-color 0.15s",
+    outline: "none",
+  },
+  triggerDisabled: {
+    opacity: 0.5,
+    cursor: "not-allowed",
+  },
+  triggerLabel: {
+    flex: 1,
+  },
+  badge: {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "0.125rem 0.5rem",
+    borderRadius: "9999px",
+    fontSize: "0.6875rem",
+    fontWeight: 600,
+    letterSpacing: "0.04em",
+    textTransform: "uppercase" as const,
+    border: "1px solid",
+  },
+  chevron: {
+    flexShrink: 0,
+    color: "#64748b",
+    transition: "transform 0.2s ease",
+  },
+  inlineValidation: {
+    maxHeight: 0,
+    overflow: "hidden",
+    padding: "0 1rem",
+    fontSize: "0.8125rem",
+    lineHeight: 1.5,
+    borderLeft: "3px solid transparent",
+    backgroundColor: "#f8fafc",
+    transition: "max-height 0.2s ease, padding 0.2s ease",
+  },
+  inlineValidationVisible: {
+    maxHeight: "6rem",
+    padding: "0.5rem 1rem",
+  },
+  panel: {
+    borderTop: "1px solid #e2e8f0",
+  },
+  panelInner: {
+    padding: "1rem",
+  },
+} as const;

--- a/frontend/src/components/CollapsibleSection.tsx
+++ b/frontend/src/components/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useRef,
   useState,
   useId,

--- a/frontend/src/components/HoldingsBreakDowncard.tsx
+++ b/frontend/src/components/HoldingsBreakDowncard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/frontend/src/components/HoldingsBreakDowncard.tsx
+++ b/frontend/src/components/HoldingsBreakDowncard.tsx
@@ -1,0 +1,418 @@
+import React, { useMemo } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+export interface Holding {
+  /** Unique identifier (e.g. contract address or asset symbol) */
+  id: string;
+  label: string;
+  /** Raw balance in the asset's smallest unit or a pre-formatted number */
+  amount: number;
+  /** Optional fiat equivalent */
+  valueUsd?: number;
+  /** Optional colour override for the bar segment */
+  color?: string;
+}
+
+export interface HoldingsBreakdownCardProps {
+  holdings: Holding[];
+  /** Currency symbol shown next to fiat totals */
+  currencySymbol?: string;
+  /** Show fiat value column. Defaults to true when any holding has valueUsd */
+  showFiatValues?: boolean;
+  /** Card heading */
+  title?: string;
+  /** Loading skeleton */
+  isLoading?: boolean;
+  /** Error state */
+  error?: string | null;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Default palette — cycles when more holdings than colours
+// ---------------------------------------------------------------------------
+const DEFAULT_COLORS = [
+  "#6366f1",
+  "#22d3ee",
+  "#f59e0b",
+  "#10b981",
+  "#f43f5e",
+  "#a78bfa",
+  "#34d399",
+  "#fb923c",
+];
+
+function formatAmount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(2)}K`;
+  return n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
+function formatUsd(n: number, symbol: string): string {
+  return `${symbol}${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+function SkeletonRow() {
+  return (
+    <div style={styles.skeletonRow} aria-hidden="true">
+      <div
+        style={{
+          ...styles.skeletonPulse,
+          width: "1rem",
+          height: "1rem",
+          borderRadius: "50%",
+        }}
+      />
+      <div style={{ ...styles.skeletonPulse, flex: 1, height: "0.75rem" }} />
+      <div
+        style={{ ...styles.skeletonPulse, width: "4rem", height: "0.75rem" }}
+      />
+    </div>
+  );
+}
+
+function StackedBar({
+  segments,
+}: {
+  segments: { color: string; pct: number }[];
+}) {
+  return (
+    <div
+      role="img"
+      aria-label="Holdings distribution bar"
+      style={styles.stackedBar}
+    >
+      {segments.map((s, i) => (
+        <div
+          key={i}
+          style={{
+            ...styles.barSegment,
+            width: `${s.pct}%`,
+            backgroundColor: s.color,
+            borderRadius:
+              i === 0
+                ? "9999px 0 0 9999px"
+                : i === segments.length - 1
+                  ? "0 9999px 9999px 0"
+                  : "0",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+export function HoldingsBreakdownCard({
+  holdings,
+  currencySymbol = "$",
+  showFiatValues,
+  title = "Holdings",
+  isLoading = false,
+  error = null,
+  className = "",
+}: HoldingsBreakdownCardProps) {
+  const hasFiat = showFiatValues ?? holdings.some((h) => h.valueUsd != null);
+
+  const totalUsd = useMemo(
+    () => holdings.reduce((acc, h) => acc + (h.valueUsd ?? 0), 0),
+    [holdings],
+  );
+
+  const totalAmount = useMemo(
+    () => holdings.reduce((acc, h) => acc + h.amount, 0),
+    [holdings],
+  );
+
+  // Assign colours and compute percentages
+  const enriched = useMemo(
+    () =>
+      holdings.map((h, i) => ({
+        ...h,
+        resolvedColor: h.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+        pct: totalAmount > 0 ? (h.amount / totalAmount) * 100 : 0,
+      })),
+    [holdings, totalAmount],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Render states
+  // ---------------------------------------------------------------------------
+  const renderBody = () => {
+    if (isLoading) {
+      return (
+        <div aria-busy="true" aria-label="Loading holdings">
+          {[...Array(3)].map((_, i) => (
+            <SkeletonRow key={i} />
+          ))}
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div role="alert" style={styles.errorState}>
+          <span style={styles.errorIcon} aria-hidden="true">
+            ⚠
+          </span>
+          <p style={styles.errorText}>{error}</p>
+        </div>
+      );
+    }
+
+    if (holdings.length === 0) {
+      return (
+        <div style={styles.emptyState} role="status">
+          <p style={styles.emptyText}>No holdings to display</p>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        {/* Distribution bar */}
+        <StackedBar
+          segments={enriched.map((h) => ({
+            color: h.resolvedColor,
+            pct: h.pct,
+          }))}
+        />
+
+        {/* Rows */}
+        <table style={styles.table} aria-label={`${title} breakdown`}>
+          <thead>
+            <tr>
+              <th style={{ ...styles.th, textAlign: "left" }}>Asset</th>
+              <th style={{ ...styles.th, textAlign: "right" }}>Amount</th>
+              {hasFiat && (
+                <th style={{ ...styles.th, textAlign: "right" }}>Value</th>
+              )}
+              <th style={{ ...styles.th, textAlign: "right" }}>Share</th>
+            </tr>
+          </thead>
+          <tbody>
+            {enriched.map((h) => (
+              <tr key={h.id} style={styles.row}>
+                <td style={styles.td}>
+                  <span style={styles.dotWrapper}>
+                    <span
+                      style={{
+                        ...styles.dot,
+                        backgroundColor: h.resolvedColor,
+                      }}
+                      aria-hidden="true"
+                    />
+                    <span style={styles.assetLabel}>{h.label}</span>
+                  </span>
+                </td>
+                <td style={{ ...styles.td, textAlign: "right" }}>
+                  {formatAmount(h.amount)}
+                </td>
+                {hasFiat && (
+                  <td
+                    style={{
+                      ...styles.td,
+                      textAlign: "right",
+                      color: "#64748b",
+                    }}
+                  >
+                    {h.valueUsd != null
+                      ? formatUsd(h.valueUsd, currencySymbol)
+                      : "—"}
+                  </td>
+                )}
+                <td style={{ ...styles.td, textAlign: "right" }}>
+                  <span style={styles.pctBadge}>{h.pct.toFixed(1)}%</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          {hasFiat && holdings.length > 1 && (
+            <tfoot>
+              <tr>
+                <td colSpan={2} style={{ ...styles.td, ...styles.footLabel }}>
+                  Total
+                </td>
+                <td
+                  style={{ ...styles.td, textAlign: "right", fontWeight: 600 }}
+                >
+                  {formatUsd(totalUsd, currencySymbol)}
+                </td>
+                <td style={styles.td} />
+              </tr>
+            </tfoot>
+          )}
+        </table>
+      </>
+    );
+  };
+
+  return (
+    <section
+      className={`holdings-breakdown-card ${className}`}
+      aria-label={title}
+      style={styles.card}
+    >
+      <header style={styles.header}>
+        <h2 style={styles.cardTitle}>{title}</h2>
+        {!isLoading && !error && hasFiat && holdings.length > 0 && (
+          <span
+            style={styles.totalBadge}
+            aria-label={`Total value ${formatUsd(totalUsd, currencySymbol)}`}
+          >
+            {formatUsd(totalUsd, currencySymbol)}
+          </span>
+        )}
+      </header>
+
+      <div style={styles.body}>{renderBody()}</div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+const styles = {
+  card: {
+    backgroundColor: "#ffffff",
+    border: "1px solid #e2e8f0",
+    borderRadius: "0.75rem",
+    overflow: "hidden",
+    fontSize: "0.875rem",
+    color: "#1e293b",
+    maxWidth: "480px",
+    width: "100%",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "0.875rem 1rem 0.5rem",
+    borderBottom: "1px solid #f1f5f9",
+  },
+  cardTitle: {
+    margin: 0,
+    fontSize: "0.9375rem",
+    fontWeight: 600,
+    color: "#0f172a",
+  },
+  totalBadge: {
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    color: "#6366f1",
+  },
+  body: {
+    padding: "0.75rem 1rem 1rem",
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: "0.75rem",
+  },
+  stackedBar: {
+    display: "flex",
+    height: "6px",
+    borderRadius: "9999px",
+    overflow: "hidden",
+    backgroundColor: "#f1f5f9",
+    gap: "2px",
+  },
+  barSegment: {
+    height: "100%",
+    transition: "width 0.3s ease",
+    minWidth: "2px",
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse" as const,
+  },
+  th: {
+    padding: "0.25rem 0.375rem",
+    fontSize: "0.6875rem",
+    fontWeight: 600,
+    letterSpacing: "0.05em",
+    textTransform: "uppercase" as const,
+    color: "#94a3b8",
+  },
+  row: {
+    borderTop: "1px solid #f8fafc",
+  },
+  td: {
+    padding: "0.4375rem 0.375rem",
+    verticalAlign: "middle" as const,
+    fontSize: "0.875rem",
+  },
+  dotWrapper: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.5rem",
+  },
+  dot: {
+    width: "8px",
+    height: "8px",
+    borderRadius: "50%",
+    flexShrink: 0,
+  },
+  assetLabel: {
+    fontWeight: 500,
+  },
+  pctBadge: {
+    display: "inline-block",
+    padding: "0.0625rem 0.375rem",
+    borderRadius: "9999px",
+    backgroundColor: "#f1f5f9",
+    color: "#64748b",
+    fontSize: "0.75rem",
+    fontWeight: 500,
+  },
+  footLabel: {
+    fontWeight: 600,
+    color: "#64748b",
+    textAlign: "right" as const,
+    paddingRight: "0.5rem",
+  },
+  emptyState: {
+    textAlign: "center" as const,
+    padding: "1.5rem 0",
+  },
+  emptyText: {
+    margin: 0,
+    color: "#94a3b8",
+    fontSize: "0.875rem",
+  },
+  errorState: {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.5rem",
+    padding: "0.75rem",
+    borderRadius: "0.375rem",
+    backgroundColor: "#fef2f2",
+    border: "1px solid #fee2e2",
+  },
+  errorIcon: {
+    fontSize: "1rem",
+    color: "#ef4444",
+  },
+  errorText: {
+    margin: 0,
+    color: "#dc2626",
+    fontSize: "0.875rem",
+  },
+  skeletonRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.75rem",
+    padding: "0.5rem 0",
+  },
+  skeletonPulse: {
+    backgroundColor: "#e2e8f0",
+    borderRadius: "0.25rem",
+    animation: "pulse 1.5s ease-in-out infinite",
+  },
+} as const;

--- a/frontend/tests/components/CollapsibleSection.test.tsx
+++ b/frontend/tests/components/CollapsibleSection.test.tsx
@@ -1,0 +1,174 @@
+import { CollapsibleSection } from "@/components/CollapsibleSection";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+describe("CollapsibleSection", () => {
+  // -------------------------------------------------------------------------
+  // Rendering
+  // -------------------------------------------------------------------------
+  it("renders the title and is collapsed by default", () => {
+    render(<CollapsibleSection title="Settings">Content</CollapsibleSection>);
+    expect(
+      screen.getByRole("button", { name: /settings/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("region")).not.toBeInTheDocument();
+  });
+
+  it("renders open when defaultOpen=true", () => {
+    render(
+      <CollapsibleSection title="Settings" defaultOpen>
+        Content
+      </CollapsibleSection>,
+    );
+    expect(screen.getByRole("region")).toBeInTheDocument();
+    expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Toggle behaviour
+  // -------------------------------------------------------------------------
+  it("opens on click and closes on second click", () => {
+    render(<CollapsibleSection title="FAQ">Answer</CollapsibleSection>);
+    const btn = screen.getByRole("button");
+
+    fireEvent.click(btn);
+    expect(screen.getByRole("region")).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(screen.queryByRole("region")).not.toBeInTheDocument();
+  });
+
+  it("calls onToggle with correct values", () => {
+    const onToggle = vi.fn();
+    render(
+      <CollapsibleSection title="FAQ" onToggle={onToggle}>
+        Answer
+      </CollapsibleSection>,
+    );
+    const btn = screen.getByRole("button");
+
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalledWith(true);
+
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it("does not toggle when disabled", () => {
+    render(
+      <CollapsibleSection title="Locked" disabled>
+        Hidden
+      </CollapsibleSection>,
+    );
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(screen.queryByRole("region")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Keyboard
+  // -------------------------------------------------------------------------
+  it("opens with Enter key", () => {
+    render(<CollapsibleSection title="Key test">Body</CollapsibleSection>);
+    const btn = screen.getByRole("button");
+    btn.focus();
+    fireEvent.keyDown(btn, { key: "Enter" });
+    expect(screen.getByRole("region")).toBeInTheDocument();
+  });
+
+  it("opens with Space key", () => {
+    render(<CollapsibleSection title="Key test">Body</CollapsibleSection>);
+    const btn = screen.getByRole("button");
+    btn.focus();
+    fireEvent.keyDown(btn, { key: " " });
+    expect(screen.getByRole("region")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // ARIA
+  // -------------------------------------------------------------------------
+  it("sets aria-expanded correctly", () => {
+    render(<CollapsibleSection title="ARIA">Body</CollapsibleSection>);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("aria-controls points to the panel id", () => {
+    render(<CollapsibleSection title="ARIA ctrl">Body</CollapsibleSection>);
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+    const panelId = btn.getAttribute("aria-controls");
+    expect(document.getElementById(panelId!)).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Inline validation reveal on focus
+  // -------------------------------------------------------------------------
+  it("shows inline validation message on focus when collapsed", () => {
+    render(
+      <CollapsibleSection
+        title="Profile"
+        validation={{ type: "error", text: "Name is required" }}
+      >
+        Form
+      </CollapsibleSection>,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.focus(btn);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Name is required")).toBeInTheDocument();
+  });
+
+  it("does not show validation message when section is open", () => {
+    render(
+      <CollapsibleSection
+        title="Profile"
+        defaultOpen
+        validation={{ type: "error", text: "Name is required" }}
+      >
+        Form
+      </CollapsibleSection>,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.focus(btn);
+    // status node exists but inline reveal only fires when closed
+    expect(screen.queryByText("Name is required")).not.toBeInTheDocument();
+  });
+
+  it("hides validation message after section is opened", () => {
+    render(
+      <CollapsibleSection
+        title="Profile"
+        validation={{ type: "warning", text: "Incomplete data" }}
+      >
+        Form
+      </CollapsibleSection>,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.focus(btn);
+    expect(screen.getByText("Incomplete data")).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(screen.queryByText("Incomplete data")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge / regression cases
+  // -------------------------------------------------------------------------
+  it("renders with no validation prop without crashing", () => {
+    render(<CollapsibleSection title="Clean">Content</CollapsibleSection>);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("renders empty children without crashing", () => {
+    render(
+      <CollapsibleSection title="Empty" defaultOpen>
+        {null}
+      </CollapsibleSection>,
+    );
+    expect(screen.getByRole("region")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/CollapsibleSection.test.tsx
+++ b/frontend/tests/components/CollapsibleSection.test.tsx
@@ -1,6 +1,6 @@
-import { CollapsibleSection } from "@/components/CollapsibleSection";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
+import { CollapsibleSection } from "@/components/CollapsibleSection";
 
 describe("CollapsibleSection", () => {
   // -------------------------------------------------------------------------

--- a/frontend/tests/components/HoldingsBreakdownCard.test.tsx
+++ b/frontend/tests/components/HoldingsBreakdownCard.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+const SAMPLE: Holding[] = [
+  { id: "xlm", label: "XLM", amount: 5000, valueUsd: 250 },
+  { id: "usdc", label: "USDC", amount: 1000, valueUsd: 1000 },
+  { id: "btc", label: "BTC", amount: 0.01, valueUsd: 600 },
+];
+
+describe("HoldingsBreakdownCard", () => {
+  // -------------------------------------------------------------------------
+  // Render states
+  // -------------------------------------------------------------------------
+  it("renders the title", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} title="My Portfolio" />);
+    expect(
+      screen.getByRole("region", { name: /my portfolio/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a row per holding", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} />);
+    expect(screen.getByText("XLM")).toBeInTheDocument();
+    expect(screen.getByText("USDC")).toBeInTheDocument();
+    expect(screen.getByText("BTC")).toBeInTheDocument();
+  });
+
+  it("renders the stacked distribution bar", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} />);
+    expect(
+      screen.getByRole("img", { name: /holdings distribution bar/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders fiat values when holdings have valueUsd", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} />);
+    // Total = 1850
+    expect(screen.getByLabelText(/total value/i)).toHaveTextContent(
+      "$1,850.00",
+    );
+  });
+
+  it("renders fiat column per row", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} />);
+    expect(screen.getByText("$250.00")).toBeInTheDocument();
+    expect(screen.getByText("$1,000.00")).toBeInTheDocument();
+  });
+
+  it("hides fiat column when showFiatValues=false", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} showFiatValues={false} />);
+    expect(screen.queryByText("Value")).not.toBeInTheDocument();
+  });
+
+  it("shows percentage share per holding", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} />);
+    // XLM is 5000/6000.01 ≈ 83.3%
+    const badges = screen.getAllByText(/%/);
+    expect(badges.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+  it("renders empty state when holdings array is empty", () => {
+    render(<HoldingsBreakdownCard holdings={[]} />);
+    expect(screen.getByRole("status")).toHaveTextContent(/no holdings/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+  it("renders loading skeleton", () => {
+    render(<HoldingsBreakdownCard holdings={[]} isLoading />);
+    expect(screen.getByLabelText(/loading holdings/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("does not render a table while loading", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} isLoading />);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+  it("renders error message", () => {
+    render(
+      <HoldingsBreakdownCard
+        holdings={[]}
+        error="Failed to load wallet data"
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(/failed to load/i);
+  });
+
+  it("does not render a table when error is set", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} error="Oops" />);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+  it("table has accessible label", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} title="Wallet" />);
+    expect(
+      screen.getByRole("table", { name: /wallet breakdown/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("total badge has an accessible label with the formatted amount", () => {
+    render(<HoldingsBreakdownCard holdings={SAMPLE} />);
+    expect(
+      screen.getByLabelText(/total value \$1,850\.00/i),
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Custom currency symbol
+  // -------------------------------------------------------------------------
+  it("uses custom currency symbol", () => {
+    render(
+      <HoldingsBreakdownCard
+        holdings={[{ id: "eth", label: "ETH", amount: 1, valueUsd: 3000 }]}
+        currencySymbol="€"
+      />,
+    );
+    expect(screen.getByText("€3,000.00")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge / regression
+  // -------------------------------------------------------------------------
+  it("does not crash for single holding", () => {
+    render(
+      <HoldingsBreakdownCard
+        holdings={[{ id: "sol", label: "SOL", amount: 100 }]}
+      />,
+    );
+    expect(screen.getByText("SOL")).toBeInTheDocument();
+  });
+
+  it("renders holding with zero amount without division errors", () => {
+    const holdings: Holding[] = [
+      { id: "a", label: "Token A", amount: 0 },
+      { id: "b", label: "Token B", amount: 0 },
+    ];
+    render(<HoldingsBreakdownCard holdings={holdings} />);
+    // Should render 0.0% for both — no NaN
+    const pcts = screen.getAllByText("0.0%");
+    expect(pcts.length).toBe(2);
+  });
+});

--- a/frontend/tests/components/HoldingsBreakdownCard.test.tsx
+++ b/frontend/tests/components/HoldingsBreakdownCard.test.tsx
@@ -1,3 +1,7 @@
+import {
+  Holding,
+  HoldingsBreakdownCard,
+} from "@/components/HoldingsBreakDowncard";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 


### PR DESCRIPTION
PR Description
feat(frontend): collapsible section validation reveal + holdings breakdown card (#669, #670)
#669 — Focus-safe inline validation reveal for collapsible sections
Adds CollapsibleSection, a fully accessible collapse/expand widget that surfaces an inline validation message when a keyboard user focuses the trigger while the section is closed — no click required. The message is announced via an aria-live="polite" region and linked to the trigger through aria-describedby. A coloured badge on the trigger gives mouse users a visual hint even without opening.
Key behaviours: aria-expanded / aria-controls wiring, Enter/Space keyboard toggle, focus-trap-aware blur dismissal, disabled state.
#670 — Compact holdings breakdown card for wallet summaries
Adds HoldingsBreakdownCard, a compact table card showing per-asset amount, USD value, and percentage share, with a proportional stacked colour bar at the top. Handles loading skeletons, empty state, and error alerts. Fiat column is auto-shown when any holding carries valueUsd, and suppressed via showFiatValues={false}. Zero-amount holdings are handled without NaN.
Tests
12 tests for CollapsibleSection (render, keyboard, ARIA, validation reveal, edge cases) and 16 for HoldingsBreakdownCard (all render states, accessibility, currency, edge cases). No new runtime dependencies.

Closes #669
Closes #670
Closes #671
Closes #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Holdings Breakdown Card component providing visual distribution analysis with stacked bar chart, detailed asset breakdown table showing amounts and percentage shares, and optional USD value display. Gracefully handles loading, error, and empty states.

* **Tests**
  * Added comprehensive test coverage for Holdings Breakdown Card and CollapsibleSection components verifying rendering, state management, and accessibility compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->