### PR TITLE
feat: add check-in coverage and resale-lock status accessors

### DIFF
--- a/contracts/attendance-pass/src/lib.rs
+++ b/contracts/attendance-pass/src/lib.rs
@@ -5,13 +5,19 @@ mod types;
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
-pub use types::{ExpiryBand, HolderCoverageSummary, PassRecord, PassStatus};
+pub use types::{
+    CheckInCoverageSummary, ExpiryBand, HolderCoverageSummary, PassRecord, PassStatus,
+    ResaleLockStatus,
+};
 
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
     Pass(u64),
+    CheckedIn(u64),
+    ResaleLocked(u64),
+    CheckedInCount,
     TotalHolders,
     ActiveHolders,
     ExpiredPasses,
@@ -50,6 +56,8 @@ impl AttendancePass {
         };
 
         storage::set_pass(&env, &record);
+        storage::set_checked_in(&env, pass_id, false);
+        storage::set_resale_locked(&env, pass_id, false);
         storage::increment_total_holders(&env);
         storage::increment_active_holders(&env);
         storage::increment_total_issued(&env);
@@ -117,6 +125,63 @@ impl AttendancePass {
             now,
         }
     }
+
+    pub fn mark_checked_in(env: Env, admin: Address, pass_id: u64) {
+        admin.require_auth();
+        let record = storage::get_pass(&env, pass_id).expect("Pass not found");
+        assert!(record.active, "Pass not active");
+
+        if !storage::is_checked_in(&env, pass_id) {
+            storage::set_checked_in(&env, pass_id, true);
+            storage::increment_checked_in_count(&env);
+        }
+    }
+
+    pub fn check_in_coverage_summary(env: Env) -> CheckInCoverageSummary {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        let total_issued = storage::get_total_issued(&env);
+        let checked_in_count = storage::get_checked_in_count(&env);
+        let unchecked_count = total_issued.saturating_sub(checked_in_count);
+        let check_in_rate_bps = if total_issued == 0 {
+            0
+        } else {
+            ((checked_in_count.saturating_mul(10_000)) / total_issued) as u32
+        };
+
+        CheckInCoverageSummary {
+            configured,
+            total_issued,
+            checked_in_count,
+            unchecked_count,
+            check_in_rate_bps,
+        }
+    }
+
+    pub fn set_resale_lock(env: Env, admin: Address, pass_id: u64, locked: bool) {
+        admin.require_auth();
+        let _ = storage::get_pass(&env, pass_id).expect("Pass not found");
+        storage::set_resale_locked(&env, pass_id, locked);
+    }
+
+    pub fn resale_lock_status(env: Env, pass_id: u64) -> ResaleLockStatus {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        match storage::get_pass(&env, pass_id) {
+            Some(pass) => ResaleLockStatus {
+                pass_id,
+                configured,
+                exists: true,
+                active: pass.active,
+                resale_locked: storage::is_resale_locked(&env, pass_id),
+            },
+            None => ResaleLockStatus {
+                pass_id,
+                configured,
+                exists: false,
+                active: false,
+                resale_locked: false,
+            },
+        }
+    }
 }
 
 #[cfg(test)]
@@ -162,5 +227,39 @@ mod test {
         let band = AttendancePass::expiry_band(env, 999);
         assert_eq!(band.exists, false);
         assert_eq!(band.configured, true);
+    }
+
+    #[test]
+    fn test_check_in_coverage_summary_updates() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1000);
+        let admin = Address::random(&env);
+        let holder_a = Address::random(&env);
+        let holder_b = Address::random(&env);
+
+        AttendancePass::init(env.clone(), admin.clone());
+        AttendancePass::issue_pass(env.clone(), admin.clone(), 1, holder_a, 2000);
+        AttendancePass::issue_pass(env.clone(), admin.clone(), 2, holder_b, 2500);
+        AttendancePass::mark_checked_in(env.clone(), admin, 1);
+
+        let summary = AttendancePass::check_in_coverage_summary(env);
+        assert_eq!(summary.configured, true);
+        assert_eq!(summary.total_issued, 2);
+        assert_eq!(summary.checked_in_count, 1);
+        assert_eq!(summary.unchecked_count, 1);
+        assert_eq!(summary.check_in_rate_bps, 5000);
+    }
+
+    #[test]
+    fn test_resale_lock_status_missing_is_predictable() {
+        let env = Env::default();
+        let admin = Address::random(&env);
+        AttendancePass::init(env.clone(), admin);
+
+        let status = AttendancePass::resale_lock_status(env, 999);
+        assert_eq!(status.configured, true);
+        assert_eq!(status.exists, false);
+        assert_eq!(status.active, false);
+        assert_eq!(status.resale_locked, false);
     }
 }

--- a/contracts/attendance-pass/src/storage.rs
+++ b/contracts/attendance-pass/src/storage.rs
@@ -100,3 +100,47 @@ pub fn get_total_issued(env: &Env) -> u64 {
         .get(&DataKey::TotalIssued)
         .unwrap_or(0u64)
 }
+
+pub fn set_checked_in(env: &Env, pass_id: u64, checked_in: bool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CheckedIn(pass_id), &checked_in);
+}
+
+pub fn is_checked_in(env: &Env, pass_id: u64) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CheckedIn(pass_id))
+        .unwrap_or(false)
+}
+
+pub fn increment_checked_in_count(env: &Env) {
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::CheckedInCount)
+        .unwrap_or(0u64);
+    env.storage()
+        .instance()
+        .set(&DataKey::CheckedInCount, &(current + 1));
+}
+
+pub fn get_checked_in_count(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::CheckedInCount)
+        .unwrap_or(0u64)
+}
+
+pub fn set_resale_locked(env: &Env, pass_id: u64, locked: bool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ResaleLocked(pass_id), &locked);
+}
+
+pub fn is_resale_locked(env: &Env, pass_id: u64) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ResaleLocked(pass_id))
+        .unwrap_or(false)
+}

--- a/contracts/attendance-pass/src/types.rs
+++ b/contracts/attendance-pass/src/types.rs
@@ -39,3 +39,24 @@ pub struct ExpiryBand {
     pub expires_at: u64,
     pub now: u64,
 }
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CheckInCoverageSummary {
+    pub configured: bool,
+    pub total_issued: u64,
+    pub checked_in_count: u64,
+    pub unchecked_count: u64,
+    /// check-in rate in basis points (0..=10000)
+    pub check_in_rate_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ResaleLockStatus {
+    pub pass_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub active: bool,
+    pub resale_locked: bool,
+}


### PR DESCRIPTION
## Summary
- add structured check-in coverage reads to `contracts/attendance-pass` via `check_in_coverage_summary`
- add resale lock read accessor `resale_lock_status` and supporting admin setter `set_resale_lock`
- add check-in mutation helper `mark_checked_in` with idempotent counter update
- extend storage/types with explicit fields for coverage and lock status responses
- add test coverage for success-path coverage summary and missing-pass resale-lock state

## Scope
- issue focus implemented: `#664`
- repository path mapping note: issue referenced `contracts/event-ticketing/*`, but this repo currently exposes equivalent pass/check-in behavior under `contracts/attendance-pass/*`

## Validation
- attempted `cargo test -p stellarcade-attendance-pass`
- blocked by local toolchain constraint: current rustc is `1.85.0` while resolved Soroban dependencies require newer rustc (`>=1.91.0`)

Closes #664
Closes #665
Closes #666
Closes #667


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendance tracking: Admins can mark individual passes as checked in and retrieve comprehensive check-in coverage statistics, including total issued counts, checked-in counts, unchecked counts, and check-in rates.
  * Resale lock management: Admins can set resale locks on passes. Users can query resale lock status for any pass, including whether the pass exists and its current lock state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->