### PR TITLE
feat: implement #450 #536 #605 #629 in one delivery PR

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -101,6 +101,7 @@ exclude = [
     "higher-lower",
     "challenge-ladder",
     "merch-redemption",
+    "profile-perks",
 ]
 
 [profile.release]

--- a/contracts/merch-redemption/Cargo.toml
+++ b/contracts/merch-redemption/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-merch-redemption"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/merch-redemption/src/lib.rs
+++ b/contracts/merch-redemption/src/lib.rs
@@ -3,9 +3,13 @@
 mod storage;
 mod types;
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol};
+#[cfg(test)]
+mod test;
 
-pub use types::{ClaimWindowSnapshot, StockPressure};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
+
+use crate::storage::get_claim_window;
+pub use types::{ClaimWindowSnapshot, ClaimWindowState, StockPressure, StockPressureLevel};
 
 const BUMP_AMOUNT: u32 = 518_400;
 const LIFETIME_THRESHOLD: u32 = BUMP_AMOUNT / 2;
@@ -21,8 +25,7 @@ pub enum DataKey {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    NotInitialized = 1,
-    ClaimWindowNotFound = 2,
+    AlreadyInitialized = 1,
 }
 
 #[contract]
@@ -32,33 +35,97 @@ pub struct MerchRedemption;
 impl MerchRedemption {
     pub fn init(env: Env, admin: Address) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Admin) {
-            return Err(Error::NotInitialized);
+            return Err(Error::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
         Ok(())
     }
 
-    /// Returns a snapshot of the claim window for merchandise.
+    /// Returns a structured claim-window snapshot for one merch item.
+    ///
+    /// Empty/missing behavior:
+    /// - Unknown or not-yet-configured `item_id` returns `configured = false` and zero-value fields.
     pub fn claim_window_snapshot(env: Env, item_id: Symbol) -> ClaimWindowSnapshot {
-        // For now, return empty state - this would be populated with actual claim window data
-        ClaimWindowSnapshot {
-            item_id,
-            exists: false,
-            start_time: 0,
-            end_time: 0,
-            total_available: 0,
-            claimed_count: 0,
+        let maybe_state = get_claim_window(&env, &item_id);
+        let now = env.ledger().timestamp();
+
+        match maybe_state {
+            Some(state) => {
+                let remaining_stock = state.total_available.saturating_sub(state.claimed_count);
+                let is_active = now >= state.start_time
+                    && (state.end_time == 0 || now <= state.end_time)
+                    && remaining_stock > 0;
+
+                ClaimWindowSnapshot {
+                    item_id,
+                    configured: true,
+                    is_active,
+                    start_time: state.start_time,
+                    end_time: state.end_time,
+                    total_available: state.total_available,
+                    claimed_count: state.claimed_count,
+                    remaining_stock,
+                }
+            }
+            None => ClaimWindowSnapshot {
+                item_id,
+                configured: false,
+                is_active: false,
+                start_time: 0,
+                end_time: 0,
+                total_available: 0,
+                claimed_count: 0,
+                remaining_stock: 0,
+            },
         }
     }
 
-    /// Returns stock pressure information for merchandise.
+    /// Returns stock pressure for one merch item using tracked claim-window aggregates.
+    ///
+    /// Zero-value conventions:
+    /// - Unknown or not-yet-configured `item_id` returns `configured = false`,
+    ///   `pressure_bps = 0`, and `pressure_level = None`.
+    /// - `pressure_bps` is always clamped to `0..=10000`.
     pub fn stock_pressure(env: Env, item_id: Symbol) -> StockPressure {
-        // For now, return empty state - this would be populated with actual stock pressure data
+        let snapshot = Self::claim_window_snapshot(env, item_id.clone());
+
+        if !snapshot.configured || snapshot.total_available == 0 {
+            return StockPressure {
+                item_id,
+                configured: false,
+                claim_window_open: false,
+                total_available: 0,
+                claimed_count: 0,
+                remaining_stock: 0,
+                pressure_bps: 0,
+                pressure_level: StockPressureLevel::None,
+            };
+        }
+
+        let raw_bps = (snapshot.claimed_count as u128)
+            .saturating_mul(10_000)
+            .saturating_div(snapshot.total_available as u128);
+        let pressure_bps = core::cmp::min(raw_bps, 10_000) as u32;
+
+        let pressure_level = if pressure_bps >= 9_000 || snapshot.remaining_stock == 0 {
+            StockPressureLevel::High
+        } else if pressure_bps >= 7_000 {
+            StockPressureLevel::Medium
+        } else if pressure_bps >= 4_000 {
+            StockPressureLevel::Low
+        } else {
+            StockPressureLevel::None
+        };
+
         StockPressure {
             item_id,
-            exists: false,
-            remaining_stock: 0,
-            pressure_level: StockPressureLevel::None,
+            configured: true,
+            claim_window_open: snapshot.is_active,
+            total_available: snapshot.total_available,
+            claimed_count: snapshot.claimed_count,
+            remaining_stock: snapshot.remaining_stock,
+            pressure_bps,
+            pressure_level,
         }
     }
 }

--- a/contracts/merch-redemption/src/storage.rs
+++ b/contracts/merch-redemption/src/storage.rs
@@ -1,7 +1,23 @@
-use soroban_sdk::Env;
+use soroban_sdk::{Env, Symbol};
 
-use crate::DataKey;
+use crate::{types::ClaimWindowState, DataKey, BUMP_AMOUNT, LIFETIME_THRESHOLD};
 
-pub fn get_admin(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&DataKey::Admin)
+pub fn get_claim_window(env: &Env, item_id: &Symbol) -> Option<ClaimWindowState> {
+    let key = DataKey::ClaimWindow(item_id.clone());
+    let result = env.storage().persistent().get(&key);
+    if result.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
+    }
+    result
+}
+
+#[cfg(test)]
+pub fn set_claim_window(env: &Env, item_id: &Symbol, state: &ClaimWindowState) {
+    let key = DataKey::ClaimWindow(item_id.clone());
+    env.storage().persistent().set(&key, state);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
 }

--- a/contracts/merch-redemption/src/test.rs
+++ b/contracts/merch-redemption/src/test.rs
@@ -1,34 +1,73 @@
 #![cfg(test)]
-use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+
+use soroban_sdk::{testutils::Ledger as _, Env, Symbol};
 
 use super::*;
+use crate::storage::set_claim_window;
 
 #[test]
-fn test_claim_window_snapshot_empty() {
+fn test_claim_window_snapshot_empty_state() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, MerchRedemption);
+    let contract_id = env.register(MerchRedemption, ());
     let client = MerchRedemptionClient::new(&env, &contract_id);
-    let item_id = Symbol::new(&env, "item1");
+    let item_id = Symbol::new(&env, "hoodie");
 
     let snapshot = client.claim_window_snapshot(&item_id);
     assert_eq!(snapshot.item_id, item_id);
-    assert!(!snapshot.exists);
-    assert_eq!(snapshot.start_time, 0);
-    assert_eq!(snapshot.end_time, 0);
+    assert!(!snapshot.configured);
+    assert!(!snapshot.is_active);
     assert_eq!(snapshot.total_available, 0);
     assert_eq!(snapshot.claimed_count, 0);
+    assert_eq!(snapshot.remaining_stock, 0);
 }
 
 #[test]
-fn test_stock_pressure_empty() {
+fn test_claim_window_snapshot_and_stock_pressure_happy_path() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, MerchRedemption);
+    env.ledger().set_timestamp(150);
+    let contract_id = env.register(MerchRedemption, ());
     let client = MerchRedemptionClient::new(&env, &contract_id);
-    let item_id = Symbol::new(&env, "item1");
+    let item_id = Symbol::new(&env, "hoodie");
+
+    env.as_contract(&contract_id, || {
+        set_claim_window(
+            &env,
+            &item_id,
+            &ClaimWindowState {
+                start_time: 100,
+                end_time: 200,
+                total_available: 100,
+                claimed_count: 74,
+            },
+        );
+    });
+
+    let snapshot = client.claim_window_snapshot(&item_id);
+    assert!(snapshot.configured);
+    assert!(snapshot.is_active);
+    assert_eq!(snapshot.remaining_stock, 26);
 
     let pressure = client.stock_pressure(&item_id);
-    assert_eq!(pressure.item_id, item_id);
-    assert!(!pressure.exists);
+    assert!(pressure.configured);
+    assert!(pressure.claim_window_open);
+    assert_eq!(pressure.remaining_stock, 26);
+    assert_eq!(pressure.pressure_bps, 7_400);
+    assert_eq!(pressure.pressure_level, StockPressureLevel::Medium);
+}
+
+#[test]
+fn test_stock_pressure_empty_state() {
+    let env = Env::default();
+    let contract_id = env.register(MerchRedemption, ());
+    let client = MerchRedemptionClient::new(&env, &contract_id);
+    let item_id = Symbol::new(&env, "unknown");
+
+    let pressure = client.stock_pressure(&item_id);
+    assert!(!pressure.configured);
+    assert!(!pressure.claim_window_open);
+    assert_eq!(pressure.total_available, 0);
+    assert_eq!(pressure.claimed_count, 0);
     assert_eq!(pressure.remaining_stock, 0);
-    assert_eq!(pressure.pressure_level as u32, StockPressureLevel::None as u32);
+    assert_eq!(pressure.pressure_bps, 0);
+    assert_eq!(pressure.pressure_level, StockPressureLevel::None);
 }

--- a/contracts/merch-redemption/src/types.rs
+++ b/contracts/merch-redemption/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::contracttype;
+use soroban_sdk::{contracttype, Symbol};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -9,32 +9,44 @@ pub enum StockPressureLevel {
     High = 3,
 }
 
-/// Snapshot of claim window details for merchandise.
+/// Tracked aggregate for one merchandise claim window.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimWindowState {
+    pub start_time: u64,
+    pub end_time: u64,
+    pub total_available: u32,
+    pub claimed_count: u32,
+}
+
+/// Snapshot of claim-window details returned to consumers.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClaimWindowSnapshot {
     pub item_id: Symbol,
-    /// True when the item_id exists.
-    pub exists: bool,
-    /// Start time of the claim window.
+    /// True when a claim-window aggregate has been configured for `item_id`.
+    pub configured: bool,
+    /// True when the current ledger timestamp is within the configured window.
+    pub is_active: bool,
     pub start_time: u64,
-    /// End time of the claim window.
     pub end_time: u64,
-    /// Total items available for claiming.
     pub total_available: u32,
-    /// Number of items already claimed.
     pub claimed_count: u32,
+    pub remaining_stock: u32,
 }
 
-/// Stock pressure information for merchandise.
+/// Read-only stock pressure summary used by UI/API consumers.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StockPressure {
     pub item_id: Symbol,
-    /// True when the item_id exists.
-    pub exists: bool,
-    /// Remaining stock available.
+    /// True when a claim-window aggregate has been configured for `item_id`.
+    pub configured: bool,
+    pub claim_window_open: bool,
+    pub total_available: u32,
+    pub claimed_count: u32,
     pub remaining_stock: u32,
-    /// Current stock pressure level.
+    /// Claimed ratio in basis points (0-10000).
+    pub pressure_bps: u32,
     pub pressure_level: StockPressureLevel,
 }

--- a/contracts/profile-perks/Cargo.toml
+++ b/contracts/profile-perks/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-profile-perks"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/profile-perks/src/lib.rs
+++ b/contracts/profile-perks/src/lib.rs
@@ -1,0 +1,136 @@
+#![no_std]
+
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+use crate::{
+    storage::{get_catalog, get_user_state},
+    types::{ActivePerkSummary, UnlockGapSnapshot},
+};
+pub use types::{PerkCatalog, PerkTier, UserPerkState};
+
+const BUMP_AMOUNT: u32 = 518_400;
+const LIFETIME_THRESHOLD: u32 = BUMP_AMOUNT / 2;
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Catalog,
+    UserState(Address),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+}
+
+#[contract]
+pub struct ProfilePerks;
+
+#[contractimpl]
+impl ProfilePerks {
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Returns the currently active perk summary for a user profile.
+    ///
+    /// Empty/missing behavior:
+    /// - Not-yet-configured catalogs return `configured = false` with zero-value fields.
+    /// - Unknown users default to `points = 0`.
+    pub fn active_perk_summary(env: Env, user: Address) -> ActivePerkSummary {
+        let points = get_user_state(&env, &user).map(|s| s.points).unwrap_or(0);
+        let maybe_catalog = get_catalog(&env);
+
+        let Some(catalog) = maybe_catalog else {
+            return ActivePerkSummary {
+                user,
+                configured: false,
+                paused: false,
+                points: 0,
+                active_perk_id: 0,
+                active_perk_required_points: 0,
+                next_perk_id: 0,
+                next_perk_required_points: 0,
+            };
+        };
+
+        let mut active_perk_id = 0u32;
+        let mut active_required_points = 0u32;
+        let mut next_perk_id = 0u32;
+        let mut next_required_points = 0u32;
+
+        for tier in catalog.tiers.iter() {
+            if points >= tier.required_points {
+                active_perk_id = tier.perk_id;
+                active_required_points = tier.required_points;
+            } else if next_perk_id == 0 {
+                next_perk_id = tier.perk_id;
+                next_required_points = tier.required_points;
+            }
+        }
+
+        ActivePerkSummary {
+            user,
+            configured: true,
+            paused: catalog.is_paused,
+            points,
+            active_perk_id,
+            active_perk_required_points: active_required_points,
+            next_perk_id,
+            next_perk_required_points: next_required_points,
+        }
+    }
+
+    /// Returns unlock-gap info for the next perk in the active catalog.
+    ///
+    /// Zero-value conventions:
+    /// - Not-yet-configured catalogs return `configured = false`.
+    /// - If all perks are unlocked, `points_to_unlock = 0` and `all_perks_unlocked = true`.
+    pub fn unlock_gap(env: Env, user: Address) -> UnlockGapSnapshot {
+        let summary = Self::active_perk_summary(env, user.clone());
+
+        if !summary.configured {
+            return UnlockGapSnapshot {
+                user,
+                configured: false,
+                paused: false,
+                points: 0,
+                next_perk_id: 0,
+                points_to_unlock: 0,
+                all_perks_unlocked: false,
+            };
+        }
+
+        let all_perks_unlocked = summary.next_perk_id == 0;
+        let points_to_unlock = if all_perks_unlocked {
+            0
+        } else {
+            summary
+                .next_perk_required_points
+                .saturating_sub(summary.points)
+        };
+
+        UnlockGapSnapshot {
+            user,
+            configured: true,
+            paused: summary.paused,
+            points: summary.points,
+            next_perk_id: summary.next_perk_id,
+            points_to_unlock,
+            all_perks_unlocked,
+        }
+    }
+}

--- a/contracts/profile-perks/src/storage.rs
+++ b/contracts/profile-perks/src/storage.rs
@@ -1,0 +1,35 @@
+use soroban_sdk::{Address, Env};
+
+use crate::{
+    types::{PerkCatalog, UserPerkState},
+    DataKey, BUMP_AMOUNT, LIFETIME_THRESHOLD,
+};
+
+pub fn get_catalog(env: &Env) -> Option<PerkCatalog> {
+    env.storage().instance().get(&DataKey::Catalog)
+}
+
+pub fn get_user_state(env: &Env, user: &Address) -> Option<UserPerkState> {
+    let key = DataKey::UserState(user.clone());
+    let state = env.storage().persistent().get(&key);
+    if state.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
+    }
+    state
+}
+
+#[cfg(test)]
+pub fn set_catalog(env: &Env, catalog: &PerkCatalog) {
+    env.storage().instance().set(&DataKey::Catalog, catalog);
+}
+
+#[cfg(test)]
+pub fn set_user_state(env: &Env, user: &Address, state: &UserPerkState) {
+    let key = DataKey::UserState(user.clone());
+    env.storage().persistent().set(&key, state);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
+}

--- a/contracts/profile-perks/src/test.rs
+++ b/contracts/profile-perks/src/test.rs
@@ -1,0 +1,121 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+use super::*;
+use crate::storage::{set_catalog, set_user_state};
+
+#[test]
+fn test_active_perk_summary_unconfigured_catalog() {
+    let env = Env::default();
+    let contract_id = env.register(ProfilePerks, ());
+    let client = ProfilePerksClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    let summary = client.active_perk_summary(&user);
+    assert!(!summary.configured);
+    assert_eq!(summary.points, 0);
+    assert_eq!(summary.active_perk_id, 0);
+    assert_eq!(summary.next_perk_id, 0);
+}
+
+#[test]
+fn test_active_perk_summary_and_unlock_gap_happy_path() {
+    let env = Env::default();
+    let contract_id = env.register(ProfilePerks, ());
+    let client = ProfilePerksClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    let tiers = vec![
+        &env,
+        PerkTier {
+            perk_id: 1,
+            required_points: 100,
+        },
+        PerkTier {
+            perk_id: 2,
+            required_points: 250,
+        },
+        PerkTier {
+            perk_id: 3,
+            required_points: 500,
+        },
+    ];
+
+    env.as_contract(&contract_id, || {
+        set_catalog(
+            &env,
+            &PerkCatalog {
+                is_paused: false,
+                tiers,
+            },
+        );
+
+        set_user_state(
+            &env,
+            &user,
+            &UserPerkState {
+                user: user.clone(),
+                points: 280,
+            },
+        );
+    });
+
+    let summary = client.active_perk_summary(&user);
+    assert!(summary.configured);
+    assert!(!summary.paused);
+    assert_eq!(summary.points, 280);
+    assert_eq!(summary.active_perk_id, 2);
+    assert_eq!(summary.next_perk_id, 3);
+    assert_eq!(summary.next_perk_required_points, 500);
+
+    let gap = client.unlock_gap(&user);
+    assert!(gap.configured);
+    assert_eq!(gap.next_perk_id, 3);
+    assert_eq!(gap.points_to_unlock, 220);
+    assert!(!gap.all_perks_unlocked);
+}
+
+#[test]
+fn test_unlock_gap_all_perks_unlocked() {
+    let env = Env::default();
+    let contract_id = env.register(ProfilePerks, ());
+    let client = ProfilePerksClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        set_catalog(
+            &env,
+            &PerkCatalog {
+                is_paused: true,
+                tiers: vec![
+                    &env,
+                    PerkTier {
+                        perk_id: 10,
+                        required_points: 10,
+                    },
+                    PerkTier {
+                        perk_id: 20,
+                        required_points: 20,
+                    },
+                ],
+            },
+        );
+
+        set_user_state(
+            &env,
+            &user,
+            &UserPerkState {
+                user: user.clone(),
+                points: 99,
+            },
+        );
+    });
+
+    let gap = client.unlock_gap(&user);
+    assert!(gap.configured);
+    assert!(gap.paused);
+    assert_eq!(gap.next_perk_id, 0);
+    assert_eq!(gap.points_to_unlock, 0);
+    assert!(gap.all_perks_unlocked);
+}

--- a/contracts/profile-perks/src/types.rs
+++ b/contracts/profile-perks/src/types.rs
@@ -1,0 +1,47 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PerkTier {
+    pub perk_id: u32,
+    pub required_points: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PerkCatalog {
+    pub is_paused: bool,
+    pub tiers: soroban_sdk::Vec<PerkTier>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserPerkState {
+    pub user: Address,
+    pub points: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActivePerkSummary {
+    pub user: Address,
+    pub configured: bool,
+    pub paused: bool,
+    pub points: u32,
+    pub active_perk_id: u32,
+    pub active_perk_required_points: u32,
+    pub next_perk_id: u32,
+    pub next_perk_required_points: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnlockGapSnapshot {
+    pub user: Address,
+    pub configured: bool,
+    pub paused: bool,
+    pub points: u32,
+    pub next_perk_id: u32,
+    pub points_to_unlock: u32,
+    pub all_perks_unlocked: bool,
+}

--- a/docs/contracts/merch-redemption.md
+++ b/docs/contracts/merch-redemption.md
@@ -1,0 +1,20 @@
+# merch-redemption
+
+## Public Reads
+
+### `claim_window_snapshot(item_id: Symbol) -> ClaimWindowSnapshot`
+
+Returns a structured claim-window read for a merch item.
+
+Fallback behavior:
+- Unknown or not-yet-configured `item_id` returns `configured = false`.
+- Numeric fields return zero values when unconfigured.
+
+### `stock_pressure(item_id: Symbol) -> StockPressure`
+
+Returns stock pressure derived from tracked claim-window aggregates.
+
+Fallback and zero-value conventions:
+- Unknown or not-yet-configured `item_id` returns `configured = false`.
+- `pressure_bps` is in basis points (`0..=10000`) and returns `0` for unconfigured items.
+- `pressure_level = None` for unconfigured items.

--- a/docs/contracts/profile-perks.md
+++ b/docs/contracts/profile-perks.md
@@ -1,0 +1,19 @@
+# profile-perks
+
+## Public Reads
+
+### `active_perk_summary(user: Address) -> ActivePerkSummary`
+
+Returns the active-perk summary and next unlock target for a user.
+
+Fallback behavior:
+- If the catalog is not configured, `configured = false` and numeric fields are zeroed.
+- Unknown users default to `points = 0`.
+
+### `unlock_gap(user: Address) -> UnlockGapSnapshot`
+
+Returns the remaining gap to the next perk unlock.
+
+Fallback and zero-value conventions:
+- If the catalog is not configured, `configured = false`.
+- When every tier is already unlocked, `all_perks_unlocked = true` and `points_to_unlock = 0`.

--- a/frontend/src/components/v1/ActionToolbar.css
+++ b/frontend/src/components/v1/ActionToolbar.css
@@ -39,7 +39,6 @@
   box-shadow: 0 0 0 2px var(--primary-color, #3b82f6);
 }
 
-/* Intents */
 .stellarcade-toolbar-item--primary {
   background: var(--primary-color, #3b82f6);
   color: white;
@@ -69,7 +68,6 @@
   color: white;
 }
 
-/* States */
 .stellarcade-toolbar-item:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -103,25 +101,11 @@
   }
 }
 
-/* Responsive adjustments */
-@media (max-width: 600px) {
-  .stellarcade-action-toolbar--horizontal {
-    flex-wrap: wrap;
-  }
-
-  .stellarcade-toolbar-item {
-    width: 100%;
-    height: 48px; /* Larger touch target for thumbs */
-    font-size: 16px; /* Prevent zoom on some mobile browsers */
-  }
-}
-
 .stellarcade-toolbar-item-wrapper {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: 4px;
-  flex: 1;
 }
 
 .stellarcade-toolbar-disabled-reason {
@@ -131,29 +115,37 @@
   line-height: 1.3;
   text-align: center;
 }
-.stellarcade-action-toolbar {
-  /* Anchor to bottom */
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%; 
-  border-radius: 0;
 
-  background: rgba(15, 15, 15, 0.9);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+@media (max-width: 600px) {
+  .stellarcade-action-toolbar--horizontal {
+    flex-wrap: wrap;
+  }
 
-  /* Safe area handling for iOS/Android notches */
-  padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+  .stellarcade-toolbar-item {
+    width: 100%;
+    height: 48px;
+    font-size: 16px;
+  }
 
-  z-index: 999;
-  box-shadow: 0 -4px 15px rgba(0, 0, 0, 0.4);
+  .stellarcade-action-toolbar--mobile-sticky {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 999;
+    width: 100%;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0;
+    background: rgba(15, 15, 15, 0.92);
+    box-shadow: 0 -4px 15px rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+    flex-wrap: nowrap;
+    gap: 12px;
+  }
 
-  /* Layout logic */
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  gap: 12px;
+  .stellarcade-action-toolbar--mobile-sticky .stellarcade-toolbar-item-wrapper {
+    flex: 1;
+  }
 }

--- a/frontend/src/components/v1/ActionToolbar.tsx
+++ b/frontend/src/components/v1/ActionToolbar.tsx
@@ -36,6 +36,8 @@ export interface ActionToolbarProps {
     actions: ToolbarAction[];
     /** Layout orientation. @default 'horizontal' */
     orientation?: 'horizontal' | 'vertical';
+    /** Pins the toolbar to a sticky mobile footer when the viewport is narrow. */
+    mobileSticky?: boolean;
     /** Optional CSS class name for custom styling. */
     className?: string;
     /** Optional test ID for automation. @default 'action-toolbar' */
@@ -51,6 +53,7 @@ export interface ActionToolbarProps {
 export const ActionToolbar: React.FC<ActionToolbarProps> = ({
     actions,
     orientation = 'horizontal',
+    mobileSticky = false,
     className = '',
     testId = 'action-toolbar'
 }) => {
@@ -91,7 +94,7 @@ export const ActionToolbar: React.FC<ActionToolbarProps> = ({
 
     return (
         <div
-            className={`stellarcade-action-toolbar stellarcade-action-toolbar--${orientation} ${className}`}
+            className={`stellarcade-action-toolbar stellarcade-action-toolbar--${orientation} ${mobileSticky ? 'stellarcade-action-toolbar--mobile-sticky' : ''} ${className}`}
             role="toolbar"
             aria-label="Action Toolbar"
             data-testid={testId}

--- a/frontend/src/components/v1/InlineStatDelta.css
+++ b/frontend/src/components/v1/InlineStatDelta.css
@@ -1,0 +1,32 @@
+.inline-stat-delta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  font-size: 0.82rem;
+  line-height: 1.2;
+}
+
+.inline-stat-delta__value {
+  font-weight: 700;
+}
+
+.inline-stat-delta__label {
+  color: var(--text-dim, #a0a0a0);
+}
+
+.inline-stat-delta--up .inline-stat-delta__value {
+  color: #34d399;
+}
+
+.inline-stat-delta--down .inline-stat-delta__value {
+  color: #f87171;
+}
+
+.inline-stat-delta--flat .inline-stat-delta__value {
+  color: #cbd5e1;
+}
+
+.inline-stat-delta--empty .inline-stat-delta__value,
+.inline-stat-delta--loading .inline-stat-delta__value {
+  color: var(--text-dim, #a0a0a0);
+}

--- a/frontend/src/components/v1/InlineStatDelta.tsx
+++ b/frontend/src/components/v1/InlineStatDelta.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "./InlineStatDelta.css";
+
+export interface InlineStatDeltaProps {
+  value: number | null;
+  label?: string;
+  loading?: boolean;
+  className?: string;
+  testId?: string;
+}
+
+function getDeltaTone(value: number | null): "up" | "down" | "flat" | "empty" {
+  if (value === null) {
+    return "empty";
+  }
+  if (value > 0) {
+    return "up";
+  }
+  if (value < 0) {
+    return "down";
+  }
+  return "flat";
+}
+
+function formatDelta(value: number): string {
+  if (value > 0) {
+    return `+${value}`;
+  }
+  return String(value);
+}
+
+export const InlineStatDelta: React.FC<InlineStatDeltaProps> = ({
+  value,
+  label = "vs last refresh",
+  loading = false,
+  className = "",
+  testId = "inline-stat-delta",
+}) => {
+  if (loading) {
+    return (
+      <span
+        className={`inline-stat-delta inline-stat-delta--loading ${className}`.trim()}
+        aria-live="polite"
+        data-testid={testId}
+      >
+        Updating
+      </span>
+    );
+  }
+
+  const tone = getDeltaTone(value);
+  const content = value === null ? "--" : formatDelta(value);
+
+  return (
+    <span
+      className={`inline-stat-delta inline-stat-delta--${tone} ${className}`.trim()}
+      aria-live="polite"
+      data-testid={testId}
+    >
+      <span className="inline-stat-delta__value">{content}</span>
+      <span className="inline-stat-delta__label">{label}</span>
+    </span>
+  );
+};
+
+export default InlineStatDelta;

--- a/frontend/src/components/v1/index.ts
+++ b/frontend/src/components/v1/index.ts
@@ -284,6 +284,12 @@ export type {
 } from "./EventDigestPanel";
 
 export {
+  InlineStatDelta,
+  default as InlineStatDeltaDefault,
+} from "./InlineStatDelta";
+export type { InlineStatDeltaProps } from "./InlineStatDelta";
+
+export {
   ReviewSubmitSheet,
   default as ReviewSubmitSheetDefault,
 } from "./ReviewSubmitSheet";

--- a/frontend/src/pages/GameLobby.tsx
+++ b/frontend/src/pages/GameLobby.tsx
@@ -15,6 +15,8 @@ import { PendingActionResumeChip } from "../components/v1/PendingActionResumeChi
 import { ResumeTaskBanner } from "../components/v1/ResumeTaskBanner";
 import { SegmentedControl } from "../components/v1/SegmentedControl";
 import { WalletSessionActivityRail } from "../components/v1/WalletSessionActivityRail";
+import { ActionToolbar, type ToolbarAction } from "../components/v1/ActionToolbar";
+import { InlineStatDelta } from "../components/v1/InlineStatDelta";
 import { useWalletStatus } from "../hooks/v1/useWalletStatus";
 import { ApiClient } from "../services/typed-api-sdk";
 import GlobalStateStore, {
@@ -133,12 +135,15 @@ export const GameLobby: React.FC = () => {
   const [pendingResumeContext, setPendingResumeContext] =
     useState<LobbyContext | null>(null);
   const [pendingActionChipDismissed, setPendingActionChipDismissed] = useState(false);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [activeGamesDelta, setActiveGamesDelta] = useState<number | null>(null);
   const wallet = useWalletStatus();
   const globalStoreRef = useRef<GlobalStateStore | null>(null);
   const walletSectionRef = useRef<HTMLDivElement | null>(null);
   const gamesSectionRef = useRef<HTMLElement | null>(null);
   const activityRailRef = useRef<HTMLDivElement | null>(null);
   const leaderboardSectionRef = useRef<HTMLElement | null>(null);
+  const previousActiveGamesCountRef = useRef<number | null>(null);
   const previousWalletStatusRef = useRef(wallet.status);
   const previousReconnectAtRef = useRef(wallet.lastReconnectAt);
 
@@ -248,6 +253,24 @@ export const GameLobby: React.FC = () => {
   }, [fetchGames, retrying]);
 
   useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(max-width: 600px)");
+    const updateMatch = () => setIsMobileViewport(mediaQuery.matches);
+    updateMatch();
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", updateMatch);
+      return () => mediaQuery.removeEventListener("change", updateMatch);
+    }
+
+    mediaQuery.addListener(updateMatch);
+    return () => mediaQuery.removeListener(updateMatch);
+  }, []);
+
+  useEffect(() => {
     const store = globalStoreRef.current!;
     setPendingTransaction(store.getState().pendingTransaction ?? null);
     return store.subscribe((state) => {
@@ -339,6 +362,14 @@ export const GameLobby: React.FC = () => {
       games.filter((game) => String(game.status).toLowerCase() === "active"),
     [games],
   );
+
+  useEffect(() => {
+    const previousCount = previousActiveGamesCountRef.current;
+    if (previousCount !== null) {
+      setActiveGamesDelta(activeGames.length - previousCount);
+    }
+    previousActiveGamesCountRef.current = activeGames.length;
+  }, [activeGames.length]);
 
   const leaderboardRows = useMemo<LeaderboardRow[]>(
     () =>
@@ -509,6 +540,46 @@ export const GameLobby: React.FC = () => {
     [handleRefreshLobby, markQuickActionsUsed, openCommandCenter, retrying, scrollToContext],
   );
 
+  const mobileToolbarActions = useMemo<ToolbarAction[]>(
+    () => [
+      {
+        id: "refresh-lobby",
+        label: "Refresh",
+        onClick: handleRefreshLobby,
+        intent: "primary",
+        isLoading: retrying,
+      },
+      {
+        id: "open-command-center",
+        label: "Commands",
+        onClick: openCommandCenter,
+        intent: "secondary",
+      },
+      pendingTransaction
+        ? {
+            id: "inspect-transaction",
+            label: "Inspect tx",
+            onClick: () => setIsTransactionDrawerOpen(true),
+            intent: "tertiary",
+          }
+        : {
+            id: "open-wallet-panel",
+            label: "Wallet",
+            onClick: () => scrollToContext("wallet-panel"),
+            intent: "tertiary",
+          },
+    ],
+    [
+      handleRefreshLobby,
+      openCommandCenter,
+      pendingTransaction,
+      retrying,
+      scrollToContext,
+    ],
+  );
+
+  const showMobileActionFooter = isMobileViewport && mobileToolbarActions.length > 0;
+
   const activityItems = useMemo(() => {
     const items: Array<{
       id: string;
@@ -626,7 +697,9 @@ export const GameLobby: React.FC = () => {
   }
 
   return (
-    <div className="game-lobby">
+    <div
+      className={`game-lobby ${showMobileActionFooter ? "game-lobby--with-mobile-footer" : ""}`.trim()}
+    >
       {!checklistDismissed ? (
         <DashboardMissionStrip
           missions={missionItems}
@@ -679,6 +752,11 @@ export const GameLobby: React.FC = () => {
           <div className="lobby-header">
             <h1 id="games-heading">Live Arena</h1>
             <p>Real-time game status across the Stellar ecosystem.</p>
+            <InlineStatDelta
+              value={activeGamesDelta}
+              label="active games vs last sync"
+              className="lobby-header__delta"
+            />
           </div>
 
           <QuickActionSurface actions={quickActions} />
@@ -862,6 +940,15 @@ export const GameLobby: React.FC = () => {
         pendingTransaction={pendingTransaction}
         network={wallet.network}
       />
+
+      {showMobileActionFooter ? (
+        <ActionToolbar
+          actions={mobileToolbarActions}
+          mobileSticky={true}
+          className="game-lobby__mobile-action-footer"
+          testId="lobby-mobile-action-footer"
+        />
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/pages/GameLobbyDashboard.css
+++ b/frontend/src/pages/GameLobbyDashboard.css
@@ -4,6 +4,18 @@
   gap: 1.5rem;
 }
 
+.game-lobby--with-mobile-footer {
+  padding-bottom: calc(96px + env(safe-area-inset-bottom));
+}
+
+.game-lobby__mobile-action-footer {
+  margin: 0;
+}
+
+.lobby-header__delta {
+  margin-top: 0.6rem;
+}
+
 .lobby-content-grid {
   display: grid;
   gap: 1.5rem;
@@ -252,5 +264,9 @@
   .quick-action-surface__item-topline {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .game-lobby--with-mobile-footer {
+    padding-bottom: calc(104px + env(safe-area-inset-bottom));
   }
 }

--- a/frontend/tests/components/v1/ActionToolbar.test.tsx
+++ b/frontend/tests/components/v1/ActionToolbar.test.tsx
@@ -104,5 +104,13 @@ describe('ActionToolbar', () => {
         const toolbar = screen.getByRole('toolbar');
         
         expect(toolbar).toHaveClass('stellarcade-action-toolbar');
+        expect(toolbar).not.toHaveClass('stellarcade-action-toolbar--mobile-sticky');
+    });
+
+    it('renders the sticky mobile footer class when enabled', () => {
+        render(<ActionToolbar actions={mockActions} mobileSticky={true} />);
+        const toolbar = screen.getByRole('toolbar');
+
+        expect(toolbar).toHaveClass('stellarcade-action-toolbar--mobile-sticky');
     });
 });

--- a/frontend/tests/components/v1/InlineStatDelta.test.tsx
+++ b/frontend/tests/components/v1/InlineStatDelta.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { InlineStatDelta } from "../../../src/components/v1/InlineStatDelta";
+
+describe("InlineStatDelta", () => {
+  it("renders a positive delta with sign", () => {
+    render(<InlineStatDelta value={4} />);
+
+    expect(screen.getByText("+4")).toBeInTheDocument();
+    expect(screen.getByText("vs last refresh")).toBeInTheDocument();
+  });
+
+  it("renders an empty-state fallback when data is unavailable", () => {
+    render(<InlineStatDelta value={null} label="vs prior sample" />);
+
+    expect(screen.getByText("--")).toBeInTheDocument();
+    expect(screen.getByText("vs prior sample")).toBeInTheDocument();
+  });
+
+  it("renders loading text when loading is true", () => {
+    render(<InlineStatDelta value={2} loading={true} />);
+
+    expect(screen.getByText("Updating")).toBeInTheDocument();
+    expect(screen.queryByText("+2")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description
This PR delivers the four backlog items together: a mobile-first action footer and trend delta primitive on the frontend, plus new structured read accessors for `merch-redemption` and `profile-perks` contracts.

Closes #450
Closes #536
Closes #605
Closes #629

## Changes proposed

### What were you told to do?
Implement all four issues in one grouped PR, covering the specified frontend and contract modules, with tests and docs updated so reviewers can verify behavior directly.

### What did I do?
#### Frontend mobile action reachability and trend delta
- Added opt-in `mobileSticky` support to `ActionToolbar` and updated CSS so sticky footer behavior applies only on mobile breakpoints.
- Wired a sticky mobile action footer into `GameLobby` for high-priority interactions (refresh, command center, tx/wallet shortcut), while preserving desktop behavior.
- Added safe-area-aware bottom spacing in `GameLobby` to prevent footer overlap with content/modals.
- Introduced reusable `InlineStatDelta` component and integrated it in `GameLobby` to show trend-aware active-game deltas.
- Extended frontend tests for sticky/footer behavior and added dedicated tests for `InlineStatDelta` states.

#### Contract merch-redemption accessors (#536)
- Implemented `claim_window_snapshot` and `stock_pressure` as structured read accessors backed by tracked claim-window storage aggregates.
- Added explicit empty/unconfigured conventions and stock pressure basis-point/level mapping.
- Added standalone contract manifest and unit tests for happy path + missing-state behavior.
- Added contract docs page describing public read interface and fallback conventions.

#### Contract profile-perks accessors (#605)
- Added new `profile-perks` contract module set with `active_perk_summary` and `unlock_gap` read methods.
- Implemented explicit handling for unconfigured catalogs, missing users, paused catalogs, and fully unlocked states.
- Added storage/type modules plus unit tests for success path and missing/edge states.
- Added contract docs page describing outputs and zero-state behavior.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `frontend`: `npx eslint src/components/v1/ActionToolbar.tsx src/components/v1/InlineStatDelta.tsx src/pages/GameLobby.tsx tests/components/v1/ActionToolbar.test.tsx tests/components/v1/InlineStatDelta.test.tsx --ext .ts,.tsx`
- `frontend`: `npx vitest run tests/components/v1/ActionToolbar.test.tsx tests/components/v1/InlineStatDelta.test.tsx`
- `contracts/merch-redemption`: `cargo test --manifest-path contracts/merch-redemption/Cargo.toml` (via stable toolchain binary)
- `contracts/profile-perks`: `cargo test --manifest-path contracts/profile-perks/Cargo.toml` (via stable toolchain binary)
- Repo-wide frontend `npm run typecheck` currently fails due pre-existing unrelated errors in existing files (e.g. `frontend/src/components/v1/QueueHealthWidget.tsx`, `frontend/src/pages/AnalyticsDashboard.tsx`, and legacy Jest-namespace test files); these were not introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Merch Redemption contract for managing item availability windows and stock levels
  * Added Profile Perks contract for tracking player progression through perk tiers
  * Improved Game Lobby mobile interface with sticky action controls and live player activity indicator

* **Documentation**
  * Added contract query documentation for Merch Redemption and Profile Perks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->