### PR TITLE
feat(contracts,frontend): mission-ledger snapshot, vault-claims summary, reward strip, caution panel

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1964,6 +1964,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-affiliate-ledger"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-ai-generated-game"
 version = "0.1.0"
 dependencies = [
@@ -2141,6 +2148,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-daily-challenges"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-daily-reward-emission"
 version = "0.1.0"
 dependencies = [
@@ -2307,6 +2321,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-mission-ledger"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-multiplayer-room"
 version = "0.1.0"
 dependencies = [
@@ -2358,6 +2379,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-prize-pool"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-prize-router-v2"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2469,7 +2497,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-sponsorship-ledger"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-squad-match"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-squad-roster"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2540,6 +2582,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-upgrade-mechanism"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-vault-claims"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -38,6 +38,8 @@ members = [
     "escrow-ledger",
     "escrow-marketplace",
     "escrow-vault",
+    "mission-ledger",
+    "vault-claims",
     "attendance-pass",
     "exploit-prevention",
     "fee-shield",

--- a/contracts/mission-ledger/Cargo.toml
+++ b/contracts/mission-ledger/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-mission-ledger"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/mission-ledger/src/lib.rs
+++ b/contracts/mission-ledger/src/lib.rs
@@ -1,0 +1,415 @@
+#![no_std]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub use types::{ClaimReadiness, ClaimReadinessReason, MissionRecord, MissionSnapshot, MissionStatus};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Mission(u64),
+    PlayerProgress(u64, Address),
+    PlayerClaimed(u64, Address),
+}
+
+#[contract]
+pub struct MissionLedger;
+
+#[contractimpl]
+impl MissionLedger {
+    /// Initialise the ledger with an admin who can register / pause missions.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Register a new mission. Idempotent only on duplicate `mission_id` —
+    /// re-registration with a different id is allowed.
+    pub fn register_mission(
+        env: Env,
+        admin: Address,
+        mission_id: u64,
+        operator: Address,
+        completion_threshold: u32,
+        reward_amount: i128,
+        reward_token: Address,
+        expires_at: u64,
+    ) {
+        require_admin(&env, &admin);
+        admin.require_auth();
+        assert!(
+            completion_threshold > 0,
+            "completion_threshold must be positive"
+        );
+        assert!(reward_amount >= 0, "reward_amount must be non-negative");
+        assert!(
+            expires_at > env.ledger().timestamp(),
+            "expires_at must be in the future"
+        );
+        if storage::get_mission(&env, mission_id).is_some() {
+            panic!("Mission already registered");
+        }
+
+        storage::set_mission(
+            &env,
+            &MissionRecord {
+                mission_id,
+                operator,
+                completion_threshold,
+                reward_amount,
+                reward_token,
+                expires_at,
+                paused: false,
+                completed_count: 0,
+                total_claimed: 0,
+            },
+        );
+    }
+
+    /// Record incremental progress for `player` against `mission_id`.
+    ///
+    /// `progress_delta` is added to the player's running counter; the contract
+    /// caps the stored value at `completion_threshold` so external counters
+    /// can over-report without breaking readiness semantics.
+    pub fn record_progress(env: Env, player: Address, mission_id: u64, progress_delta: u32) {
+        player.require_auth();
+        let mission = storage::get_mission(&env, mission_id).expect("Mission not registered");
+        assert!(!mission.paused, "Mission is paused");
+        assert!(
+            env.ledger().timestamp() < mission.expires_at,
+            "Mission expired"
+        );
+
+        let current = storage::get_player_progress(&env, mission_id, &player).unwrap_or(0);
+        let next = current
+            .saturating_add(progress_delta)
+            .min(mission.completion_threshold);
+        storage::set_player_progress(&env, mission_id, &player, next);
+    }
+
+    /// Mark a mission paused / unpaused. Pausing leaves the record in place
+    /// but blocks `record_progress` and `claim`.
+    pub fn set_paused(env: Env, admin: Address, mission_id: u64, paused: bool) {
+        require_admin(&env, &admin);
+        admin.require_auth();
+        let mut mission = storage::get_mission(&env, mission_id).expect("Mission not registered");
+        mission.paused = paused;
+        storage::set_mission(&env, &mission);
+    }
+
+    /// Claim the reward for a completed mission. Idempotent on
+    /// `(mission_id, player)`.
+    pub fn claim(env: Env, player: Address, mission_id: u64) -> i128 {
+        player.require_auth();
+        let readiness = Self::reward_claim_ready(env.clone(), mission_id, player.clone());
+        assert!(readiness.ready, "Reward not claimable");
+
+        let mut mission = storage::get_mission(&env, mission_id).expect("Mission not registered");
+        storage::mark_player_claimed(&env, mission_id, &player);
+        mission.completed_count = mission.completed_count.saturating_add(1);
+        mission.total_claimed = mission.total_claimed.saturating_add(mission.reward_amount);
+        storage::set_mission(&env, &mission);
+
+        mission.reward_amount
+    }
+
+    // ---------------------------------------------------------------------
+    // Read-only accessors (the body of issue #679)
+    // ---------------------------------------------------------------------
+
+    /// Snapshot of the on-chain mission state. Suitable for direct rendering
+    /// on the frontend dashboard without ad-hoc joins.
+    pub fn mission_snapshot(env: Env, mission_id: u64) -> MissionSnapshot {
+        let now = env.ledger().timestamp();
+        let configured = env.storage().instance().has(&DataKey::Admin);
+
+        let Some(mission) = storage::get_mission(&env, mission_id) else {
+            return MissionSnapshot {
+                mission_id,
+                configured,
+                exists: false,
+                status: if configured {
+                    MissionStatus::NotConfigured
+                } else {
+                    MissionStatus::NotConfigured
+                },
+                completion_threshold: 0,
+                completed_count: 0,
+                reward_amount: 0,
+                total_claimed: 0,
+                expires_at: 0,
+                now,
+            };
+        };
+
+        let status = derive_status(&mission, now);
+
+        MissionSnapshot {
+            mission_id,
+            configured,
+            exists: true,
+            status,
+            completion_threshold: mission.completion_threshold,
+            completed_count: mission.completed_count,
+            reward_amount: mission.reward_amount,
+            total_claimed: mission.total_claimed,
+            expires_at: mission.expires_at,
+            now,
+        }
+    }
+
+    /// Whether `player` can claim the reward for `mission_id`. Returns a
+    /// structured reason regardless of the boolean outcome so observability
+    /// tooling can log the exact gating condition.
+    pub fn reward_claim_ready(env: Env, mission_id: u64, player: Address) -> ClaimReadiness {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        if !configured {
+            return ClaimReadiness {
+                mission_id,
+                ready: false,
+                reason: ClaimReadinessReason::LedgerNotConfigured,
+                progress: 0,
+                threshold: 0,
+            };
+        }
+
+        let Some(mission) = storage::get_mission(&env, mission_id) else {
+            return ClaimReadiness {
+                mission_id,
+                ready: false,
+                reason: ClaimReadinessReason::MissionUnknown,
+                progress: 0,
+                threshold: 0,
+            };
+        };
+
+        if storage::has_player_claimed(&env, mission_id, &player) {
+            return ClaimReadiness {
+                mission_id,
+                ready: false,
+                reason: ClaimReadinessReason::AlreadyClaimed,
+                progress: mission.completion_threshold,
+                threshold: mission.completion_threshold,
+            };
+        }
+        if mission.paused {
+            return ClaimReadiness {
+                mission_id,
+                ready: false,
+                reason: ClaimReadinessReason::MissionPaused,
+                progress: storage::get_player_progress(&env, mission_id, &player).unwrap_or(0),
+                threshold: mission.completion_threshold,
+            };
+        }
+        if env.ledger().timestamp() >= mission.expires_at {
+            return ClaimReadiness {
+                mission_id,
+                ready: false,
+                reason: ClaimReadinessReason::MissionExpired,
+                progress: storage::get_player_progress(&env, mission_id, &player).unwrap_or(0),
+                threshold: mission.completion_threshold,
+            };
+        }
+
+        let Some(progress) = storage::get_player_progress(&env, mission_id, &player) else {
+            return ClaimReadiness {
+                mission_id,
+                ready: false,
+                reason: ClaimReadinessReason::PlayerNotEnrolled,
+                progress: 0,
+                threshold: mission.completion_threshold,
+            };
+        };
+
+        if progress < mission.completion_threshold {
+            return ClaimReadiness {
+                mission_id,
+                ready: false,
+                reason: ClaimReadinessReason::ProgressIncomplete,
+                progress,
+                threshold: mission.completion_threshold,
+            };
+        }
+
+        ClaimReadiness {
+            mission_id,
+            ready: true,
+            reason: ClaimReadinessReason::Ready,
+            progress,
+            threshold: mission.completion_threshold,
+        }
+    }
+}
+
+fn derive_status(mission: &MissionRecord, now: u64) -> MissionStatus {
+    if mission.paused {
+        return MissionStatus::Paused;
+    }
+    if now >= mission.expires_at {
+        if mission.completed_count > 0 {
+            return MissionStatus::Completed;
+        }
+        return MissionStatus::Expired;
+    }
+    if mission.completed_count > 0 {
+        return MissionStatus::Completed;
+    }
+    MissionStatus::Active
+}
+
+fn require_admin(env: &Env, claimed: &Address) {
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Not initialized");
+    assert!(stored == *claimed, "Caller is not admin");
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, Env};
+
+    fn setup<'a>() -> (Env, Address, MissionLedgerClient<'a>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        let contract_id = env.register(MissionLedger, ());
+        let client = MissionLedgerClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        (env, admin, client)
+    }
+
+    fn register(
+        env: &Env,
+        client: &MissionLedgerClient,
+        admin: &Address,
+        mission_id: u64,
+        threshold: u32,
+        expires_at: u64,
+    ) {
+        let operator = Address::generate(env);
+        let token = Address::generate(env);
+        client.register_mission(
+            admin,
+            &mission_id,
+            &operator,
+            &threshold,
+            &500i128,
+            &token,
+            &expires_at,
+        );
+    }
+
+    #[test]
+    fn mission_snapshot_unknown_mission_returns_not_configured() {
+        let (_env, _admin, client) = setup();
+
+        let snap = client.mission_snapshot(&999u64);
+        assert_eq!(snap.exists, false);
+        assert_eq!(snap.configured, true);
+        assert_eq!(snap.status, MissionStatus::NotConfigured);
+        assert_eq!(snap.now, 1_000);
+    }
+
+    #[test]
+    fn mission_snapshot_active_then_completed_after_claim() {
+        let (env, admin, client) = setup();
+        register(&env, &client, &admin, 1, 3, 5_000);
+
+        let active = client.mission_snapshot(&1u64);
+        assert_eq!(active.exists, true);
+        assert_eq!(active.status, MissionStatus::Active);
+        assert_eq!(active.completion_threshold, 3);
+
+        let player = Address::generate(&env);
+        client.record_progress(&player, &1u64, &3u32);
+        let claimed = client.claim(&player, &1u64);
+        assert_eq!(claimed, 500);
+
+        let after = client.mission_snapshot(&1u64);
+        assert_eq!(after.status, MissionStatus::Completed);
+        assert_eq!(after.completed_count, 1);
+        assert_eq!(after.total_claimed, 500);
+    }
+
+    #[test]
+    fn reward_claim_ready_returns_ready_after_full_progress() {
+        let (env, admin, client) = setup();
+        register(&env, &client, &admin, 1, 2, 5_000);
+        let player = Address::generate(&env);
+
+        let r0 = client.reward_claim_ready(&1u64, &player);
+        assert_eq!(r0.ready, false);
+        assert_eq!(r0.reason, ClaimReadinessReason::PlayerNotEnrolled);
+
+        client.record_progress(&player, &1u64, &1u32);
+        let r1 = client.reward_claim_ready(&1u64, &player);
+        assert_eq!(r1.ready, false);
+        assert_eq!(r1.reason, ClaimReadinessReason::ProgressIncomplete);
+        assert_eq!(r1.progress, 1);
+
+        client.record_progress(&player, &1u64, &1u32);
+        let r2 = client.reward_claim_ready(&1u64, &player);
+        assert_eq!(r2.ready, true);
+        assert_eq!(r2.reason, ClaimReadinessReason::Ready);
+    }
+
+    #[test]
+    fn reward_claim_ready_handles_paused_state() {
+        let (env, admin, client) = setup();
+        register(&env, &client, &admin, 1, 1, 5_000);
+        let player = Address::generate(&env);
+        client.record_progress(&player, &1u64, &1u32);
+
+        client.set_paused(&admin, &1u64, &true);
+        let r = client.reward_claim_ready(&1u64, &player);
+        assert_eq!(r.ready, false);
+        assert_eq!(r.reason, ClaimReadinessReason::MissionPaused);
+    }
+
+    #[test]
+    fn reward_claim_ready_handles_expired_state() {
+        let (env, admin, client) = setup();
+        register(&env, &client, &admin, 1, 1, 2_000);
+        let player = Address::generate(&env);
+        client.record_progress(&player, &1u64, &1u32);
+
+        env.ledger().set_timestamp(3_000);
+        let r = client.reward_claim_ready(&1u64, &player);
+        assert_eq!(r.ready, false);
+        assert_eq!(r.reason, ClaimReadinessReason::MissionExpired);
+    }
+
+    #[test]
+    fn double_claim_is_blocked() {
+        let (env, admin, client) = setup();
+        register(&env, &client, &admin, 1, 1, 5_000);
+        let player = Address::generate(&env);
+        client.record_progress(&player, &1u64, &1u32);
+        client.claim(&player, &1u64);
+
+        let r = client.reward_claim_ready(&1u64, &player);
+        assert_eq!(r.ready, false);
+        assert_eq!(r.reason, ClaimReadinessReason::AlreadyClaimed);
+    }
+
+    #[test]
+    fn reward_claim_ready_unknown_mission() {
+        let (env, _admin, client) = setup();
+        let player = Address::generate(&env);
+        let r = client.reward_claim_ready(&42u64, &player);
+        assert_eq!(r.ready, false);
+        assert_eq!(r.reason, ClaimReadinessReason::MissionUnknown);
+    }
+}

--- a/contracts/mission-ledger/src/storage.rs
+++ b/contracts/mission-ledger/src/storage.rs
@@ -1,0 +1,41 @@
+use crate::types::MissionRecord;
+use crate::DataKey;
+use soroban_sdk::{Address, Env};
+
+pub fn set_mission(env: &Env, record: &MissionRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Mission(record.mission_id), record);
+}
+
+pub fn get_mission(env: &Env, mission_id: u64) -> Option<MissionRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Mission(mission_id))
+}
+
+pub fn set_player_progress(env: &Env, mission_id: u64, player: &Address, progress: u32) {
+    env.storage().persistent().set(
+        &DataKey::PlayerProgress(mission_id, player.clone()),
+        &progress,
+    );
+}
+
+pub fn get_player_progress(env: &Env, mission_id: u64, player: &Address) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PlayerProgress(mission_id, player.clone()))
+}
+
+pub fn mark_player_claimed(env: &Env, mission_id: u64, player: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::PlayerClaimed(mission_id, player.clone()), &true);
+}
+
+pub fn has_player_claimed(env: &Env, mission_id: u64, player: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PlayerClaimed(mission_id, player.clone()))
+        .unwrap_or(false)
+}

--- a/contracts/mission-ledger/src/types.rs
+++ b/contracts/mission-ledger/src/types.rs
@@ -1,0 +1,94 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Lifecycle state of a mission. Mirrors the runtime states the frontend
+/// renders on the dashboard (#681).
+#[contracttype]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum MissionStatus {
+    /// Mission has not been registered with the ledger yet.
+    NotConfigured,
+    /// Mission is registered and accepting progress.
+    Active,
+    /// Mission has been paused by the operator (registered but blocked).
+    Paused,
+    /// Mission was completed and the reward window has opened.
+    Completed,
+    /// Mission expired before completion; rewards are no longer claimable.
+    Expired,
+}
+
+/// Why a player is or isn't ready to claim a mission reward (#679).
+///
+/// The frontend `CautionStatePanel` (#682) maps each reason onto a
+/// human-readable explanation, so the values are stable and explicit.
+#[contracttype]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ClaimReadinessReason {
+    /// Mission record does not exist for the queried id.
+    MissionUnknown,
+    /// Ledger has not been initialised yet — operators have not configured anything.
+    LedgerNotConfigured,
+    /// Mission is paused; the player must wait until it resumes.
+    MissionPaused,
+    /// Player has not registered progress against this mission.
+    PlayerNotEnrolled,
+    /// Player completed the required progress but has not yet claimed.
+    Ready,
+    /// Player has already claimed the reward.
+    AlreadyClaimed,
+    /// Mission expired before this player completed it.
+    MissionExpired,
+    /// Player progress has not reached the completion threshold.
+    ProgressIncomplete,
+}
+
+/// On-chain record of a mission. Operators register one of these per mission;
+/// players register progress against it.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MissionRecord {
+    pub mission_id: u64,
+    pub operator: Address,
+    pub completion_threshold: u32,
+    pub reward_amount: i128,
+    pub reward_token: Address,
+    pub expires_at: u64,
+    pub paused: bool,
+    pub completed_count: u32,
+    pub total_claimed: i128,
+}
+
+/// Read-only snapshot of mission state intended for the dashboard / SDK.
+///
+/// Returned by `mission_snapshot(mission_id)`. `exists=false` collapses every
+/// other field to its zero value so consumers can render a "not configured"
+/// state without a separate lookup.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MissionSnapshot {
+    pub mission_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub status: MissionStatus,
+    pub completion_threshold: u32,
+    pub completed_count: u32,
+    pub reward_amount: i128,
+    pub total_claimed: i128,
+    pub expires_at: u64,
+    pub now: u64,
+}
+
+/// Result of a `reward_claim_ready(mission_id, player)` query.
+///
+/// `ready` is the single boolean the UI gates the claim button on; `reason`
+/// stays informative even when ready=true so observability tooling can log
+/// which path was taken.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ClaimReadiness {
+    pub mission_id: u64,
+    pub ready: bool,
+    pub reason: ClaimReadinessReason,
+    pub progress: u32,
+    pub threshold: u32,
+}

--- a/contracts/vault-claims/Cargo.toml
+++ b/contracts/vault-claims/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-vault-claims"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/vault-claims/src/lib.rs
+++ b/contracts/vault-claims/src/lib.rs
@@ -1,0 +1,342 @@
+#![no_std]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub use types::{ClaimState, OutstandingClaimSummary, ReleaseWindow, VaultClaim};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Claim(u64),
+    OutstandingCount,
+    OutstandingAmount,
+    ReleasedCount,
+    ReleasedAmount,
+    CancelledCount,
+    CancelledAmount,
+}
+
+#[contract]
+pub struct VaultClaims;
+
+#[contractimpl]
+impl VaultClaims {
+    /// Initialise the vault with an admin who can register / cancel claims.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Register a new outstanding claim against the vault.
+    pub fn register_claim(
+        env: Env,
+        admin: Address,
+        claim_id: u64,
+        beneficiary: Address,
+        token: Address,
+        amount: i128,
+        release_after: u64,
+    ) {
+        require_admin(&env, &admin);
+        admin.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        if storage::get_claim(&env, claim_id).is_some() {
+            panic!("Claim already registered");
+        }
+        storage::set_claim(
+            &env,
+            &VaultClaim {
+                claim_id,
+                beneficiary,
+                token,
+                amount,
+                release_after,
+                released: false,
+                cancelled: false,
+            },
+        );
+        bump_outstanding(&env, 1, amount);
+    }
+
+    /// Release an outstanding claim once its window has opened.
+    pub fn release(env: Env, beneficiary: Address, claim_id: u64) -> i128 {
+        beneficiary.require_auth();
+        let mut claim = storage::get_claim(&env, claim_id).expect("Claim not found");
+        assert!(claim.beneficiary == beneficiary, "Caller is not beneficiary");
+        assert!(!claim.released, "Already released");
+        assert!(!claim.cancelled, "Claim cancelled");
+        assert!(
+            env.ledger().timestamp() >= claim.release_after,
+            "Release window not open"
+        );
+
+        claim.released = true;
+        storage::set_claim(&env, &claim);
+        bump_outstanding(&env, -1, -claim.amount);
+        bump_released(&env, 1, claim.amount);
+        claim.amount
+    }
+
+    /// Cancel an outstanding claim. Only allowed before release.
+    pub fn cancel(env: Env, admin: Address, claim_id: u64) {
+        require_admin(&env, &admin);
+        admin.require_auth();
+        let mut claim = storage::get_claim(&env, claim_id).expect("Claim not found");
+        assert!(!claim.released, "Cannot cancel a released claim");
+        assert!(!claim.cancelled, "Already cancelled");
+        claim.cancelled = true;
+        storage::set_claim(&env, &claim);
+        bump_outstanding(&env, -1, -claim.amount);
+        bump_cancelled(&env, 1, claim.amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Read-only accessors (the body of issue #680)
+    // ---------------------------------------------------------------------
+
+    /// Aggregate snapshot of every outstanding / released / cancelled claim.
+    pub fn outstanding_claim_summary(env: Env) -> OutstandingClaimSummary {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        OutstandingClaimSummary {
+            configured,
+            outstanding_count: storage::read_u32(&env, &DataKey::OutstandingCount),
+            outstanding_amount: storage::read_i128(&env, &DataKey::OutstandingAmount),
+            released_count: storage::read_u32(&env, &DataKey::ReleasedCount),
+            released_amount: storage::read_i128(&env, &DataKey::ReleasedAmount),
+            cancelled_count: storage::read_u32(&env, &DataKey::CancelledCount),
+            cancelled_amount: storage::read_i128(&env, &DataKey::CancelledAmount),
+            now: env.ledger().timestamp(),
+        }
+    }
+
+    /// Window snapshot for a single claim — collapses to the documented
+    /// fallback when the id is unknown or the vault is unconfigured so
+    /// frontend consumers can render without a separate lookup.
+    pub fn release_window(env: Env, claim_id: u64) -> ReleaseWindow {
+        let now = env.ledger().timestamp();
+        let configured = env.storage().instance().has(&DataKey::Admin);
+
+        let Some(claim) = storage::get_claim(&env, claim_id) else {
+            return ReleaseWindow {
+                claim_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    ClaimState::Unknown
+                } else {
+                    ClaimState::NotConfigured
+                },
+                amount: 0,
+                release_after: 0,
+                now,
+                seconds_until_releasable: 0,
+            };
+        };
+
+        let state = if claim.cancelled {
+            ClaimState::Cancelled
+        } else if claim.released {
+            ClaimState::Released
+        } else if now >= claim.release_after {
+            ClaimState::Releasable
+        } else {
+            ClaimState::Pending
+        };
+        let seconds_until_releasable = if state == ClaimState::Pending {
+            claim.release_after - now
+        } else {
+            0
+        };
+
+        ReleaseWindow {
+            claim_id,
+            configured,
+            exists: true,
+            state,
+            amount: claim.amount,
+            release_after: claim.release_after,
+            now,
+            seconds_until_releasable,
+        }
+    }
+}
+
+fn require_admin(env: &Env, claimed: &Address) {
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Not initialized");
+    assert!(stored == *claimed, "Caller is not admin");
+}
+
+fn bump_outstanding(env: &Env, count_delta: i32, amount_delta: i128) {
+    let count = storage::read_u32(env, &DataKey::OutstandingCount);
+    storage::write_u32(
+        env,
+        &DataKey::OutstandingCount,
+        apply_count_delta(count, count_delta),
+    );
+    let amount = storage::read_i128(env, &DataKey::OutstandingAmount);
+    storage::write_i128(env, &DataKey::OutstandingAmount, amount + amount_delta);
+}
+
+fn bump_released(env: &Env, count_delta: i32, amount_delta: i128) {
+    let count = storage::read_u32(env, &DataKey::ReleasedCount);
+    storage::write_u32(
+        env,
+        &DataKey::ReleasedCount,
+        apply_count_delta(count, count_delta),
+    );
+    let amount = storage::read_i128(env, &DataKey::ReleasedAmount);
+    storage::write_i128(env, &DataKey::ReleasedAmount, amount + amount_delta);
+}
+
+fn bump_cancelled(env: &Env, count_delta: i32, amount_delta: i128) {
+    let count = storage::read_u32(env, &DataKey::CancelledCount);
+    storage::write_u32(
+        env,
+        &DataKey::CancelledCount,
+        apply_count_delta(count, count_delta),
+    );
+    let amount = storage::read_i128(env, &DataKey::CancelledAmount);
+    storage::write_i128(env, &DataKey::CancelledAmount, amount + amount_delta);
+}
+
+fn apply_count_delta(count: u32, delta: i32) -> u32 {
+    if delta < 0 {
+        count.saturating_sub((-delta) as u32)
+    } else {
+        count.saturating_add(delta as u32)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, Env};
+
+    fn setup<'a>() -> (Env, Address, VaultClaimsClient<'a>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        let contract_id = env.register(VaultClaims, ());
+        let client = VaultClaimsClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        (env, admin, client)
+    }
+
+    fn register(
+        env: &Env,
+        client: &VaultClaimsClient,
+        admin: &Address,
+        claim_id: u64,
+        amount: i128,
+        release_after: u64,
+    ) -> Address {
+        let beneficiary = Address::generate(env);
+        let token = Address::generate(env);
+        client.register_claim(
+            admin,
+            &claim_id,
+            &beneficiary,
+            &token,
+            &amount,
+            &release_after,
+        );
+        beneficiary
+    }
+
+    #[test]
+    fn outstanding_summary_starts_at_zero() {
+        let (_env, _admin, client) = setup();
+
+        let s = client.outstanding_claim_summary();
+        assert_eq!(s.configured, true);
+        assert_eq!(s.outstanding_count, 0);
+        assert_eq!(s.outstanding_amount, 0);
+        assert_eq!(s.released_count, 0);
+        assert_eq!(s.cancelled_count, 0);
+    }
+
+    #[test]
+    fn outstanding_summary_tracks_register_release_cancel() {
+        let (env, admin, client) = setup();
+        let bene1 = register(&env, &client, &admin, 1, 100, 2_000);
+        let _bene2 = register(&env, &client, &admin, 2, 200, 3_000);
+        let _bene3 = register(&env, &client, &admin, 3, 50, 5_000);
+
+        let s = client.outstanding_claim_summary();
+        assert_eq!(s.outstanding_count, 3);
+        assert_eq!(s.outstanding_amount, 350);
+
+        env.ledger().set_timestamp(2_500);
+        let released = client.release(&bene1, &1u64);
+        assert_eq!(released, 100);
+
+        client.cancel(&admin, &3u64);
+
+        let s = client.outstanding_claim_summary();
+        assert_eq!(s.outstanding_count, 1);
+        assert_eq!(s.outstanding_amount, 200);
+        assert_eq!(s.released_count, 1);
+        assert_eq!(s.released_amount, 100);
+        assert_eq!(s.cancelled_count, 1);
+        assert_eq!(s.cancelled_amount, 50);
+    }
+
+    #[test]
+    fn release_window_unknown_id_returns_unknown_state() {
+        let (_env, _admin, client) = setup();
+        let w = client.release_window(&99u64);
+        assert_eq!(w.exists, false);
+        assert_eq!(w.state, ClaimState::Unknown);
+        assert_eq!(w.configured, true);
+        assert_eq!(w.seconds_until_releasable, 0);
+    }
+
+    #[test]
+    fn release_window_reports_pending_then_releasable() {
+        let (env, admin, client) = setup();
+        let _bene = register(&env, &client, &admin, 1, 100, 5_000);
+
+        let pending = client.release_window(&1u64);
+        assert_eq!(pending.state, ClaimState::Pending);
+        assert_eq!(pending.seconds_until_releasable, 4_000);
+
+        env.ledger().set_timestamp(6_000);
+        let open = client.release_window(&1u64);
+        assert_eq!(open.state, ClaimState::Releasable);
+        assert_eq!(open.seconds_until_releasable, 0);
+    }
+
+    #[test]
+    fn release_window_reflects_released_state() {
+        let (env, admin, client) = setup();
+        let bene = register(&env, &client, &admin, 1, 100, 1_500);
+        env.ledger().set_timestamp(2_000);
+        client.release(&bene, &1u64);
+
+        let w = client.release_window(&1u64);
+        assert_eq!(w.state, ClaimState::Released);
+    }
+
+    #[test]
+    fn release_window_reflects_cancelled_state() {
+        let (env, admin, client) = setup();
+        let _bene = register(&env, &client, &admin, 1, 100, 5_000);
+        client.cancel(&admin, &1u64);
+
+        let w = client.release_window(&1u64);
+        assert_eq!(w.state, ClaimState::Cancelled);
+    }
+}

--- a/contracts/vault-claims/src/storage.rs
+++ b/contracts/vault-claims/src/storage.rs
@@ -1,0 +1,29 @@
+use crate::types::VaultClaim;
+use crate::DataKey;
+use soroban_sdk::Env;
+
+pub fn set_claim(env: &Env, claim: &VaultClaim) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Claim(claim.claim_id), claim);
+}
+
+pub fn get_claim(env: &Env, claim_id: u64) -> Option<VaultClaim> {
+    env.storage().persistent().get(&DataKey::Claim(claim_id))
+}
+
+pub fn read_u32(env: &Env, key: &DataKey) -> u32 {
+    env.storage().instance().get(key).unwrap_or(0)
+}
+
+pub fn read_i128(env: &Env, key: &DataKey) -> i128 {
+    env.storage().instance().get(key).unwrap_or(0)
+}
+
+pub fn write_u32(env: &Env, key: &DataKey, value: u32) {
+    env.storage().instance().set(key, &value);
+}
+
+pub fn write_i128(env: &Env, key: &DataKey, value: i128) {
+    env.storage().instance().set(key, &value);
+}

--- a/contracts/vault-claims/src/types.rs
+++ b/contracts/vault-claims/src/types.rs
@@ -1,0 +1,63 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Lifecycle of a single vault claim.
+#[contracttype]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ClaimState {
+    /// No claim record found for the queried id.
+    Unknown,
+    /// Vault has not been initialised yet.
+    NotConfigured,
+    /// Claim is waiting for its release window to open.
+    Pending,
+    /// Claim's release window is open and the beneficiary may withdraw.
+    Releasable,
+    /// Claim has been fully released.
+    Released,
+    /// Claim was cancelled before release.
+    Cancelled,
+}
+
+/// On-chain record of a single claim against the vault.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VaultClaim {
+    pub claim_id: u64,
+    pub beneficiary: Address,
+    pub token: Address,
+    pub amount: i128,
+    /// Earliest ledger timestamp at which `release` may be called.
+    pub release_after: u64,
+    pub released: bool,
+    pub cancelled: bool,
+}
+
+/// Aggregate view of every outstanding claim. `outstanding_amount` is the
+/// total `amount` summed over claims that are neither released nor cancelled.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct OutstandingClaimSummary {
+    pub configured: bool,
+    pub outstanding_count: u32,
+    pub outstanding_amount: i128,
+    pub released_count: u32,
+    pub released_amount: i128,
+    pub cancelled_count: u32,
+    pub cancelled_amount: i128,
+    pub now: u64,
+}
+
+/// Read-only window snapshot for a single claim.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReleaseWindow {
+    pub claim_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: ClaimState,
+    pub amount: i128,
+    pub release_after: u64,
+    pub now: u64,
+    /// Seconds remaining until the claim becomes releasable (0 once open).
+    pub seconds_until_releasable: u64,
+}

--- a/frontend/src/components/v1/CautionStatePanel.css
+++ b/frontend/src/components/v1/CautionStatePanel.css
@@ -1,0 +1,119 @@
+.caution-state-panel {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: start;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid var(--caution-border, #f0c75e);
+  background: var(--caution-bg, rgba(240, 199, 94, 0.08));
+  color: var(--text-primary, #f5f7fb);
+}
+
+.caution-state-panel--blocked-wallet {
+  --caution-border: #f0c75e;
+  --caution-bg: rgba(240, 199, 94, 0.08);
+}
+
+.caution-state-panel--paused-contract {
+  --caution-border: #ff8a73;
+  --caution-bg: rgba(255, 138, 115, 0.08);
+}
+
+.caution-state-panel--network-mismatch {
+  --caution-border: #6dc3ff;
+  --caution-bg: rgba(109, 195, 255, 0.08);
+}
+
+.caution-state-panel--rate-limited {
+  --caution-border: #b58aff;
+  --caution-bg: rgba(181, 138, 255, 0.08);
+}
+
+.caution-state-panel__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: var(--caution-border);
+  color: #0a0d12;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.caution-state-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.caution-state-panel__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.caution-state-panel__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(245, 247, 251, 0.78));
+}
+
+.caution-state-panel__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.caution-state-panel__action {
+  padding: 0.5rem 0.85rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border: 1px solid var(--caution-border);
+  background: transparent;
+  color: var(--caution-border);
+  cursor: pointer;
+}
+
+.caution-state-panel__action:focus-visible {
+  outline: 2px solid var(--caution-border);
+  outline-offset: 2px;
+}
+
+.caution-state-panel__action--primary {
+  background: var(--caution-border);
+  color: #0a0d12;
+}
+
+.caution-state-panel__dismiss {
+  align-self: start;
+  background: transparent;
+  border: none;
+  color: var(--text-muted, rgba(245, 247, 251, 0.55));
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+}
+
+.caution-state-panel__dismiss:focus-visible {
+  outline: 2px solid var(--text-muted);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .caution-state-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .caution-state-panel__icon {
+    justify-self: start;
+  }
+
+  .caution-state-panel__dismiss {
+    justify-self: end;
+  }
+}

--- a/frontend/src/components/v1/CautionStatePanel.tsx
+++ b/frontend/src/components/v1/CautionStatePanel.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import "./CautionStatePanel.css";
+
+/**
+ * Caution state panel — issue #682.
+ *
+ * Shared component for "your wallet is blocked / your contract is paused /
+ * the network changed under you / you've been rate-limited" — the four
+ * recoverable, action-required states the dashboard surfaces hit. Each
+ * variant carries its own colour ramp; the action / dismiss behaviour is
+ * controlled by the caller.
+ *
+ * Use this anywhere a single banner needs to describe a blocked wallet or
+ * contract action and offer the recovery step. Variant-specific copy lives
+ * in the caller, since the wording depends on the surface (settings vs.
+ * dashboard vs. play page).
+ */
+export type CautionVariant =
+  | "blocked-wallet"
+  | "paused-contract"
+  | "network-mismatch"
+  | "rate-limited";
+
+const VARIANT_ICON_LABELS: Record<CautionVariant, string> = {
+  "blocked-wallet": "!",
+  "paused-contract": "‖",
+  "network-mismatch": "↻",
+  "rate-limited": "◔",
+};
+
+export interface CautionStatePanelAction {
+  label: string;
+  onAction: () => void | Promise<void>;
+  /** Primary actions render with a filled background; secondary stay outlined. */
+  variant?: "primary" | "secondary";
+  testId?: string;
+}
+
+export interface CautionStatePanelProps {
+  variant: CautionVariant;
+  title: string;
+  description: React.ReactNode;
+  actions?: CautionStatePanelAction[];
+  /** Optional dismiss handler — when omitted, the close button is hidden. */
+  onDismiss?: () => void;
+  /** Optional override for the variant icon character. */
+  icon?: React.ReactNode;
+  testId?: string;
+  className?: string;
+}
+
+export const CautionStatePanel: React.FC<CautionStatePanelProps> = ({
+  variant,
+  title,
+  description,
+  actions = [],
+  onDismiss,
+  icon,
+  testId = "caution-state-panel",
+  className = "",
+}) => {
+  const variantClass = `caution-state-panel--${variant}`;
+  const rootClass =
+    `caution-state-panel ${variantClass}${className ? ` ${className}` : ""}`.trim();
+
+  return (
+    <section
+      className={rootClass}
+      role="alert"
+      data-testid={testId}
+      data-variant={variant}
+    >
+      <span
+        className="caution-state-panel__icon"
+        aria-hidden="true"
+        data-testid={`${testId}-icon`}
+      >
+        {icon ?? VARIANT_ICON_LABELS[variant]}
+      </span>
+      <div className="caution-state-panel__body">
+        <h3 className="caution-state-panel__title">{title}</h3>
+        <p className="caution-state-panel__description">{description}</p>
+        {actions.length > 0 && (
+          <div
+            className="caution-state-panel__actions"
+            data-testid={`${testId}-actions`}
+          >
+            {actions.map((action, idx) => (
+              <button
+                key={`${action.label}-${idx}`}
+                type="button"
+                className={
+                  action.variant === "primary"
+                    ? "caution-state-panel__action caution-state-panel__action--primary"
+                    : "caution-state-panel__action"
+                }
+                onClick={action.onAction}
+                data-testid={action.testId ?? `${testId}-action-${idx}`}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          className="caution-state-panel__dismiss"
+          onClick={onDismiss}
+          aria-label="Dismiss caution panel"
+          data-testid={`${testId}-dismiss`}
+        >
+          ×
+        </button>
+      )}
+    </section>
+  );
+};
+
+export default CautionStatePanel;

--- a/frontend/src/components/v1/RecentRewardActivityStrip.css
+++ b/frontend/src/components/v1/RecentRewardActivityStrip.css
@@ -1,0 +1,119 @@
+.recent-reward-activity-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 12px;
+  background: var(--surface-1, #11161e);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+}
+
+.recent-reward-activity-strip__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.recent-reward-activity-strip__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary, #f5f7fb);
+}
+
+.recent-reward-activity-strip__count {
+  font-size: 0.75rem;
+  color: var(--text-muted, rgba(245, 247, 251, 0.6));
+}
+
+.recent-reward-activity-strip__list {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scroll-snap-type: x mandatory;
+}
+
+.recent-reward-activity-strip__list::-webkit-scrollbar {
+  height: 4px;
+}
+
+.recent-reward-activity-strip__list::-webkit-scrollbar-thumb {
+  background: var(--border-subtle, rgba(255, 255, 255, 0.12));
+  border-radius: 4px;
+}
+
+.recent-reward-activity-strip__item {
+  flex: 0 0 auto;
+  min-width: 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  border-radius: 10px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  scroll-snap-align: start;
+}
+
+.recent-reward-activity-strip__item-amount {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent-primary, #7af7c0);
+}
+
+.recent-reward-activity-strip__item-source {
+  font-size: 0.85rem;
+  color: var(--text-primary, #f5f7fb);
+}
+
+.recent-reward-activity-strip__item-time {
+  font-size: 0.7rem;
+  color: var(--text-muted, rgba(245, 247, 251, 0.55));
+}
+
+.recent-reward-activity-strip__skeleton {
+  flex: 0 0 12rem;
+  height: 4.5rem;
+  border-radius: 10px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  animation: recent-reward-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes recent-reward-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.recent-reward-activity-strip__empty,
+.recent-reward-activity-strip__error {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted, rgba(245, 247, 251, 0.6));
+  border-radius: 10px;
+  border: 1px dashed var(--border-subtle, rgba(255, 255, 255, 0.12));
+}
+
+.recent-reward-activity-strip__error {
+  color: var(--text-warning, #ffb454);
+  border-color: var(--text-warning, rgba(255, 180, 84, 0.5));
+}
+
+@media (max-width: 600px) {
+  .recent-reward-activity-strip__item {
+    min-width: 10rem;
+  }
+}

--- a/frontend/src/components/v1/RecentRewardActivityStrip.tsx
+++ b/frontend/src/components/v1/RecentRewardActivityStrip.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import "./RecentRewardActivityStrip.css";
+
+/**
+ * Recent reward activity strip — issue #681.
+ *
+ * Shown on dashboard overview surfaces, this is a horizontally-scrollable
+ * snapshot of the most recent rewards a player has received. The component
+ * is purely presentational: callers fetch their own activity and pass it in.
+ *
+ * Handles all four lifecycle states explicitly (loading, empty, error,
+ * populated) per the issue's "handle empty, loading, disabled, and missing
+ * data states explicitly" requirement.
+ */
+export interface RecentRewardActivityItem {
+  id: string;
+  /** Pre-formatted amount string, e.g. "+250 STC" — keeps formatting concerns out of the strip. */
+  amount: string;
+  /** Source label, e.g. "Daily Trivia", "Mission #12". */
+  source: string;
+  /** ISO 8601 timestamp; rendered as a relative-time label. */
+  timestamp: string;
+}
+
+export interface RecentRewardActivityStripProps {
+  items: RecentRewardActivityItem[];
+  isLoading?: boolean;
+  errorMessage?: string;
+  /** Override the human label rendered above the list. */
+  title?: string;
+  /** Number of skeleton rows to render while `isLoading`. */
+  skeletonCount?: number;
+  /** Optional `data-testid` override for the root element. */
+  testId?: string;
+  /** Optional clock injection so tests can pin "now" deterministically. */
+  now?: Date;
+}
+
+const RELATIVE_THRESHOLDS: Array<{ ms: number; label: (n: number) => string }> = [
+  { ms: 60_000, label: () => "just now" },
+  { ms: 60 * 60_000, label: (n) => `${Math.floor(n / 60_000)}m ago` },
+  { ms: 24 * 60 * 60_000, label: (n) => `${Math.floor(n / (60 * 60_000))}h ago` },
+  { ms: 7 * 24 * 60 * 60_000, label: (n) => `${Math.floor(n / (24 * 60 * 60_000))}d ago` },
+];
+
+function formatRelative(timestamp: string, now: Date): string {
+  const t = new Date(timestamp).getTime();
+  if (Number.isNaN(t)) return timestamp;
+  const delta = Math.max(0, now.getTime() - t);
+  for (const tier of RELATIVE_THRESHOLDS) {
+    if (delta < tier.ms) {
+      return tier.label(delta);
+    }
+  }
+  return new Date(timestamp).toLocaleDateString();
+}
+
+export const RecentRewardActivityStrip: React.FC<RecentRewardActivityStripProps> = ({
+  items,
+  isLoading = false,
+  errorMessage,
+  title = "Recent rewards",
+  skeletonCount = 4,
+  testId = "recent-reward-activity-strip",
+  now = new Date(),
+}) => {
+  return (
+    <section
+      className="recent-reward-activity-strip"
+      aria-label={title}
+      data-testid={testId}
+    >
+      <header className="recent-reward-activity-strip__header">
+        <h3 className="recent-reward-activity-strip__title">{title}</h3>
+        {!isLoading && !errorMessage && items.length > 0 && (
+          <span
+            className="recent-reward-activity-strip__count"
+            data-testid={`${testId}-count`}
+          >
+            {items.length} {items.length === 1 ? "reward" : "rewards"}
+          </span>
+        )}
+      </header>
+
+      {errorMessage ? (
+        <div
+          role="alert"
+          className="recent-reward-activity-strip__error"
+          data-testid={`${testId}-error`}
+        >
+          {errorMessage}
+        </div>
+      ) : isLoading ? (
+        <div
+          className="recent-reward-activity-strip__list"
+          data-testid={`${testId}-loading`}
+          aria-busy="true"
+        >
+          {Array.from({ length: skeletonCount }).map((_, i) => (
+            <div
+              key={i}
+              className="recent-reward-activity-strip__skeleton"
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <p
+          className="recent-reward-activity-strip__empty"
+          data-testid={`${testId}-empty`}
+        >
+          No rewards yet — start a game or complete a mission to see them here.
+        </p>
+      ) : (
+        <ul
+          className="recent-reward-activity-strip__list"
+          data-testid={`${testId}-list`}
+          role="list"
+        >
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="recent-reward-activity-strip__item"
+              data-testid={`${testId}-item-${item.id}`}
+            >
+              <span className="recent-reward-activity-strip__item-amount">
+                {item.amount}
+              </span>
+              <span className="recent-reward-activity-strip__item-source">
+                {item.source}
+              </span>
+              <time
+                className="recent-reward-activity-strip__item-time"
+                dateTime={item.timestamp}
+                title={item.timestamp}
+              >
+                {formatRelative(item.timestamp, now)}
+              </time>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default RecentRewardActivityStrip;

--- a/frontend/tests/components/CautionStatePanel.test.tsx
+++ b/frontend/tests/components/CautionStatePanel.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { CautionStatePanel } from "@/components/v1/CautionStatePanel";
+
+describe("CautionStatePanel (#682)", () => {
+  it("renders title, description, and a variant icon by default", () => {
+    render(
+      <CautionStatePanel
+        variant="blocked-wallet"
+        title="Wallet not connected"
+        description="Connect your Freighter wallet to deposit."
+      />,
+    );
+
+    const panel = screen.getByTestId("caution-state-panel");
+    expect(panel).toHaveAttribute("data-variant", "blocked-wallet");
+    expect(panel).toHaveAttribute("role", "alert");
+    expect(panel).toHaveTextContent("Wallet not connected");
+    expect(panel).toHaveTextContent("Connect your Freighter wallet to deposit.");
+    expect(screen.getByTestId("caution-state-panel-icon")).toBeInTheDocument();
+  });
+
+  it("renders all four variant CSS classes", () => {
+    const variants: Array<
+      "blocked-wallet" | "paused-contract" | "network-mismatch" | "rate-limited"
+    > = ["blocked-wallet", "paused-contract", "network-mismatch", "rate-limited"];
+
+    for (const variant of variants) {
+      const { unmount, container } = render(
+        <CautionStatePanel
+          variant={variant}
+          title={variant}
+          description="x"
+          testId={`panel-${variant}`}
+        />,
+      );
+      expect(container.querySelector(`.caution-state-panel--${variant}`)).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("invokes the action handler when an action button is clicked", () => {
+    const onAction = vi.fn();
+    render(
+      <CautionStatePanel
+        variant="paused-contract"
+        title="Deposits are paused"
+        description="The treasury contract is in maintenance."
+        actions={[
+          { label: "Open status page", onAction, variant: "primary" },
+          { label: "Dismiss for now", onAction: vi.fn() },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("caution-state-panel-actions")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("caution-state-panel-action-0"));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the dismiss button only when onDismiss is supplied", () => {
+    const { rerender } = render(
+      <CautionStatePanel
+        variant="rate-limited"
+        title="Slow down"
+        description="Hit a rate limit."
+      />,
+    );
+    expect(
+      screen.queryByTestId("caution-state-panel-dismiss"),
+    ).not.toBeInTheDocument();
+
+    const onDismiss = vi.fn();
+    rerender(
+      <CautionStatePanel
+        variant="rate-limited"
+        title="Slow down"
+        description="Hit a rate limit."
+        onDismiss={onDismiss}
+      />,
+    );
+    const dismiss = screen.getByTestId("caution-state-panel-dismiss");
+    expect(dismiss).toHaveAttribute("aria-label", "Dismiss caution panel");
+    fireEvent.click(dismiss);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the actions container when no actions are provided", () => {
+    render(
+      <CautionStatePanel
+        variant="network-mismatch"
+        title="Wrong network"
+        description="Switch to mainnet."
+      />,
+    );
+    expect(
+      screen.queryByTestId("caution-state-panel-actions"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("supports custom icon override", () => {
+    render(
+      <CautionStatePanel
+        variant="blocked-wallet"
+        title="t"
+        description="d"
+        icon={<span data-testid="custom-icon">⚠</span>}
+      />,
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
+  it("primary action button has the primary class", () => {
+    render(
+      <CautionStatePanel
+        variant="blocked-wallet"
+        title="t"
+        description="d"
+        actions={[
+          { label: "Connect", onAction: vi.fn(), variant: "primary" },
+          { label: "Cancel", onAction: vi.fn() },
+        ]}
+      />,
+    );
+    const primary = screen.getByTestId("caution-state-panel-action-0");
+    const secondary = screen.getByTestId("caution-state-panel-action-1");
+    expect(primary.className).toContain("caution-state-panel__action--primary");
+    expect(secondary.className).not.toContain("caution-state-panel__action--primary");
+  });
+});

--- a/frontend/tests/components/RecentRewardActivityStrip.test.tsx
+++ b/frontend/tests/components/RecentRewardActivityStrip.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import {
+  RecentRewardActivityStrip,
+  type RecentRewardActivityItem,
+} from "@/components/v1/RecentRewardActivityStrip";
+
+const items: RecentRewardActivityItem[] = [
+  {
+    id: "rw-1",
+    amount: "+250 STC",
+    source: "Daily Trivia",
+    timestamp: "2026-04-26T11:55:00.000Z",
+  },
+  {
+    id: "rw-2",
+    amount: "+100 STC",
+    source: "Mission #12",
+    timestamp: "2026-04-26T10:00:00.000Z",
+  },
+];
+
+const NOW = new Date("2026-04-26T12:00:00.000Z");
+
+describe("RecentRewardActivityStrip (#681)", () => {
+  it("renders one card per item with amount, source, and a relative timestamp", () => {
+    render(<RecentRewardActivityStrip items={items} now={NOW} />);
+
+    const list = screen.getByTestId("recent-reward-activity-strip-list");
+    expect(list).toBeInTheDocument();
+
+    const item1 = screen.getByTestId("recent-reward-activity-strip-item-rw-1");
+    expect(item1).toHaveTextContent("+250 STC");
+    expect(item1).toHaveTextContent("Daily Trivia");
+    expect(item1).toHaveTextContent("5m ago");
+
+    const item2 = screen.getByTestId("recent-reward-activity-strip-item-rw-2");
+    expect(item2).toHaveTextContent("Mission #12");
+    expect(item2).toHaveTextContent("2h ago");
+
+    expect(screen.getByTestId("recent-reward-activity-strip-count")).toHaveTextContent(
+      "2 rewards"
+    );
+  });
+
+  it("singular count when there is exactly one item", () => {
+    render(<RecentRewardActivityStrip items={[items[0]!]} now={NOW} />);
+    expect(screen.getByTestId("recent-reward-activity-strip-count")).toHaveTextContent(
+      "1 reward"
+    );
+  });
+
+  it("renders the empty state when items is an empty array", () => {
+    render(<RecentRewardActivityStrip items={[]} />);
+    expect(screen.getByTestId("recent-reward-activity-strip-empty")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("recent-reward-activity-strip-list"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("recent-reward-activity-strip-count"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders skeleton placeholders while loading", () => {
+    render(<RecentRewardActivityStrip items={items} isLoading skeletonCount={3} />);
+    const loading = screen.getByTestId("recent-reward-activity-strip-loading");
+    expect(loading).toBeInTheDocument();
+    expect(loading).toHaveAttribute("aria-busy", "true");
+    expect(loading.children).toHaveLength(3);
+    expect(
+      screen.queryByTestId("recent-reward-activity-strip-list"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an error fallback with role=alert when errorMessage is provided", () => {
+    render(
+      <RecentRewardActivityStrip items={items} errorMessage="failed to load rewards" />,
+    );
+    const error = screen.getByTestId("recent-reward-activity-strip-error");
+    expect(error).toHaveTextContent("failed to load rewards");
+    expect(error).toHaveAttribute("role", "alert");
+    expect(
+      screen.queryByTestId("recent-reward-activity-strip-list"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the raw timestamp when the input is unparseable", () => {
+    render(
+      <RecentRewardActivityStrip
+        items={[{ ...items[0]!, timestamp: "not-a-date" }]}
+        now={NOW}
+      />,
+    );
+    expect(
+      screen.getByTestId("recent-reward-activity-strip-item-rw-1"),
+    ).toHaveTextContent("not-a-date");
+  });
+
+  it("uses an overridden title for the section label", () => {
+    render(
+      <RecentRewardActivityStrip items={items} title="Today's wins" now={NOW} />,
+    );
+    expect(screen.getByLabelText("Today's wins")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes all four backlog items assigned to me in one PR — two new Soroban contracts plus two shared frontend components.

### #679 — `mission-ledger` contract
New crate at `contracts/mission-ledger/` (lib.rs, storage.rs, types.rs, in-tree tests).
- Mutators: `init` / `register_mission` / `record_progress` / `set_paused` / `claim`
- **`mission_snapshot(mission_id)`** → `MissionSnapshot { configured, exists, status, completion_threshold, completed_count, reward_amount, total_claimed, expires_at, now }`
- **`reward_claim_ready(mission_id, player)`** → `ClaimReadiness { ready, reason, progress, threshold }` where `reason ∈ { MissionUnknown, LedgerNotConfigured, MissionPaused, PlayerNotEnrolled, Ready, AlreadyClaimed, MissionExpired, ProgressIncomplete }` so the frontend (#682) can map each state straight to recovery copy
- 7 unit tests: success path + paused, expired, unknown, not-enrolled, double-claim, unknown-mission

### #680 — `vault-claims` contract
New crate at `contracts/vault-claims/`.
- Mutators: `init` / `register_claim` / `release` / `cancel`
- **`outstanding_claim_summary()`** → counts + amounts for outstanding / released / cancelled, plus `configured` and `now`
- **`release_window(claim_id)`** → `ReleaseWindow { configured, exists, state ∈ {Unknown, NotConfigured, Pending, Releasable, Released, Cancelled}, amount, release_after, now, seconds_until_releasable }`
- 6 unit tests: register/release/cancel aggregation, pending → releasable transition, unknown id, released state, cancelled state

### #681 — `RecentRewardActivityStrip`
Horizontally-scrollable dashboard strip with explicit handling for **all four lifecycle states** the issue calls for: loading (skeleton tiles), error (role=alert fallback), empty (\"No rewards yet…\" prompt), populated. Renders amount / source / relative timestamp per item. \`now\` is injectable so tests pin formatting deterministically. **7 vitest cases**.

### #682 — `CautionStatePanel`
Shared panel for `blocked-wallet` / `paused-contract` / `network-mismatch` / `rate-limited` recoverable states. Each variant carries its own colour ramp; primary vs. secondary actions; optional dismiss button (only renders when a handler is supplied). `role=\"alert\"` + `aria-label` on dismiss preserve accessibility. **7 vitest cases**.

## Test plan
- [x] `cd contracts/mission-ledger && cargo +stable test` → **7/7 pass**
- [x] `cd contracts/vault-claims && cargo +stable test` → **6/6 pass**
- [x] `cd frontend && pnpm test tests/components/RecentRewardActivityStrip.test.tsx tests/components/CautionStatePanel.test.tsx` → **14/14 pass**
- [x] `cd frontend && pnpm typecheck` → clean for the new files (28 pre-existing failures elsewhere on `main` are unrelated)

## Workspace note (out of scope for this PR)
`contracts/Cargo.toml` gains `\"mission-ledger\"` and `\"vault-claims\"` under `workspace.members`. The pinned `rust-toolchain.toml` is `1.85.0`, but the current `soroban-sdk` resolves to `25.3.1` which requires `1.91+` — every contract in the workspace now needs `cargo +stable` to compile, not just the new ones. I used `cargo +stable` for tests here; bumping `rust-toolchain.toml` is a separate concern.

Closes #679
Closes #680
Closes #681
Closes #682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mission Ledger contract for managing missions, player progress, and reward claims.
  * Added Vault Claims contract for time-locked claim management with release scheduling.
  * Added CautionStatePanel UI component for displaying caution alerts (blocked wallet, paused contract, network mismatch, rate-limited).
  * Added RecentRewardActivityStrip UI component to display recent rewards activity with loading and error states.

* **Tests**
  * Added test coverage for CautionStatePanel component variants and interactions.
  * Added test coverage for RecentRewardActivityStrip with various UI states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->