### PR TITLE
feat(contracts,frontend): sponsor-pool contract, table overflow menu, page intro

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2497,6 +2497,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-sponsor-pool"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-sponsorship-ledger"
 version = "0.1.0"
 dependencies = [

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -96,6 +96,7 @@ members = [
     "reserve-manager",
     "quest-redeemer",
     "squad-match",
+    "sponsor-pool",
     "sponsorship-ledger",
 ]
 

--- a/contracts/sponsor-pool/Cargo.toml
+++ b/contracts/sponsor-pool/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-sponsor-pool"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/sponsor-pool/src/lib.rs
+++ b/contracts/sponsor-pool/src/lib.rs
@@ -1,0 +1,418 @@
+#![no_std]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub use types::{
+    CampaignCoverage, CampaignRecord, CampaignStatus, CommittedFundsSummary,
+};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Campaign(u64),
+    OpenCampaigns,
+    SettledCampaigns,
+    CancelledCampaigns,
+    OutstandingCommitted,
+    LifetimeCommitted,
+    LifetimeSettled,
+    LifetimeCancelled,
+}
+
+#[contract]
+pub struct SponsorPool;
+
+#[contractimpl]
+impl SponsorPool {
+    /// Initialise the pool with an admin who can register / settle / cancel
+    /// campaigns.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Register a new sponsorship campaign. Idempotent on `campaign_id`:
+    /// re-registration with the same id panics so the operator notices.
+    pub fn register_campaign(
+        env: Env,
+        admin: Address,
+        campaign_id: u64,
+        beneficiary: Address,
+        token: Address,
+        target_amount: i128,
+    ) {
+        require_admin(&env, &admin);
+        admin.require_auth();
+        assert!(target_amount > 0, "target_amount must be positive");
+        if storage::get_campaign(&env, campaign_id).is_some() {
+            panic!("Campaign already registered");
+        }
+        storage::set_campaign(
+            &env,
+            &CampaignRecord {
+                campaign_id,
+                beneficiary,
+                token,
+                target_amount,
+                committed_amount: 0,
+                settled: false,
+                cancelled: false,
+            },
+        );
+        bump_open(&env, 1);
+    }
+
+    /// Add `amount` worth of funds to `campaign_id`. The pool only tracks
+    /// the committed amount; actual token movement is handled by the caller
+    /// (treasury contract or user-side transfer) since on-chain custody is
+    /// out of scope for the issue.
+    pub fn commit_funds(env: Env, sponsor: Address, campaign_id: u64, amount: i128) {
+        sponsor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        let mut campaign =
+            storage::get_campaign(&env, campaign_id).expect("Campaign not found");
+        assert!(!campaign.cancelled, "Campaign cancelled");
+        assert!(!campaign.settled, "Campaign already settled");
+
+        // Cap the running committed amount at the campaign target so a
+        // late-arriving commit cannot push the pool past 100% coverage.
+        let next = campaign
+            .committed_amount
+            .checked_add(amount)
+            .expect("Overflow")
+            .min(campaign.target_amount);
+        let actually_committed = next - campaign.committed_amount;
+        campaign.committed_amount = next;
+        storage::set_campaign(&env, &campaign);
+
+        bump_outstanding(&env, actually_committed);
+        bump_lifetime_committed(&env, actually_committed);
+    }
+
+    /// Mark a campaign settled. Releases the committed amount as "settled"
+    /// in the aggregate counters.
+    pub fn settle(env: Env, admin: Address, campaign_id: u64) -> i128 {
+        require_admin(&env, &admin);
+        admin.require_auth();
+        let mut campaign =
+            storage::get_campaign(&env, campaign_id).expect("Campaign not found");
+        assert!(!campaign.settled, "Already settled");
+        assert!(!campaign.cancelled, "Campaign cancelled");
+
+        campaign.settled = true;
+        let committed = campaign.committed_amount;
+        storage::set_campaign(&env, &campaign);
+
+        bump_open(&env, -1);
+        bump_settled_count(&env, 1);
+        bump_outstanding(&env, -committed);
+        bump_lifetime_settled(&env, committed);
+        committed
+    }
+
+    /// Cancel a campaign. Returns the amount that was committed at cancel
+    /// time so the caller can refund sponsors out-of-band.
+    pub fn cancel(env: Env, admin: Address, campaign_id: u64) -> i128 {
+        require_admin(&env, &admin);
+        admin.require_auth();
+        let mut campaign =
+            storage::get_campaign(&env, campaign_id).expect("Campaign not found");
+        assert!(!campaign.settled, "Cannot cancel a settled campaign");
+        assert!(!campaign.cancelled, "Already cancelled");
+
+        campaign.cancelled = true;
+        let committed = campaign.committed_amount;
+        storage::set_campaign(&env, &campaign);
+
+        bump_open(&env, -1);
+        bump_cancelled_count(&env, 1);
+        bump_outstanding(&env, -committed);
+        bump_lifetime_cancelled(&env, committed);
+        committed
+    }
+
+    // ---------------------------------------------------------------------
+    // Read-only accessors (the body of issues #521 / #541)
+    // ---------------------------------------------------------------------
+
+    /// Aggregate snapshot of the pool's committed funds across every state.
+    pub fn committed_funds_summary(env: Env) -> CommittedFundsSummary {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        CommittedFundsSummary {
+            configured,
+            open_campaigns: storage::read_u32(&env, &DataKey::OpenCampaigns),
+            settled_campaigns: storage::read_u32(&env, &DataKey::SettledCampaigns),
+            cancelled_campaigns: storage::read_u32(&env, &DataKey::CancelledCampaigns),
+            outstanding_committed: storage::read_i128(&env, &DataKey::OutstandingCommitted),
+            lifetime_committed: storage::read_i128(&env, &DataKey::LifetimeCommitted),
+            lifetime_settled: storage::read_i128(&env, &DataKey::LifetimeSettled),
+            lifetime_cancelled: storage::read_i128(&env, &DataKey::LifetimeCancelled),
+            now: env.ledger().timestamp(),
+        }
+    }
+
+    /// Coverage view for a single campaign. Collapses to the documented
+    /// fallback when the id is unknown or the pool is unconfigured so the
+    /// frontend can render without a separate lookup.
+    pub fn campaign_coverage(env: Env, campaign_id: u64) -> CampaignCoverage {
+        let now = env.ledger().timestamp();
+        let configured = env.storage().instance().has(&DataKey::Admin);
+
+        let Some(campaign) = storage::get_campaign(&env, campaign_id) else {
+            return CampaignCoverage {
+                campaign_id,
+                configured,
+                exists: false,
+                status: if configured {
+                    CampaignStatus::Unknown
+                } else {
+                    CampaignStatus::NotConfigured
+                },
+                target_amount: 0,
+                committed_amount: 0,
+                remaining_amount: 0,
+                coverage_bps: 0,
+                now,
+            };
+        };
+
+        let status = if campaign.cancelled {
+            CampaignStatus::Cancelled
+        } else if campaign.settled {
+            CampaignStatus::Settled
+        } else {
+            CampaignStatus::Open
+        };
+        let remaining = (campaign.target_amount - campaign.committed_amount).max(0);
+        // Integer basis points to keep the contract floating-point-free.
+        // `coverage_bps = (committed * 10_000) / target`, capped at 10_000.
+        let coverage_bps: u32 = if campaign.target_amount == 0 {
+            0
+        } else {
+            let raw = (campaign.committed_amount * 10_000) / campaign.target_amount;
+            raw.min(10_000) as u32
+        };
+
+        CampaignCoverage {
+            campaign_id,
+            configured,
+            exists: true,
+            status,
+            target_amount: campaign.target_amount,
+            committed_amount: campaign.committed_amount,
+            remaining_amount: remaining,
+            coverage_bps,
+            now,
+        }
+    }
+}
+
+fn require_admin(env: &Env, claimed: &Address) {
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Not initialized");
+    assert!(stored == *claimed, "Caller is not admin");
+}
+
+fn bump_open(env: &Env, delta: i32) {
+    let count = storage::read_u32(env, &DataKey::OpenCampaigns);
+    storage::write_u32(
+        env,
+        &DataKey::OpenCampaigns,
+        storage::apply_count_delta(count, delta),
+    );
+}
+
+fn bump_settled_count(env: &Env, delta: i32) {
+    let count = storage::read_u32(env, &DataKey::SettledCampaigns);
+    storage::write_u32(
+        env,
+        &DataKey::SettledCampaigns,
+        storage::apply_count_delta(count, delta),
+    );
+}
+
+fn bump_cancelled_count(env: &Env, delta: i32) {
+    let count = storage::read_u32(env, &DataKey::CancelledCampaigns);
+    storage::write_u32(
+        env,
+        &DataKey::CancelledCampaigns,
+        storage::apply_count_delta(count, delta),
+    );
+}
+
+fn bump_outstanding(env: &Env, delta: i128) {
+    let value = storage::read_i128(env, &DataKey::OutstandingCommitted);
+    storage::write_i128(env, &DataKey::OutstandingCommitted, value + delta);
+}
+
+fn bump_lifetime_committed(env: &Env, delta: i128) {
+    let value = storage::read_i128(env, &DataKey::LifetimeCommitted);
+    storage::write_i128(env, &DataKey::LifetimeCommitted, value + delta);
+}
+
+fn bump_lifetime_settled(env: &Env, delta: i128) {
+    let value = storage::read_i128(env, &DataKey::LifetimeSettled);
+    storage::write_i128(env, &DataKey::LifetimeSettled, value + delta);
+}
+
+fn bump_lifetime_cancelled(env: &Env, delta: i128) {
+    let value = storage::read_i128(env, &DataKey::LifetimeCancelled);
+    storage::write_i128(env, &DataKey::LifetimeCancelled, value + delta);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, Env};
+
+    fn setup<'a>() -> (Env, Address, SponsorPoolClient<'a>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        let contract_id = env.register(SponsorPool, ());
+        let client = SponsorPoolClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        (env, admin, client)
+    }
+
+    fn register(
+        env: &Env,
+        client: &SponsorPoolClient,
+        admin: &Address,
+        campaign_id: u64,
+        target: i128,
+    ) -> Address {
+        let beneficiary = Address::generate(env);
+        let token = Address::generate(env);
+        client.register_campaign(admin, &campaign_id, &beneficiary, &token, &target);
+        beneficiary
+    }
+
+    #[test]
+    fn committed_funds_summary_starts_at_zero() {
+        let (_env, _admin, client) = setup();
+        let s = client.committed_funds_summary();
+        assert_eq!(s.configured, true);
+        assert_eq!(s.open_campaigns, 0);
+        assert_eq!(s.settled_campaigns, 0);
+        assert_eq!(s.cancelled_campaigns, 0);
+        assert_eq!(s.outstanding_committed, 0);
+        assert_eq!(s.lifetime_committed, 0);
+    }
+
+    #[test]
+    fn committed_funds_summary_tracks_lifecycle() {
+        let (env, admin, client) = setup();
+        let _b1 = register(&env, &client, &admin, 1, 1_000);
+        let _b2 = register(&env, &client, &admin, 2, 500);
+        let _b3 = register(&env, &client, &admin, 3, 2_000);
+
+        let sponsor = Address::generate(&env);
+        client.commit_funds(&sponsor, &1u64, &400i128);
+        client.commit_funds(&sponsor, &2u64, &500i128);
+        client.commit_funds(&sponsor, &3u64, &200i128);
+
+        let s = client.committed_funds_summary();
+        assert_eq!(s.open_campaigns, 3);
+        assert_eq!(s.outstanding_committed, 1_100);
+        assert_eq!(s.lifetime_committed, 1_100);
+
+        client.settle(&admin, &2u64);
+        client.cancel(&admin, &3u64);
+
+        let s = client.committed_funds_summary();
+        assert_eq!(s.open_campaigns, 1);
+        assert_eq!(s.settled_campaigns, 1);
+        assert_eq!(s.cancelled_campaigns, 1);
+        // Only campaign 1 is still outstanding (400 committed).
+        assert_eq!(s.outstanding_committed, 400);
+        assert_eq!(s.lifetime_committed, 1_100);
+        assert_eq!(s.lifetime_settled, 500);
+        assert_eq!(s.lifetime_cancelled, 200);
+    }
+
+    #[test]
+    fn campaign_coverage_unknown_id_returns_unknown_state() {
+        let (_env, _admin, client) = setup();
+        let c = client.campaign_coverage(&999u64);
+        assert_eq!(c.exists, false);
+        assert_eq!(c.status, CampaignStatus::Unknown);
+        assert_eq!(c.configured, true);
+        assert_eq!(c.coverage_bps, 0);
+    }
+
+    #[test]
+    fn campaign_coverage_reports_status_and_basis_points() {
+        let (env, admin, client) = setup();
+        let _b = register(&env, &client, &admin, 1, 1_000);
+
+        let zero = client.campaign_coverage(&1u64);
+        assert_eq!(zero.status, CampaignStatus::Open);
+        assert_eq!(zero.coverage_bps, 0);
+        assert_eq!(zero.remaining_amount, 1_000);
+
+        let sponsor = Address::generate(&env);
+        client.commit_funds(&sponsor, &1u64, &500i128);
+
+        let half = client.campaign_coverage(&1u64);
+        assert_eq!(half.status, CampaignStatus::Open);
+        assert_eq!(half.committed_amount, 500);
+        assert_eq!(half.remaining_amount, 500);
+        // 50% coverage → 5000 bps.
+        assert_eq!(half.coverage_bps, 5_000);
+
+        // A late commit larger than the remaining amount caps at the target.
+        client.commit_funds(&sponsor, &1u64, &10_000i128);
+        let full = client.campaign_coverage(&1u64);
+        assert_eq!(full.committed_amount, 1_000);
+        assert_eq!(full.remaining_amount, 0);
+        assert_eq!(full.coverage_bps, 10_000);
+    }
+
+    #[test]
+    fn campaign_coverage_reflects_settled_and_cancelled() {
+        let (env, admin, client) = setup();
+        let _b = register(&env, &client, &admin, 1, 1_000);
+        let sponsor = Address::generate(&env);
+        client.commit_funds(&sponsor, &1u64, &1_000i128);
+
+        client.settle(&admin, &1u64);
+        let s = client.campaign_coverage(&1u64);
+        assert_eq!(s.status, CampaignStatus::Settled);
+        assert_eq!(s.coverage_bps, 10_000);
+
+        let _b2 = register(&env, &client, &admin, 2, 1_000);
+        client.commit_funds(&sponsor, &2u64, &200i128);
+        client.cancel(&admin, &2u64);
+        let c = client.campaign_coverage(&2u64);
+        assert_eq!(c.status, CampaignStatus::Cancelled);
+        assert_eq!(c.committed_amount, 200);
+    }
+
+    #[test]
+    fn commit_funds_caps_at_target() {
+        let (env, admin, client) = setup();
+        let _b = register(&env, &client, &admin, 1, 100);
+        let sponsor = Address::generate(&env);
+        client.commit_funds(&sponsor, &1u64, &500i128);
+        let c = client.campaign_coverage(&1u64);
+        assert_eq!(c.committed_amount, 100);
+        assert_eq!(c.coverage_bps, 10_000);
+        // outstanding mirrors the actually-committed amount, not the input.
+        let s = client.committed_funds_summary();
+        assert_eq!(s.outstanding_committed, 100);
+        assert_eq!(s.lifetime_committed, 100);
+    }
+}

--- a/contracts/sponsor-pool/src/storage.rs
+++ b/contracts/sponsor-pool/src/storage.rs
@@ -1,0 +1,39 @@
+use crate::types::CampaignRecord;
+use crate::DataKey;
+use soroban_sdk::Env;
+
+pub fn set_campaign(env: &Env, record: &CampaignRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Campaign(record.campaign_id), record);
+}
+
+pub fn get_campaign(env: &Env, campaign_id: u64) -> Option<CampaignRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Campaign(campaign_id))
+}
+
+pub fn read_u32(env: &Env, key: &DataKey) -> u32 {
+    env.storage().instance().get(key).unwrap_or(0)
+}
+
+pub fn read_i128(env: &Env, key: &DataKey) -> i128 {
+    env.storage().instance().get(key).unwrap_or(0)
+}
+
+pub fn write_u32(env: &Env, key: &DataKey, value: u32) {
+    env.storage().instance().set(key, &value);
+}
+
+pub fn write_i128(env: &Env, key: &DataKey, value: i128) {
+    env.storage().instance().set(key, &value);
+}
+
+pub fn apply_count_delta(count: u32, delta: i32) -> u32 {
+    if delta < 0 {
+        count.saturating_sub((-delta) as u32)
+    } else {
+        count.saturating_add(delta as u32)
+    }
+}

--- a/contracts/sponsor-pool/src/types.rs
+++ b/contracts/sponsor-pool/src/types.rs
@@ -1,0 +1,81 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Lifecycle of a sponsorship campaign within the pool.
+#[contracttype]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum CampaignStatus {
+    /// Campaign id is unknown to the pool.
+    Unknown,
+    /// Pool has not been initialised yet.
+    NotConfigured,
+    /// Campaign is registered and accepting commitments.
+    Open,
+    /// Campaign has been fully funded and committed funds released.
+    Settled,
+    /// Campaign was cancelled before settlement; remaining funds released back.
+    Cancelled,
+}
+
+/// On-chain record for a single sponsorship campaign.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CampaignRecord {
+    pub campaign_id: u64,
+    /// Beneficiary that receives funds on settlement.
+    pub beneficiary: Address,
+    /// Token contract used by every commitment to this campaign.
+    pub token: Address,
+    /// Amount the operator targets for this campaign.
+    pub target_amount: i128,
+    /// Sum of every commit_funds call against this campaign.
+    pub committed_amount: i128,
+    /// True after `settle` succeeds.
+    pub settled: bool,
+    /// True after `cancel` succeeds.
+    pub cancelled: bool,
+}
+
+/// Aggregate snapshot returned by `committed_funds_summary()`.
+///
+/// Reuses the in-storage instance counters so callers don't need to fan out
+/// across every campaign to compute totals — matches the issue's
+/// "reuse tracked storage aggregates when possible" guidance.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CommittedFundsSummary {
+    pub configured: bool,
+    /// Number of campaigns currently in `Open` state.
+    pub open_campaigns: u32,
+    /// Number of campaigns settled (terminal).
+    pub settled_campaigns: u32,
+    /// Number of campaigns cancelled (terminal).
+    pub cancelled_campaigns: u32,
+    /// Outstanding committed funds across every Open campaign.
+    pub outstanding_committed: i128,
+    /// Total committed across the pool's lifetime (irrespective of state).
+    pub lifetime_committed: i128,
+    /// Total released to beneficiaries via `settle`.
+    pub lifetime_settled: i128,
+    /// Total returned to sponsors via `cancel`.
+    pub lifetime_cancelled: i128,
+    pub now: u64,
+}
+
+/// Coverage view for a single campaign returned by `campaign_coverage(id)`.
+///
+/// `coverage_bps` is integer basis points (10_000 = 100%) so the frontend
+/// doesn't need floating point. Capped at 10_000 once the campaign is fully
+/// funded.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CampaignCoverage {
+    pub campaign_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub status: CampaignStatus,
+    pub target_amount: i128,
+    pub committed_amount: i128,
+    pub remaining_amount: i128,
+    pub coverage_bps: u32,
+    pub now: u64,
+}

--- a/frontend/src/components/v1/PageIntro.css
+++ b/frontend/src/components/v1/PageIntro.css
@@ -1,0 +1,138 @@
+.page-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  background: var(--surface-1, #11161e);
+}
+
+.page-intro__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.page-intro__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.page-intro__eyebrow {
+  margin: 0;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-primary, #7af7c0);
+}
+
+.page-intro__title {
+  margin: 0;
+  font-size: 1.4rem;
+  line-height: 1.2;
+  font-weight: 600;
+  color: var(--text-primary, #f5f7fb);
+}
+
+.page-intro__description {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--text-secondary, rgba(245, 247, 251, 0.78));
+  max-width: 60ch;
+}
+
+.page-intro__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.page-intro__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-muted, rgba(245, 247, 251, 0.55));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.page-intro__breadcrumbs li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.page-intro__breadcrumbs li::after {
+  content: "/";
+  margin-left: 0.25rem;
+  color: var(--text-muted, rgba(245, 247, 251, 0.4));
+}
+
+.page-intro__breadcrumbs li:last-child::after {
+  content: "";
+}
+
+.page-intro__breadcrumb-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page-intro__breadcrumb-link:hover {
+  color: var(--text-primary, #f5f7fb);
+  text-decoration: underline;
+}
+
+.page-intro__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--border-subtle, rgba(255, 255, 255, 0.08));
+}
+
+.page-intro__meta-item {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.page-intro__meta-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, rgba(245, 247, 251, 0.55));
+}
+
+.page-intro__meta-value {
+  font-size: 0.85rem;
+  color: var(--text-primary, #f5f7fb);
+  font-weight: 500;
+}
+
+@media (max-width: 600px) {
+  .page-intro {
+    padding: 1rem 1.25rem;
+  }
+
+  .page-intro__title {
+    font-size: 1.15rem;
+  }
+
+  .page-intro__top {
+    flex-direction: column;
+  }
+
+  .page-intro__actions {
+    width: 100%;
+  }
+}

--- a/frontend/src/components/v1/PageIntro.tsx
+++ b/frontend/src/components/v1/PageIntro.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import "./PageIntro.css";
+
+/**
+ * Page intro pattern for feature-heavy dashboard routes (#576).
+ *
+ * Standardises the top-of-page header so dense routes like Audit Log,
+ * Analytics, Treasury, and Player Lookup don't each invent their own. Slots
+ * cover the common shape: optional eyebrow, title, description, breadcrumbs,
+ * primary actions, and a meta strip for status / counts / freshness.
+ *
+ * The component is presentational — callers decide what state drives each
+ * slot. Empty / loading states are surfaced through the `meta` array
+ * (caller passes a "Loading…" item) and the `actions` slot (caller can
+ * disable the buttons), so this component doesn't need its own data layer.
+ */
+export interface PageIntroBreadcrumb {
+  /** Display label. */
+  label: string;
+  /** Optional href; when omitted the crumb renders as plain text (current page). */
+  href?: string;
+  /** Optional click handler — preferred over `href` for SPA navigation. */
+  onClick?: () => void;
+}
+
+export interface PageIntroMeta {
+  label: string;
+  value: React.ReactNode;
+}
+
+export interface PageIntroProps {
+  /** Required title — main heading for the page. */
+  title: string;
+  /** Optional eyebrow rendered above the title. */
+  eyebrow?: string;
+  /** Optional supporting description, typically one to two sentences. */
+  description?: React.ReactNode;
+  /** Optional breadcrumb trail. The last crumb is treated as the current page. */
+  breadcrumbs?: PageIntroBreadcrumb[];
+  /** Optional inline action slot rendered top-right. */
+  actions?: React.ReactNode;
+  /** Optional meta strip rendered at the bottom of the intro card. */
+  meta?: PageIntroMeta[];
+  /** Optional override for `data-testid` on the root section. */
+  testId?: string;
+  className?: string;
+}
+
+export function PageIntro({
+  title,
+  eyebrow,
+  description,
+  breadcrumbs,
+  actions,
+  meta,
+  testId = "page-intro",
+  className = "",
+}: PageIntroProps): React.JSX.Element {
+  return (
+    <section
+      className={`page-intro ${className}`.trim()}
+      aria-labelledby={`${testId}-title`}
+      data-testid={testId}
+    >
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <ol
+          className="page-intro__breadcrumbs"
+          aria-label="Breadcrumb"
+          data-testid={`${testId}-breadcrumbs`}
+        >
+          {breadcrumbs.map((crumb, idx) => {
+            const isLast = idx === breadcrumbs.length - 1;
+            return (
+              <li key={`${crumb.label}-${idx}`}>
+                {crumb.href || crumb.onClick ? (
+                  <a
+                    href={crumb.href ?? "#"}
+                    onClick={(e) => {
+                      if (crumb.onClick) {
+                        e.preventDefault();
+                        crumb.onClick();
+                      }
+                    }}
+                    className="page-intro__breadcrumb-link"
+                    aria-current={isLast ? "page" : undefined}
+                    data-testid={`${testId}-breadcrumb-${idx}`}
+                  >
+                    {crumb.label}
+                  </a>
+                ) : (
+                  <span
+                    aria-current={isLast ? "page" : undefined}
+                    data-testid={`${testId}-breadcrumb-${idx}`}
+                  >
+                    {crumb.label}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      <div className="page-intro__top">
+        <div className="page-intro__copy">
+          {eyebrow && (
+            <p
+              className="page-intro__eyebrow"
+              data-testid={`${testId}-eyebrow`}
+            >
+              {eyebrow}
+            </p>
+          )}
+          <h1
+            id={`${testId}-title`}
+            className="page-intro__title"
+            data-testid={`${testId}-title`}
+          >
+            {title}
+          </h1>
+          {description && (
+            <p
+              className="page-intro__description"
+              data-testid={`${testId}-description`}
+            >
+              {description}
+            </p>
+          )}
+        </div>
+
+        {actions && (
+          <div
+            className="page-intro__actions"
+            data-testid={`${testId}-actions`}
+          >
+            {actions}
+          </div>
+        )}
+      </div>
+
+      {meta && meta.length > 0 && (
+        <dl className="page-intro__meta" data-testid={`${testId}-meta`}>
+          {meta.map((item, idx) => (
+            <div
+              key={`${item.label}-${idx}`}
+              className="page-intro__meta-item"
+              data-testid={`${testId}-meta-${idx}`}
+            >
+              <dt className="page-intro__meta-label">{item.label}</dt>
+              <dd className="page-intro__meta-value">{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </section>
+  );
+}
+
+export default PageIntro;

--- a/frontend/src/components/v1/TableRowActionOverflowMenu.css
+++ b/frontend/src/components/v1/TableRowActionOverflowMenu.css
@@ -1,0 +1,97 @@
+.tr-action-overflow {
+  position: relative;
+  display: inline-flex;
+}
+
+.tr-action-overflow__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted, rgba(245, 247, 251, 0.65));
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.tr-action-overflow__trigger:hover:not(:disabled) {
+  border-color: var(--border-subtle, rgba(255, 255, 255, 0.12));
+  color: var(--text-primary, #f5f7fb);
+}
+
+.tr-action-overflow__trigger:focus-visible {
+  outline: 2px solid var(--accent-primary, #7af7c0);
+  outline-offset: 2px;
+}
+
+.tr-action-overflow__trigger:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tr-action-overflow__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 11rem;
+  z-index: 30;
+  padding: 0.25rem;
+  margin: 0;
+  list-style: none;
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+  background: var(--surface-1, #11161e);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.tr-action-overflow__item-button {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  font-size: 0.85rem;
+  color: var(--text-primary, #f5f7fb);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.tr-action-overflow__item-button:hover:not(:disabled) {
+  background: var(--surface-2, rgba(255, 255, 255, 0.04));
+}
+
+.tr-action-overflow__item-button:focus-visible {
+  outline: none;
+  background: var(--surface-2, rgba(255, 255, 255, 0.06));
+}
+
+.tr-action-overflow__item-button[data-tone="danger"] {
+  color: var(--text-danger, #ff8a73);
+}
+
+.tr-action-overflow__item-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tr-action-overflow__empty {
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-muted, rgba(245, 247, 251, 0.65));
+  text-align: center;
+}
+
+.tr-action-overflow__divider {
+  height: 1px;
+  margin: 0.25rem 0;
+  background: var(--border-subtle, rgba(255, 255, 255, 0.08));
+  border: 0;
+}

--- a/frontend/src/components/v1/TableRowActionOverflowMenu.tsx
+++ b/frontend/src/components/v1/TableRowActionOverflowMenu.tsx
@@ -1,0 +1,227 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
+import "./TableRowActionOverflowMenu.css";
+
+/**
+ * Table row action overflow menu (#565).
+ *
+ * Drop-in for dense data views: collapses N row actions into a single
+ * "More" trigger and surfaces them in a popover list. Keyboard accessible
+ * (arrow keys + Enter), closes on Escape / outside-click / blur, and
+ * handles the "no actions provided" / "all actions disabled" edge cases
+ * explicitly so callers don't need to gate the trigger.
+ */
+export type OverflowItemTone = "default" | "danger";
+
+export interface TableRowActionOverflowItem {
+  id: string;
+  label: string;
+  /** Triggered when the item is selected. */
+  onSelect: () => void | Promise<void>;
+  /** Visual tone — `danger` colours destructive actions. */
+  tone?: OverflowItemTone;
+  /** Disable a specific action without removing it from the list. */
+  disabled?: boolean;
+  /** Optional leading icon. */
+  icon?: React.ReactNode;
+  /** Render a divider above this item; useful between groups. */
+  divider?: boolean;
+}
+
+export interface TableRowActionOverflowMenuProps {
+  items: TableRowActionOverflowItem[];
+  /** Optional label for the trigger (announced by screen readers). */
+  triggerLabel?: string;
+  /** Disables the trigger entirely. */
+  disabled?: boolean;
+  /** Optional override for `data-testid` on the trigger. */
+  testId?: string;
+  className?: string;
+}
+
+export function TableRowActionOverflowMenu({
+  items,
+  triggerLabel = "Row actions",
+  disabled = false,
+  testId = "table-row-action-overflow",
+  className = "",
+}: TableRowActionOverflowMenuProps): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+
+  const enabledItemIndices = items
+    .map((item, idx) => ({ item, idx }))
+    .filter(({ item }) => !item.disabled);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setActiveIdx(0);
+  }, []);
+
+  // Close on outside click + Escape so the menu doesn't stay attached when
+  // the user navigates away by other means.
+  useEffect(() => {
+    if (!open) return;
+    const onDocumentClick = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (target && wrapperRef.current && !wrapperRef.current.contains(target)) {
+        close();
+      }
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+      }
+    };
+    document.addEventListener("mousedown", onDocumentClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocumentClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, close]);
+
+  const moveActive = useCallback(
+    (delta: 1 | -1) => {
+      if (enabledItemIndices.length === 0) return;
+      setActiveIdx((prev) => {
+        const currentEnabledPos = Math.max(
+          0,
+          enabledItemIndices.findIndex(({ idx }) => idx === prev),
+        );
+        const nextEnabledPos =
+          (currentEnabledPos + delta + enabledItemIndices.length) %
+          enabledItemIndices.length;
+        return enabledItemIndices[nextEnabledPos]!.idx;
+      });
+    },
+    [enabledItemIndices],
+  );
+
+  const handleTriggerKey = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setOpen(true);
+      const firstEnabled = enabledItemIndices[0]?.idx ?? 0;
+      setActiveIdx(firstEnabled);
+    }
+  };
+
+  const handleMenuKey = (e: React.KeyboardEvent<HTMLUListElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      moveActive(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      moveActive(-1);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      const first = enabledItemIndices[0]?.idx;
+      if (first !== undefined) setActiveIdx(first);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      const last = enabledItemIndices[enabledItemIndices.length - 1]?.idx;
+      if (last !== undefined) setActiveIdx(last);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const item = items[activeIdx];
+      if (item && !item.disabled) {
+        void runAction(item);
+      }
+    }
+  };
+
+  const runAction = async (item: TableRowActionOverflowItem) => {
+    close();
+    await item.onSelect();
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={`tr-action-overflow ${className}`.trim()}
+      data-testid={testId}
+    >
+      <button
+        type="button"
+        aria-label={triggerLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        className="tr-action-overflow__trigger"
+        disabled={disabled || items.length === 0}
+        data-testid={`${testId}-trigger`}
+        onClick={() => {
+          if (open) {
+            close();
+          } else {
+            setOpen(true);
+            const firstEnabled = enabledItemIndices[0]?.idx ?? 0;
+            setActiveIdx(firstEnabled);
+          }
+        }}
+        onKeyDown={handleTriggerKey}
+      >
+        {/* Vertical ellipsis */}
+        <span aria-hidden="true">⋮</span>
+      </button>
+
+      {open && (
+        <ul
+          id={menuId}
+          role="menu"
+          tabIndex={-1}
+          ref={(node) => {
+            // Move focus into the menu when it opens so arrow keys work
+            // immediately without an extra click.
+            if (node) node.focus();
+          }}
+          aria-label={triggerLabel}
+          className="tr-action-overflow__menu"
+          data-testid={`${testId}-menu`}
+          onKeyDown={handleMenuKey}
+        >
+          {items.length === 0 ? (
+            <li
+              className="tr-action-overflow__empty"
+              data-testid={`${testId}-empty`}
+            >
+              No actions available
+            </li>
+          ) : (
+            items.map((item, idx) => (
+              <React.Fragment key={item.id}>
+                {item.divider && idx > 0 && (
+                  <hr aria-hidden="true" className="tr-action-overflow__divider" />
+                )}
+                <li role="none">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={item.disabled}
+                    data-tone={item.tone ?? "default"}
+                    data-active={idx === activeIdx ? "true" : "false"}
+                    data-testid={`${testId}-item-${item.id}`}
+                    className="tr-action-overflow__item-button"
+                    onClick={() => {
+                      if (!item.disabled) {
+                        void runAction(item);
+                      }
+                    }}
+                  >
+                    {item.icon && <span aria-hidden="true">{item.icon}</span>}
+                    <span>{item.label}</span>
+                  </button>
+                </li>
+              </React.Fragment>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default TableRowActionOverflowMenu;

--- a/frontend/tests/components/PageIntro.test.tsx
+++ b/frontend/tests/components/PageIntro.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { PageIntro } from "@/components/v1/PageIntro";
+
+describe("PageIntro (#576)", () => {
+  it("renders title only when other slots are omitted", () => {
+    render(<PageIntro title="Audit Log" />);
+    expect(screen.getByTestId("page-intro-title")).toHaveTextContent("Audit Log");
+    expect(screen.queryByTestId("page-intro-eyebrow")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("page-intro-description")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("page-intro-actions")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("page-intro-meta")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("page-intro-breadcrumbs")).not.toBeInTheDocument();
+  });
+
+  it("renders eyebrow + description when provided", () => {
+    render(
+      <PageIntro
+        title="Audit Log"
+        eyebrow="Operations"
+        description="Every state-changing call is recorded with its caller."
+      />,
+    );
+    expect(screen.getByTestId("page-intro-eyebrow")).toHaveTextContent("Operations");
+    expect(screen.getByTestId("page-intro-description")).toHaveTextContent(
+      "Every state-changing call",
+    );
+  });
+
+  it("renders the actions slot for top-right buttons", () => {
+    render(
+      <PageIntro
+        title="Treasury"
+        actions={
+          <button type="button" data-testid="primary-action">
+            Settle
+          </button>
+        }
+      />,
+    );
+    expect(screen.getByTestId("page-intro-actions")).toBeInTheDocument();
+    expect(screen.getByTestId("primary-action")).toBeInTheDocument();
+  });
+
+  it("renders breadcrumbs and marks the last crumb aria-current", () => {
+    render(
+      <PageIntro
+        title="Player Detail"
+        breadcrumbs={[
+          { label: "Dashboard", href: "/" },
+          { label: "Players", href: "/players" },
+          { label: "Alice" },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId("page-intro-breadcrumbs")).toBeInTheDocument();
+    expect(screen.getByTestId("page-intro-breadcrumb-2")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByTestId("page-intro-breadcrumb-0")).not.toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("invokes the breadcrumb onClick handler instead of navigating", () => {
+    const onClick = vi.fn();
+    render(
+      <PageIntro
+        title="Player Detail"
+        breadcrumbs={[
+          { label: "Dashboard", onClick },
+          { label: "Alice" },
+        ]}
+      />,
+    );
+    const link = screen.getByTestId("page-intro-breadcrumb-0");
+    fireEvent.click(link);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders the meta strip with label/value pairs", () => {
+    render(
+      <PageIntro
+        title="Analytics"
+        meta={[
+          { label: "Last refresh", value: "2 min ago" },
+          { label: "Rows", value: "1,234" },
+        ]}
+      />,
+    );
+    const strip = screen.getByTestId("page-intro-meta");
+    expect(strip).toBeInTheDocument();
+    expect(screen.getByTestId("page-intro-meta-0")).toHaveTextContent("Last refresh");
+    expect(screen.getByTestId("page-intro-meta-1")).toHaveTextContent("1,234");
+  });
+
+  it("hides the breadcrumbs slot when the array is empty", () => {
+    render(<PageIntro title="t" breadcrumbs={[]} />);
+    expect(screen.queryByTestId("page-intro-breadcrumbs")).not.toBeInTheDocument();
+  });
+
+  it("hides the meta slot when the array is empty", () => {
+    render(<PageIntro title="t" meta={[]} />);
+    expect(screen.queryByTestId("page-intro-meta")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/TableRowActionOverflowMenu.test.tsx
+++ b/frontend/tests/components/TableRowActionOverflowMenu.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TableRowActionOverflowMenu } from "@/components/v1/TableRowActionOverflowMenu";
+
+describe("TableRowActionOverflowMenu (#565)", () => {
+  it("renders only the trigger when closed", () => {
+    render(
+      <TableRowActionOverflowMenu
+        items={[
+          { id: "edit", label: "Edit", onSelect: vi.fn() },
+          { id: "delete", label: "Delete", onSelect: vi.fn() },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId("table-row-action-overflow-trigger")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("table-row-action-overflow-menu"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the menu on click and lists every action", () => {
+    render(
+      <TableRowActionOverflowMenu
+        items={[
+          { id: "edit", label: "Edit", onSelect: vi.fn() },
+          { id: "delete", label: "Delete", onSelect: vi.fn(), tone: "danger" },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-trigger"));
+    expect(screen.getByTestId("table-row-action-overflow-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("table-row-action-overflow-item-edit")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("table-row-action-overflow-item-delete"),
+    ).toHaveAttribute("data-tone", "danger");
+  });
+
+  it("invokes onSelect when an action is chosen and closes the menu", async () => {
+    const onSelect = vi.fn();
+    render(
+      <TableRowActionOverflowMenu
+        items={[{ id: "edit", label: "Edit", onSelect }]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-trigger"));
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-item-edit"));
+    expect(onSelect).toHaveBeenCalledOnce();
+    // Menu re-renders without the popover after selecting.
+    expect(
+      screen.queryByTestId("table-row-action-overflow-menu"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not invoke onSelect for disabled actions", () => {
+    const onSelect = vi.fn();
+    render(
+      <TableRowActionOverflowMenu
+        items={[{ id: "edit", label: "Edit", onSelect, disabled: true }]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-trigger"));
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-item-edit"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("disables the trigger when no items are supplied", () => {
+    render(<TableRowActionOverflowMenu items={[]} />);
+    const trigger = screen.getByTestId("table-row-action-overflow-trigger");
+    expect(trigger).toBeDisabled();
+  });
+
+  it("respects the `disabled` prop on the trigger", () => {
+    render(
+      <TableRowActionOverflowMenu
+        items={[{ id: "edit", label: "Edit", onSelect: vi.fn() }]}
+        disabled
+      />,
+    );
+    const trigger = screen.getByTestId("table-row-action-overflow-trigger");
+    expect(trigger).toBeDisabled();
+  });
+
+  it("closes on Escape", () => {
+    render(
+      <TableRowActionOverflowMenu
+        items={[{ id: "edit", label: "Edit", onSelect: vi.fn() }]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-trigger"));
+    expect(screen.getByTestId("table-row-action-overflow-menu")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(
+      screen.queryByTestId("table-row-action-overflow-menu"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("supports keyboard navigation across enabled items only", () => {
+    render(
+      <TableRowActionOverflowMenu
+        items={[
+          { id: "view", label: "View", onSelect: vi.fn() },
+          { id: "skip", label: "Skip me", onSelect: vi.fn(), disabled: true },
+          { id: "delete", label: "Delete", onSelect: vi.fn() },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-trigger"));
+    const menu = screen.getByTestId("table-row-action-overflow-menu");
+    // Initial active should be the first enabled item.
+    expect(screen.getByTestId("table-row-action-overflow-item-view")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    // Next enabled is delete (skipping the disabled item).
+    expect(
+      screen.getByTestId("table-row-action-overflow-item-delete"),
+    ).toHaveAttribute("data-active", "true");
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    // Wraps back to first enabled.
+    expect(screen.getByTestId("table-row-action-overflow-item-view")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+  });
+
+  it("shows an empty fallback if every item is disabled and the menu is opened anyway", () => {
+    // Forcing the menu open by passing a single item that's disabled — the
+    // trigger stays clickable but selecting the disabled item is a no-op.
+    render(
+      <TableRowActionOverflowMenu
+        items={[{ id: "view", label: "View", onSelect: vi.fn(), disabled: true }]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("table-row-action-overflow-trigger"));
+    const item = screen.getByTestId("table-row-action-overflow-item-view");
+    expect(item).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes all four open issues assigned to me in one PR. **#521 and #541 are duplicate issues** with identical bodies and acceptance criteria; the same sponsor-pool contract closes both.

### #521 / #541 — `sponsor-pool` contract
New Soroban crate at `contracts/sponsor-pool/` with `lib.rs`, `storage.rs`, `types.rs`, in-tree tests.
- Mutators: `init` / `register_campaign` / `commit_funds` (caps at target) / `settle` / `cancel`
- **`committed_funds_summary()`** → `CommittedFundsSummary { configured, open_campaigns, settled_campaigns, cancelled_campaigns, outstanding_committed, lifetime_committed, lifetime_settled, lifetime_cancelled, now }` — reuses tracked instance counters so the read is O(1) instead of fanning out across every campaign (matches the issue's "reuse storage aggregates" guidance)
- **`campaign_coverage(campaign_id)`** → `CampaignCoverage` with `status ∈ { Unknown, NotConfigured, Open, Settled, Cancelled }`, target / committed / remaining amounts, plus integer `coverage_bps` (0..=10_000) capped at 10_000 — keeps the contract floating-point-free
- 6 unit tests: zero-state, lifecycle aggregation, unknown-id fallback, basis-point math, settled / cancelled state, cap-at-target invariant
- `contracts/Cargo.toml` workspace.members gains the new crate

### #565 — `TableRowActionOverflowMenu`
Drop-in for dense data views.
- Vertical-ellipsis trigger; popover list with `aria-haspopup`, `aria-expanded`, `role="menu"` / `menuitem`
- Arrow-key navigation that **skips disabled items**; closes on Escape and outside-click
- Trigger auto-disables when no items are supplied so callers don't need a render guard
- Items support `tone="danger"` and an optional `divider` for grouping
- **9 vitest cases**

### #576 — `PageIntro`
Standardises the top-of-page header for feature-heavy dashboard routes.
- Slots: optional `eyebrow`, required `title`, optional `description`, optional `breadcrumbs` (last crumb auto-gets `aria-current="page"`), optional `actions` (top-right), optional `meta` strip
- Empty arrays for `breadcrumbs` / `meta` hide the slot entirely
- SPA-friendly: breadcrumb `onClick` takes precedence over `href`
- **8 vitest cases**

## Test plan
- [x] `cd contracts/sponsor-pool && cargo +stable test` → **6 / 6 pass**
- [x] `cd frontend && pnpm test tests/components/TableRowActionOverflowMenu.test.tsx tests/components/PageIntro.test.tsx` → **17 / 17 pass**

## Workspace note (same as my previous stellarcade PRs)
The pinned `rust-toolchain.toml` is `1.85.0` but the current `soroban-sdk` resolves to `25.3.1` which requires `1.91+`. I used `cargo +stable` for tests; bumping `rust-toolchain.toml` is out of scope.

Closes #521
Closes #541
Closes #565
Closes #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sponsor pool smart contract with campaign registration, fund commitment tracking, and settlement functionality
  * Added a page introduction component for displaying headers with titles, breadcrumbs, and metadata strips
  * Added a table row action overflow menu component for collapsing multiple actions into a keyboard-navigable dropdown

* **Tests**
  * Added test coverage for the page introduction component
  * Added test coverage for the table row action overflow menu component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->