### PR TITLE
test(validation): use checksum-valid StrKey fixtures and assert remap…

### DIFF
--- a/frontend/tests/unit/input-validation-schemas.test.ts
+++ b/frontend/tests/unit/input-validation-schemas.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
 import {
   // Constants
   U64_MAX,
@@ -40,8 +41,8 @@ import {
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-const VALID_WALLET = 'GABCDEFGHJKLMNPQRSTUVWXYZ234567ABCDEFGHJKLMNPQRSTUVWXYZ2';
-const VALID_CONTRACT = 'CABCDEFGHJKLMNPQRSTUVWXYZ234567ABCDEFGHJKLMNPQRSTUVWXYZ2';
+const VALID_WALLET = Keypair.fromRawEd25519Seed(new Uint8Array(32)).publicKey();
+const VALID_CONTRACT = StrKey.encodeContract(Buffer.alloc(32));
 const VALID_HASH = 'a3f5c1d2e4b6789012345678901234567890abcdef1234567890abcdef123456';
 const TESTNET_PASSPHRASE = 'Test SDF Network ; September 2015';
 const VALID_WAGER = 50_000_000n; // 5 XLM
@@ -430,6 +431,7 @@ describe('parsePatternSubmission', () => {
   it('fails when walletAddress is invalid', () => {
     const result = parsePatternSubmission({ ...validInput, walletAddress: 'bad-address' });
     expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.field).toBe('walletAddress');
   });
 });
 
@@ -515,6 +517,7 @@ describe('parsePrizePoolPayout', () => {
   it('fails when recipient is missing', () => {
     const result = parsePrizePoolPayout({ gameId: '5', amount: VALID_WAGER, recipient: null });
     expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.field).toBe('recipient');
   });
 
   it('fails when gameId is invalid', () => {


### PR DESCRIPTION
Closes #716
Closes #702
Closes #698
Closes #693

## Summary
This PR addresses two low-risk validation/test improvements:

1. Uses checksum-valid Stellar StrKey fixtures in unit tests instead of format-only placeholder strings.
2. Strengthens field-remap coverage by asserting the returned error fields are:
- `walletAddress` for invalid wallet input in `parsePatternSubmission`
- `recipient` for missing recipient in `parsePrizePoolPayout`

## Changes
- Updated test fixtures in `frontend/tests/unit/input-validation-schemas.test.ts`:
  - `VALID_WALLET` now generated via `Keypair.fromRawEd25519Seed(...).publicKey()`
  - `VALID_CONTRACT` now generated via `StrKey.encodeContract(...)`
- Added explicit assertions for remapped error fields in the two affected tests.

## Why
- Future-proofs tests against stricter Stellar SDK validation behavior.
- Ensures consumers receive consistent field names that match input payload keys.

## Testing
- Local test execution is currently blocked in this environment because `vitest` is not available on PATH.
- Changes are test-only and scoped to validation schema unit test expectations/fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation test suite with more robust fixtures and stronger error field assertions for wallet address and recipient validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->