### PR TITLE
feat: add prize-streamer, mission-pass, arena-ladder, and clan-seasons contracts (#697 #735 #738 #741)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1986,6 +1986,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-arena-ladder"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-arena-sessions"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-attendance-pass"
 version = "0.1.0"
 dependencies = [
@@ -2014,6 +2028,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-bonus-vault"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-bounty-escrow"
 version = "0.1.0"
 dependencies = [
@@ -2022,6 +2043,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-campaign-claims"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-clan-seasons"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2037,6 +2065,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-color-prediction"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-combo-rewards"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2118,6 +2153,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-creator-drops"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-creator-escrow"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2241,6 +2283,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-fee-allocator"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-fee-management"
 version = "0.1.0"
 dependencies = [
@@ -2299,6 +2348,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-ladder-seasons"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-leaderboard"
 version = "0.1.0"
 dependencies = [
@@ -2321,6 +2377,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-loot-rotation"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-map-voting"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-matchmaking-queue"
 version = "0.1.0"
 dependencies = [
@@ -2329,6 +2399,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-mission-ledger"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-mission-pass"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2399,6 +2476,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-prize-streamer"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-quest-redeemer"
 version = "0.1.0"
 dependencies = [
@@ -2441,6 +2525,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-reserve-auction"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-reserve-manager"
 version = "0.1.0"
 dependencies = [
@@ -2477,6 +2568,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-reward-vesting"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-round-finalizer"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2644,6 +2742,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-vault-routing"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-vip-subscription"
 version = "0.1.0"
 dependencies = [
@@ -2652,6 +2757,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-vote-escrow"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-voucher-minter"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -116,6 +116,10 @@ members = [
     "vault-routing",
     "bonus-vault",
     "combo-rewards",
+    "prize-streamer",
+    "mission-pass",
+    "arena-ladder",
+    "clan-seasons",
 ]
 
 exclude = [

--- a/contracts/arena-ladder/Cargo.toml
+++ b/contracts/arena-ladder/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-arena-ladder"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/arena-ladder/src/lib.rs
+++ b/contracts/arena-ladder/src/lib.rs
@@ -1,0 +1,179 @@
+//! Stellarcade Arena Ladder Contract
+//!
+//! Manages per-bracket competitive pressure and promotion-window state for
+//! the arena ladder system.
+//!
+//! ## Read-only accessors
+//! - `bracket_pressure_snapshot(bracket_id)` — player count, pressure score,
+//!   and elimination-critical flag.
+//! - `promotion_window(bracket_id)` — window ledger range and eligibility rank.
+//!
+//! ## Zero-state behaviour
+//! Both accessors return `exists = false` with zeroed numeric fields when the
+//! requested `bracket_id` has not been written to storage, so callers never
+//! need to handle a missing-key error.
+
+#![no_std]
+#![allow(unexpected_cfgs)]
+#![allow(clippy::too_many_arguments)]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+pub use types::{BracketPressureSnapshot, BracketRecord, PromotionWindow};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Bracket(u32),
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct ArenaLadder;
+
+#[contractimpl]
+impl ArenaLadder {
+    /// Initialize the contract. May only be called once.
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Write or update a bracket record. Admin only.
+    ///
+    /// Existing records are fully replaced. Callers may read, modify, then
+    /// re-submit to update individual fields.
+    pub fn upsert_bracket(
+        env: Env,
+        admin: Address,
+        bracket_id: u32,
+        players_in_bracket: u32,
+        elimination_threshold: u32,
+        pressure_score: u32,
+        window_open_ledger: u32,
+        window_close_ledger: u32,
+        min_rank_for_promotion: u32,
+        window_active: bool,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        storage::set_bracket(
+            &env,
+            bracket_id,
+            &BracketRecord {
+                players_in_bracket,
+                elimination_threshold,
+                pressure_score,
+                window_open_ledger,
+                window_close_ledger,
+                min_rank_for_promotion,
+                window_active,
+            },
+        );
+        Ok(())
+    }
+
+    /// Return the bracket pressure snapshot for `bracket_id`.
+    ///
+    /// Unknown bracket ids return `exists = false` with zeroed numeric fields.
+    /// `is_critical` is `true` when `players_in_bracket <= elimination_threshold`.
+    pub fn bracket_pressure_snapshot(env: Env, bracket_id: u32) -> BracketPressureSnapshot {
+        match storage::get_bracket(&env, bracket_id) {
+            Some(record) => BracketPressureSnapshot {
+                bracket_id,
+                exists: true,
+                players_in_bracket: record.players_in_bracket,
+                elimination_threshold: record.elimination_threshold,
+                pressure_score: record.pressure_score,
+                is_critical: record.players_in_bracket <= record.elimination_threshold,
+            },
+            None => BracketPressureSnapshot {
+                bracket_id,
+                exists: false,
+                players_in_bracket: 0,
+                elimination_threshold: 0,
+                pressure_score: 0,
+                is_critical: false,
+            },
+        }
+    }
+
+    /// Return the promotion window for `bracket_id`.
+    ///
+    /// Unknown bracket ids return `exists = false` with zeroed numeric fields.
+    /// `window_active` is `false` when the window has been administratively
+    /// closed, regardless of ledger range.
+    pub fn promotion_window(env: Env, bracket_id: u32) -> PromotionWindow {
+        match storage::get_bracket(&env, bracket_id) {
+            Some(record) => PromotionWindow {
+                bracket_id,
+                exists: true,
+                window_open_ledger: record.window_open_ledger,
+                window_close_ledger: record.window_close_ledger,
+                min_rank_for_promotion: record.min_rank_for_promotion,
+                window_active: record.window_active,
+            },
+            None => PromotionWindow {
+                bracket_id,
+                exists: false,
+                window_open_ledger: 0,
+                window_close_ledger: 0,
+                min_rank_for_promotion: 0,
+                window_active: false,
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    caller.require_auth();
+    if caller != &admin {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test;

--- a/contracts/arena-ladder/src/storage.rs
+++ b/contracts/arena-ladder/src/storage.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::Env;
+
+use crate::{DataKey, types::BracketRecord};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+pub fn get_bracket(env: &Env, bracket_id: u32) -> Option<BracketRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Bracket(bracket_id))
+}
+
+pub fn set_bracket(env: &Env, bracket_id: u32, record: &BracketRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Bracket(bracket_id), record);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Bracket(bracket_id),
+        PERSISTENT_BUMP_LEDGERS,
+        PERSISTENT_BUMP_LEDGERS,
+    );
+}

--- a/contracts/arena-ladder/src/test.rs
+++ b/contracts/arena-ladder/src/test.rs
@@ -1,0 +1,132 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use super::*;
+
+fn setup(env: &Env) -> (ArenaLadderClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(ArenaLadder, ());
+    let client = ArenaLadderClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.init(&admin);
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// bracket_pressure_snapshot — success path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_bracket_pressure_snapshot_success() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // 32 players, threshold=8, pressure=750 → not critical
+    client.upsert_bracket(
+        &admin, &1, &32, &8, &750, &1_000_000, &1_100_000, &10, &true,
+    );
+
+    let snap = client.bracket_pressure_snapshot(&1);
+    assert!(snap.exists);
+    assert_eq!(snap.bracket_id, 1);
+    assert_eq!(snap.players_in_bracket, 32);
+    assert_eq!(snap.elimination_threshold, 8);
+    assert_eq!(snap.pressure_score, 750);
+    assert!(!snap.is_critical);
+}
+
+// ---------------------------------------------------------------------------
+// bracket_pressure_snapshot — critical bracket
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_bracket_pressure_snapshot_critical() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // 4 players, threshold=8 → critical (4 <= 8)
+    client.upsert_bracket(
+        &admin, &2, &4, &8, &1200, &900_000, &950_000, &5, &true,
+    );
+
+    let snap = client.bracket_pressure_snapshot(&2);
+    assert!(snap.exists);
+    assert!(snap.is_critical);
+}
+
+// ---------------------------------------------------------------------------
+// bracket_pressure_snapshot — missing bracket returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_bracket_pressure_snapshot_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let snap = client.bracket_pressure_snapshot(&99);
+    assert!(!snap.exists);
+    assert_eq!(snap.bracket_id, 99);
+    assert_eq!(snap.players_in_bracket, 0);
+    assert_eq!(snap.elimination_threshold, 0);
+    assert_eq!(snap.pressure_score, 0);
+    assert!(!snap.is_critical);
+}
+
+// ---------------------------------------------------------------------------
+// promotion_window — window open
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_promotion_window_open() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_bracket(
+        &admin, &3, &16, &4, &500, &1_000_000, &1_200_000, &5, &true,
+    );
+
+    let window = client.promotion_window(&3);
+    assert!(window.exists);
+    assert_eq!(window.bracket_id, 3);
+    assert_eq!(window.window_open_ledger, 1_000_000);
+    assert_eq!(window.window_close_ledger, 1_200_000);
+    assert_eq!(window.min_rank_for_promotion, 5);
+    assert!(window.window_active);
+}
+
+// ---------------------------------------------------------------------------
+// promotion_window — window closed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_promotion_window_closed() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_bracket(
+        &admin, &4, &8, &4, &300, &800_000, &900_000, &3, &false,
+    );
+
+    let window = client.promotion_window(&4);
+    assert!(window.exists);
+    assert!(!window.window_active);
+}
+
+// ---------------------------------------------------------------------------
+// promotion_window — missing bracket returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_promotion_window_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let window = client.promotion_window(&999);
+    assert!(!window.exists);
+    assert_eq!(window.bracket_id, 999);
+    assert_eq!(window.window_open_ledger, 0);
+    assert_eq!(window.window_close_ledger, 0);
+    assert_eq!(window.min_rank_for_promotion, 0);
+    assert!(!window.window_active);
+}

--- a/contracts/arena-ladder/src/types.rs
+++ b/contracts/arena-ladder/src/types.rs
@@ -1,0 +1,54 @@
+use soroban_sdk::contracttype;
+
+/// Bracket pressure snapshot for an arena ladder bracket.
+///
+/// Returned by `bracket_pressure_snapshot`. When no bracket has been
+/// configured, `exists` is `false` and all numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BracketPressureSnapshot {
+    pub bracket_id: u32,
+    /// `true` when the bracket_id exists in storage.
+    pub exists: bool,
+    /// Current number of active players in the bracket.
+    pub players_in_bracket: u32,
+    /// Player count at or below which eliminations begin.
+    pub elimination_threshold: u32,
+    /// Aggregate competitive pressure score (higher = more contested).
+    pub pressure_score: u32,
+    /// `true` when players_in_bracket <= elimination_threshold.
+    pub is_critical: bool,
+}
+
+/// Promotion window details for an arena ladder bracket.
+///
+/// Returned by `promotion_window`. When no bracket has been configured,
+/// `exists` is `false` and numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PromotionWindow {
+    pub bracket_id: u32,
+    /// `true` when the bracket_id exists in storage.
+    pub exists: bool,
+    /// Ledger sequence at which the promotion window opened.
+    pub window_open_ledger: u32,
+    /// Ledger sequence at which the promotion window closes.
+    pub window_close_ledger: u32,
+    /// Minimum rank a player must hold to be eligible for promotion.
+    pub min_rank_for_promotion: u32,
+    /// `true` when the promotion window is currently accepting candidates.
+    pub window_active: bool,
+}
+
+/// Persistent bracket record written by admin mutations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BracketRecord {
+    pub players_in_bracket: u32,
+    pub elimination_threshold: u32,
+    pub pressure_score: u32,
+    pub window_open_ledger: u32,
+    pub window_close_ledger: u32,
+    pub min_rank_for_promotion: u32,
+    pub window_active: bool,
+}

--- a/contracts/clan-seasons/Cargo.toml
+++ b/contracts/clan-seasons/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-clan-seasons"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/clan-seasons/src/lib.rs
+++ b/contracts/clan-seasons/src/lib.rs
@@ -1,0 +1,179 @@
+//! Stellarcade Clan Seasons Contract
+//!
+//! Manages per-season clan state including XP/rank carryover snapshots and
+//! roster-lock configuration.
+//!
+//! ## Read-only accessors
+//! - `season_carryover_snapshot(season_id)` — carryover XP, rank, and lock flag.
+//! - `roster_lock(season_id)` — lock ledger, member count, and reason code.
+//!
+//! ## Zero-state behaviour
+//! Both accessors return `exists = false` with zeroed numeric fields when the
+//! requested `season_id` has not been written to storage, so callers never
+//! need to handle a missing-key error.
+
+#![no_std]
+#![allow(unexpected_cfgs)]
+#![allow(clippy::too_many_arguments)]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+pub use types::{RosterLock, SeasonCarryoverSnapshot, SeasonRecord};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Season(u32),
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct ClanSeasons;
+
+#[contractimpl]
+impl ClanSeasons {
+    /// Initialize the contract. May only be called once.
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Write or update a season record. Admin only.
+    ///
+    /// Existing records are fully replaced. Callers may read, modify, then
+    /// re-submit to update individual fields.
+    pub fn upsert_season(
+        env: Env,
+        admin: Address,
+        season_id: u32,
+        carryover_xp: u32,
+        carryover_rank: u32,
+        season_end_ledger: u32,
+        was_locked: bool,
+        lock_ledger: u32,
+        is_locked: bool,
+        locked_member_count: u32,
+        lock_reason_code: u32,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        storage::set_season(
+            &env,
+            season_id,
+            &SeasonRecord {
+                carryover_xp,
+                carryover_rank,
+                season_end_ledger,
+                was_locked,
+                lock_ledger,
+                is_locked,
+                locked_member_count,
+                lock_reason_code,
+            },
+        );
+        Ok(())
+    }
+
+    /// Return the carryover snapshot for `season_id`.
+    ///
+    /// Unknown season ids return `exists = false` with zeroed numeric fields.
+    /// `was_locked` surfaces whether the roster was locked when the season ended.
+    pub fn season_carryover_snapshot(env: Env, season_id: u32) -> SeasonCarryoverSnapshot {
+        match storage::get_season(&env, season_id) {
+            Some(record) => SeasonCarryoverSnapshot {
+                season_id,
+                exists: true,
+                carryover_xp: record.carryover_xp,
+                carryover_rank: record.carryover_rank,
+                season_end_ledger: record.season_end_ledger,
+                was_locked: record.was_locked,
+            },
+            None => SeasonCarryoverSnapshot {
+                season_id,
+                exists: false,
+                carryover_xp: 0,
+                carryover_rank: 0,
+                season_end_ledger: 0,
+                was_locked: false,
+            },
+        }
+    }
+
+    /// Return the roster-lock state for `season_id`.
+    ///
+    /// Unknown season ids return `exists = false` with zeroed numeric fields.
+    /// `lock_reason_code`: 0 = not locked, 1 = season-end lock, 2 = admin lock.
+    pub fn roster_lock(env: Env, season_id: u32) -> RosterLock {
+        match storage::get_season(&env, season_id) {
+            Some(record) => RosterLock {
+                season_id,
+                exists: true,
+                lock_ledger: record.lock_ledger,
+                is_locked: record.is_locked,
+                locked_member_count: record.locked_member_count,
+                lock_reason_code: record.lock_reason_code,
+            },
+            None => RosterLock {
+                season_id,
+                exists: false,
+                lock_ledger: 0,
+                is_locked: false,
+                locked_member_count: 0,
+                lock_reason_code: 0,
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    caller.require_auth();
+    if caller != &admin {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test;

--- a/contracts/clan-seasons/src/storage.rs
+++ b/contracts/clan-seasons/src/storage.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::Env;
+
+use crate::{DataKey, types::SeasonRecord};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+pub fn get_season(env: &Env, season_id: u32) -> Option<SeasonRecord> {
+    env.storage().persistent().get(&DataKey::Season(season_id))
+}
+
+pub fn set_season(env: &Env, season_id: u32, record: &SeasonRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Season(season_id), record);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Season(season_id),
+        PERSISTENT_BUMP_LEDGERS,
+        PERSISTENT_BUMP_LEDGERS,
+    );
+}

--- a/contracts/clan-seasons/src/test.rs
+++ b/contracts/clan-seasons/src/test.rs
@@ -1,0 +1,156 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use super::*;
+
+fn setup(env: &Env) -> (ClanSeasonsClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(ClanSeasons, ());
+    let client = ClanSeasonsClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.init(&admin);
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// season_carryover_snapshot — success path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_season_carryover_snapshot_success() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_season(
+        &admin, &1, &5000, &12, &2_000_000, &true,
+        &1_900_000, &true, &25, &1,
+    );
+
+    let snap = client.season_carryover_snapshot(&1);
+    assert!(snap.exists);
+    assert_eq!(snap.season_id, 1);
+    assert_eq!(snap.carryover_xp, 5000);
+    assert_eq!(snap.carryover_rank, 12);
+    assert_eq!(snap.season_end_ledger, 2_000_000);
+    assert!(snap.was_locked);
+}
+
+// ---------------------------------------------------------------------------
+// season_carryover_snapshot — unlocked season
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_season_carryover_snapshot_unlocked() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_season(
+        &admin, &2, &1200, &5, &1_500_000, &false,
+        &0, &false, &0, &0,
+    );
+
+    let snap = client.season_carryover_snapshot(&2);
+    assert!(snap.exists);
+    assert!(!snap.was_locked);
+}
+
+// ---------------------------------------------------------------------------
+// season_carryover_snapshot — missing season returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_season_carryover_snapshot_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let snap = client.season_carryover_snapshot(&99);
+    assert!(!snap.exists);
+    assert_eq!(snap.season_id, 99);
+    assert_eq!(snap.carryover_xp, 0);
+    assert_eq!(snap.carryover_rank, 0);
+    assert_eq!(snap.season_end_ledger, 0);
+    assert!(!snap.was_locked);
+}
+
+// ---------------------------------------------------------------------------
+// roster_lock — locked by season-end
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_roster_lock_season_end() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_season(
+        &admin, &3, &3000, &8, &1_800_000, &true,
+        &1_750_000, &true, &30, &1,
+    );
+
+    let lock = client.roster_lock(&3);
+    assert!(lock.exists);
+    assert_eq!(lock.season_id, 3);
+    assert_eq!(lock.lock_ledger, 1_750_000);
+    assert!(lock.is_locked);
+    assert_eq!(lock.locked_member_count, 30);
+    assert_eq!(lock.lock_reason_code, 1);
+}
+
+// ---------------------------------------------------------------------------
+// roster_lock — locked by admin
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_roster_lock_admin() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_season(
+        &admin, &4, &800, &3, &1_200_000, &true,
+        &1_100_000, &true, &10, &2,
+    );
+
+    let lock = client.roster_lock(&4);
+    assert!(lock.exists);
+    assert!(lock.is_locked);
+    assert_eq!(lock.lock_reason_code, 2);
+}
+
+// ---------------------------------------------------------------------------
+// roster_lock — not locked
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_roster_lock_not_locked() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_season(
+        &admin, &5, &200, &1, &900_000, &false,
+        &0, &false, &0, &0,
+    );
+
+    let lock = client.roster_lock(&5);
+    assert!(lock.exists);
+    assert!(!lock.is_locked);
+    assert_eq!(lock.lock_reason_code, 0);
+    assert_eq!(lock.locked_member_count, 0);
+}
+
+// ---------------------------------------------------------------------------
+// roster_lock — missing season returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_roster_lock_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let lock = client.roster_lock(&999);
+    assert!(!lock.exists);
+    assert_eq!(lock.season_id, 999);
+    assert_eq!(lock.lock_ledger, 0);
+    assert!(!lock.is_locked);
+    assert_eq!(lock.locked_member_count, 0);
+    assert_eq!(lock.lock_reason_code, 0);
+}

--- a/contracts/clan-seasons/src/types.rs
+++ b/contracts/clan-seasons/src/types.rs
@@ -1,0 +1,55 @@
+use soroban_sdk::contracttype;
+
+/// Carryover snapshot taken at the end of a clan season.
+///
+/// Returned by `season_carryover_snapshot`. When no season has been
+/// configured, `exists` is `false` and all numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeasonCarryoverSnapshot {
+    pub season_id: u32,
+    /// `true` when the season_id exists in storage.
+    pub exists: bool,
+    /// Experience points carried over into the next season.
+    pub carryover_xp: u32,
+    /// Rank carried over into the next season.
+    pub carryover_rank: u32,
+    /// Ledger sequence at which the season ended.
+    pub season_end_ledger: u32,
+    /// `true` when the roster was locked at the time of the snapshot.
+    pub was_locked: bool,
+}
+
+/// Roster-lock state for a clan season.
+///
+/// Returned by `roster_lock`. When no season has been configured,
+/// `exists` is `false` and numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RosterLock {
+    pub season_id: u32,
+    /// `true` when the season_id exists in storage.
+    pub exists: bool,
+    /// Ledger sequence at which the roster lock was applied.
+    pub lock_ledger: u32,
+    /// `true` when the roster is currently locked.
+    pub is_locked: bool,
+    /// Number of clan members locked into this season.
+    pub locked_member_count: u32,
+    /// Reason code for the lock (0 = not locked, 1 = season-end, 2 = admin).
+    pub lock_reason_code: u32,
+}
+
+/// Persistent season record written by admin mutations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeasonRecord {
+    pub carryover_xp: u32,
+    pub carryover_rank: u32,
+    pub season_end_ledger: u32,
+    pub was_locked: bool,
+    pub lock_ledger: u32,
+    pub is_locked: bool,
+    pub locked_member_count: u32,
+    pub lock_reason_code: u32,
+}

--- a/contracts/mission-pass/Cargo.toml
+++ b/contracts/mission-pass/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-mission-pass"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/mission-pass/src/lib.rs
+++ b/contracts/mission-pass/src/lib.rs
@@ -1,0 +1,185 @@
+//! Stellarcade Mission Pass Contract
+//!
+//! Tracks per-pass mission completion progress and unlock-tier gating.
+//!
+//! ## Read-only accessors
+//! - `pass_progress_snapshot(pass_id)` — completed vs. total missions with pct.
+//! - `unlock_gap(pass_id)` — missions remaining until the next unlock tier.
+//!
+//! ## Zero-state behaviour
+//! Both accessors return `exists = false` with zeroed numeric fields when the
+//! requested `pass_id` has not been written to storage, so callers never need
+//! to handle a missing-key error.
+
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+pub use types::{PassProgressSnapshot, PassRecord, UnlockGap};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Pass(u32),
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct MissionPass;
+
+#[contractimpl]
+impl MissionPass {
+    /// Initialize the contract. May only be called once.
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Write or update a pass record. Admin only.
+    ///
+    /// Existing records are fully replaced. Callers may read, modify, then
+    /// re-submit to update individual fields.
+    pub fn upsert_pass(
+        env: Env,
+        admin: Address,
+        pass_id: u32,
+        total_missions: u32,
+        completed_missions: u32,
+        next_unlock_threshold: u32,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        storage::set_pass(
+            &env,
+            pass_id,
+            &PassRecord {
+                total_missions,
+                completed_missions,
+                next_unlock_threshold,
+            },
+        );
+        Ok(())
+    }
+
+    /// Return a progress snapshot for `pass_id`.
+    ///
+    /// Unknown pass ids return `exists = false` with zeroed numeric fields.
+    /// `completion_pct` is integer division (0–100), rounded down.
+    /// `is_complete` is `true` only when `completed_missions == total_missions`
+    /// and `total_missions > 0`.
+    pub fn pass_progress_snapshot(env: Env, pass_id: u32) -> PassProgressSnapshot {
+        match storage::get_pass(&env, pass_id) {
+            Some(record) => {
+                let completion_pct = (record.completed_missions * 100)
+                    .checked_div(record.total_missions)
+                    .unwrap_or(0);
+                let is_complete = record.total_missions > 0
+                    && record.completed_missions >= record.total_missions;
+                PassProgressSnapshot {
+                    pass_id,
+                    exists: true,
+                    total_missions: record.total_missions,
+                    completed_missions: record.completed_missions,
+                    completion_pct,
+                    is_complete,
+                }
+            }
+            None => PassProgressSnapshot {
+                pass_id,
+                exists: false,
+                total_missions: 0,
+                completed_missions: 0,
+                completion_pct: 0,
+                is_complete: false,
+            },
+        }
+    }
+
+    /// Return the unlock gap for `pass_id`.
+    ///
+    /// Unknown pass ids return `exists = false` with zeroed numeric fields.
+    /// `missions_to_next_unlock` is floored at zero when the threshold is
+    /// already reached.  `locked` is `false` when the threshold is met.
+    pub fn unlock_gap(env: Env, pass_id: u32) -> UnlockGap {
+        match storage::get_pass(&env, pass_id) {
+            Some(record) => {
+                let locked = record.completed_missions < record.next_unlock_threshold;
+                let missions_to_next_unlock = if locked {
+                    record.next_unlock_threshold - record.completed_missions
+                } else {
+                    0
+                };
+                UnlockGap {
+                    pass_id,
+                    exists: true,
+                    missions_to_next_unlock,
+                    next_unlock_threshold: record.next_unlock_threshold,
+                    current_progress: record.completed_missions,
+                    locked,
+                }
+            }
+            None => UnlockGap {
+                pass_id,
+                exists: false,
+                missions_to_next_unlock: 0,
+                next_unlock_threshold: 0,
+                current_progress: 0,
+                locked: false,
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    caller.require_auth();
+    if caller != &admin {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test;

--- a/contracts/mission-pass/src/storage.rs
+++ b/contracts/mission-pass/src/storage.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::Env;
+
+use crate::{DataKey, types::PassRecord};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+pub fn get_pass(env: &Env, pass_id: u32) -> Option<PassRecord> {
+    env.storage().persistent().get(&DataKey::Pass(pass_id))
+}
+
+pub fn set_pass(env: &Env, pass_id: u32, record: &PassRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Pass(pass_id), record);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Pass(pass_id),
+        PERSISTENT_BUMP_LEDGERS,
+        PERSISTENT_BUMP_LEDGERS,
+    );
+}

--- a/contracts/mission-pass/src/test.rs
+++ b/contracts/mission-pass/src/test.rs
@@ -1,0 +1,127 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use super::*;
+
+fn setup(env: &Env) -> (MissionPassClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(MissionPass, ());
+    let client = MissionPassClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.init(&admin);
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// pass_progress_snapshot — success path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pass_progress_snapshot_success() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // 6 of 10 missions done → 60 %
+    client.upsert_pass(&admin, &1, &10, &6, &8);
+
+    let snap = client.pass_progress_snapshot(&1);
+    assert!(snap.exists);
+    assert_eq!(snap.pass_id, 1);
+    assert_eq!(snap.total_missions, 10);
+    assert_eq!(snap.completed_missions, 6);
+    assert_eq!(snap.completion_pct, 60);
+    assert!(!snap.is_complete);
+}
+
+// ---------------------------------------------------------------------------
+// pass_progress_snapshot — fully completed pass
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pass_progress_snapshot_complete() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_pass(&admin, &2, &5, &5, &5);
+
+    let snap = client.pass_progress_snapshot(&2);
+    assert!(snap.exists);
+    assert!(snap.is_complete);
+    assert_eq!(snap.completion_pct, 100);
+}
+
+// ---------------------------------------------------------------------------
+// pass_progress_snapshot — missing pass returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pass_progress_snapshot_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let snap = client.pass_progress_snapshot(&99);
+    assert!(!snap.exists);
+    assert_eq!(snap.pass_id, 99);
+    assert_eq!(snap.total_missions, 0);
+    assert_eq!(snap.completed_missions, 0);
+    assert_eq!(snap.completion_pct, 0);
+    assert!(!snap.is_complete);
+}
+
+// ---------------------------------------------------------------------------
+// unlock_gap — still locked
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_unlock_gap_locked() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // completed=3, threshold=8 → gap=5, locked
+    client.upsert_pass(&admin, &3, &10, &3, &8);
+
+    let gap = client.unlock_gap(&3);
+    assert!(gap.exists);
+    assert_eq!(gap.pass_id, 3);
+    assert_eq!(gap.current_progress, 3);
+    assert_eq!(gap.next_unlock_threshold, 8);
+    assert_eq!(gap.missions_to_next_unlock, 5);
+    assert!(gap.locked);
+}
+
+// ---------------------------------------------------------------------------
+// unlock_gap — threshold reached (unlocked)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_unlock_gap_unlocked() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // completed=8, threshold=8 → gap=0, not locked
+    client.upsert_pass(&admin, &4, &10, &8, &8);
+
+    let gap = client.unlock_gap(&4);
+    assert!(gap.exists);
+    assert_eq!(gap.missions_to_next_unlock, 0);
+    assert!(!gap.locked);
+}
+
+// ---------------------------------------------------------------------------
+// unlock_gap — missing pass returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_unlock_gap_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let gap = client.unlock_gap(&999);
+    assert!(!gap.exists);
+    assert_eq!(gap.pass_id, 999);
+    assert_eq!(gap.missions_to_next_unlock, 0);
+    assert_eq!(gap.next_unlock_threshold, 0);
+    assert_eq!(gap.current_progress, 0);
+    assert!(!gap.locked);
+}

--- a/contracts/mission-pass/src/types.rs
+++ b/contracts/mission-pass/src/types.rs
@@ -1,0 +1,50 @@
+use soroban_sdk::contracttype;
+
+/// Progress snapshot for a mission pass.
+///
+/// Returned by `pass_progress_snapshot`. When no pass has been configured,
+/// `exists` is `false` and all numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PassProgressSnapshot {
+    pub pass_id: u32,
+    /// `true` when the pass_id exists in storage.
+    pub exists: bool,
+    /// Total number of missions in this pass.
+    pub total_missions: u32,
+    /// Number of missions the holder has completed.
+    pub completed_missions: u32,
+    /// Completion percentage (0–100), rounded down.
+    pub completion_pct: u32,
+    /// `true` when all missions are completed.
+    pub is_complete: bool,
+}
+
+/// Unlock gap details for a mission pass.
+///
+/// Returned by `unlock_gap`. When no pass has been configured,
+/// `exists` is `false` and numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnlockGap {
+    pub pass_id: u32,
+    /// `true` when the pass_id exists in storage.
+    pub exists: bool,
+    /// Number of missions still needed to reach the next unlock.
+    pub missions_to_next_unlock: u32,
+    /// Cumulative missions required to trigger the next unlock tier.
+    pub next_unlock_threshold: u32,
+    /// Current completed mission count.
+    pub current_progress: u32,
+    /// `true` when the next unlock has not yet been reached.
+    pub locked: bool,
+}
+
+/// Persistent pass record written by admin mutations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PassRecord {
+    pub total_missions: u32,
+    pub completed_missions: u32,
+    pub next_unlock_threshold: u32,
+}

--- a/contracts/prize-streamer/Cargo.toml
+++ b/contracts/prize-streamer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-prize-streamer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/contracts/prize-streamer/src/lib.rs
+++ b/contracts/prize-streamer/src/lib.rs
@@ -1,0 +1,180 @@
+//! Stellarcade Prize Streamer Contract
+//!
+//! Tracks prize stream outflow metrics and funding health for a per-stream
+//! prize distribution system.
+//!
+//! ## Read-only accessors
+//! - `stream_outflow_summary(stream_id)` — aggregated outflow metrics.
+//! - `funding_gap(stream_id)` — remaining balance vs. configured target.
+//!
+//! ## Zero-state behaviour
+//! Both accessors return `exists = false` with zeroed numeric fields when
+//! the requested `stream_id` has not been written to storage, so callers
+//! never need to handle a missing-key error.
+
+#![no_std]
+#![allow(unexpected_cfgs)]
+#![allow(clippy::too_many_arguments)]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+pub use types::{FundingGap, StreamOutflowSummary, StreamRecord};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Stream(u32),
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct PrizeStreamer;
+
+#[contractimpl]
+impl PrizeStreamer {
+    /// Initialize the contract. May only be called once.
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Write or update a stream record. Admin only.
+    ///
+    /// Existing records are fully replaced. Callers may read, modify, then
+    /// re-submit to update individual fields.
+    pub fn upsert_stream(
+        env: Env,
+        admin: Address,
+        stream_id: u32,
+        total_streamed: i128,
+        outflow_rate_per_ledger: i128,
+        last_outflow_ledger: u32,
+        is_draining: bool,
+        total_funding: i128,
+        funding_target: i128,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        storage::set_stream(
+            &env,
+            stream_id,
+            &StreamRecord {
+                total_streamed,
+                outflow_rate_per_ledger,
+                last_outflow_ledger,
+                is_draining,
+                total_funding,
+                funding_target,
+            },
+        );
+        Ok(())
+    }
+
+    /// Return aggregated outflow metrics for `stream_id`.
+    ///
+    /// Unknown stream ids return `exists = false` with zeroed numeric fields.
+    /// A paused or exhausted stream is surfaced via `is_draining = false`.
+    pub fn stream_outflow_summary(env: Env, stream_id: u32) -> StreamOutflowSummary {
+        match storage::get_stream(&env, stream_id) {
+            Some(record) => StreamOutflowSummary {
+                stream_id,
+                exists: true,
+                total_streamed: record.total_streamed,
+                outflow_rate_per_ledger: record.outflow_rate_per_ledger,
+                last_outflow_ledger: record.last_outflow_ledger,
+                is_draining: record.is_draining,
+            },
+            None => StreamOutflowSummary {
+                stream_id,
+                exists: false,
+                total_streamed: 0,
+                outflow_rate_per_ledger: 0,
+                last_outflow_ledger: 0,
+                is_draining: false,
+            },
+        }
+    }
+
+    /// Return the funding gap report for `stream_id`.
+    ///
+    /// Unknown stream ids return `exists = false` with zeroed numeric fields.
+    /// `gap_amount` is floored at zero — a fully-funded stream returns zero.
+    /// `is_underfunded` is `true` when `current_balance < funding_target`.
+    pub fn funding_gap(env: Env, stream_id: u32) -> FundingGap {
+        match storage::get_stream(&env, stream_id) {
+            Some(record) => {
+                let current_balance = (record.total_funding - record.total_streamed).max(0);
+                let gap_amount = (record.funding_target - current_balance).max(0);
+                FundingGap {
+                    stream_id,
+                    exists: true,
+                    total_funding: record.total_funding,
+                    current_balance,
+                    gap_amount,
+                    is_underfunded: current_balance < record.funding_target,
+                }
+            }
+            None => FundingGap {
+                stream_id,
+                exists: false,
+                total_funding: 0,
+                current_balance: 0,
+                gap_amount: 0,
+                is_underfunded: false,
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    caller.require_auth();
+    if caller != &admin {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test;

--- a/contracts/prize-streamer/src/storage.rs
+++ b/contracts/prize-streamer/src/storage.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::Env;
+
+use crate::{DataKey, types::StreamRecord};
+
+pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
+
+pub fn get_stream(env: &Env, stream_id: u32) -> Option<StreamRecord> {
+    env.storage().persistent().get(&DataKey::Stream(stream_id))
+}
+
+pub fn set_stream(env: &Env, stream_id: u32, record: &StreamRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Stream(stream_id), record);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Stream(stream_id),
+        PERSISTENT_BUMP_LEDGERS,
+        PERSISTENT_BUMP_LEDGERS,
+    );
+}

--- a/contracts/prize-streamer/src/test.rs
+++ b/contracts/prize-streamer/src/test.rs
@@ -1,0 +1,136 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use super::*;
+
+fn setup(env: &Env) -> (PrizeStreamerClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(PrizeStreamer, ());
+    let client = PrizeStreamerClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.init(&admin);
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// stream_outflow_summary — success path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_stream_outflow_summary_success() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_stream(
+        &admin, &1, &50_000, &100, &1_000_000, &true, &200_000, &300_000,
+    );
+
+    let summary = client.stream_outflow_summary(&1);
+    assert!(summary.exists);
+    assert_eq!(summary.stream_id, 1);
+    assert_eq!(summary.total_streamed, 50_000);
+    assert_eq!(summary.outflow_rate_per_ledger, 100);
+    assert_eq!(summary.last_outflow_ledger, 1_000_000);
+    assert!(summary.is_draining);
+}
+
+// ---------------------------------------------------------------------------
+// stream_outflow_summary — paused stream
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_stream_outflow_summary_paused() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_stream(
+        &admin, &2, &10_000, &50, &900_000, &false, &100_000, &200_000,
+    );
+
+    let summary = client.stream_outflow_summary(&2);
+    assert!(summary.exists);
+    assert!(!summary.is_draining);
+}
+
+// ---------------------------------------------------------------------------
+// stream_outflow_summary — missing stream returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_stream_outflow_summary_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let summary = client.stream_outflow_summary(&99);
+    assert!(!summary.exists);
+    assert_eq!(summary.stream_id, 99);
+    assert_eq!(summary.total_streamed, 0);
+    assert_eq!(summary.outflow_rate_per_ledger, 0);
+    assert_eq!(summary.last_outflow_ledger, 0);
+    assert!(!summary.is_draining);
+}
+
+// ---------------------------------------------------------------------------
+// funding_gap — underfunded stream
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_funding_gap_underfunded() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // total_funding=100_000, total_streamed=80_000 → balance=20_000
+    // funding_target=300_000 → gap=280_000
+    client.upsert_stream(
+        &admin, &3, &80_000, &100, &1_000_000, &true, &100_000, &300_000,
+    );
+
+    let gap = client.funding_gap(&3);
+    assert!(gap.exists);
+    assert_eq!(gap.stream_id, 3);
+    assert_eq!(gap.total_funding, 100_000);
+    assert_eq!(gap.current_balance, 20_000);
+    assert_eq!(gap.gap_amount, 280_000);
+    assert!(gap.is_underfunded);
+}
+
+// ---------------------------------------------------------------------------
+// funding_gap — fully funded stream
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_funding_gap_fully_funded() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // total_funding=500_000, total_streamed=100_000 → balance=400_000
+    // funding_target=300_000 → gap=0, not underfunded
+    client.upsert_stream(
+        &admin, &4, &100_000, &200, &2_000_000, &true, &500_000, &300_000,
+    );
+
+    let gap = client.funding_gap(&4);
+    assert!(gap.exists);
+    assert_eq!(gap.current_balance, 400_000);
+    assert_eq!(gap.gap_amount, 0);
+    assert!(!gap.is_underfunded);
+}
+
+// ---------------------------------------------------------------------------
+// funding_gap — missing stream returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_funding_gap_missing() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let gap = client.funding_gap(&999);
+    assert!(!gap.exists);
+    assert_eq!(gap.stream_id, 999);
+    assert_eq!(gap.total_funding, 0);
+    assert_eq!(gap.current_balance, 0);
+    assert_eq!(gap.gap_amount, 0);
+    assert!(!gap.is_underfunded);
+}

--- a/contracts/prize-streamer/src/types.rs
+++ b/contracts/prize-streamer/src/types.rs
@@ -1,0 +1,53 @@
+use soroban_sdk::contracttype;
+
+/// Aggregated outflow metrics for a prize stream.
+///
+/// Returned by `stream_outflow_summary`. When no stream has been configured,
+/// `exists` is `false` and all numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamOutflowSummary {
+    pub stream_id: u32,
+    /// `true` when the stream_id exists in storage.
+    pub exists: bool,
+    /// Total amount that has been streamed out since inception.
+    pub total_streamed: i128,
+    /// Configured outflow rate in tokens per ledger.
+    pub outflow_rate_per_ledger: i128,
+    /// Ledger sequence of the last recorded outflow event.
+    pub last_outflow_ledger: u32,
+    /// `true` when the stream is actively draining (not paused, not exhausted).
+    pub is_draining: bool,
+}
+
+/// Funding gap report for a prize stream.
+///
+/// Returned by `funding_gap`. When no stream has been configured,
+/// `exists` is `false` and all numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FundingGap {
+    pub stream_id: u32,
+    /// `true` when the stream_id exists in storage.
+    pub exists: bool,
+    /// Total tokens ever deposited into the stream.
+    pub total_funding: i128,
+    /// Remaining balance (total_funding − total_streamed), floored at zero.
+    pub current_balance: i128,
+    /// Tokens still required to reach the configured target, floored at zero.
+    pub gap_amount: i128,
+    /// `true` when current_balance is below the configured funding_target.
+    pub is_underfunded: bool,
+}
+
+/// Persistent stream record written by admin mutations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamRecord {
+    pub total_streamed: i128,
+    pub outflow_rate_per_ledger: i128,
+    pub last_outflow_ledger: u32,
+    pub is_draining: bool,
+    pub total_funding: i128,
+    pub funding_target: i128,
+}


### PR DESCRIPTION
## Summary

Implements four new Soroban contracts resolving issues #697, #735, #738, and #741.

### contracts/prize-streamer (closes #697)
- `stream_outflow_summary(stream_id)` — returns total streamed, outflow rate per ledger, last outflow ledger, and drain status
- `funding_gap(stream_id)` — returns total funding, current balance, gap to target, and underfunded flag

### contracts/mission-pass (closes #735)
- `pass_progress_snapshot(pass_id)` — returns total/completed missions, completion percentage (0–100), and is_complete flag
- `unlock_gap(pass_id)` — returns missions needed to next unlock threshold, current progress, and locked flag

### contracts/arena-ladder (closes #738)
- `bracket_pressure_snapshot(bracket_id)` — returns player count, elimination threshold, pressure score, and is_critical flag
- `promotion_window(bracket_id)` — returns window open/close ledgers, minimum promotion rank, and window_active flag

### contracts/clan-seasons (closes #741)
- `season_carryover_snapshot(season_id)` — returns carryover XP, rank, season-end ledger, and roster-lock flag at close
- `roster_lock(season_id)` — returns lock ledger, is_locked, locked member count, and reason code (0=none, 1=season-end, 2=admin)

## Implementation notes
- All contracts follow the `ladder-seasons` reference pattern: named response structs, `exists = false` zero-state for unknown IDs, persistent storage with 518 400-ledger TTL bumps, admin-only `upsert_*` mutation, and `#[contracterror]` enum
- `#![allow(clippy::too_many_arguments)]` at crate level covers macro-generated contract client stubs (same pattern needed by all multi-field upsert contracts in this repo)
- `mission-pass` completion percentage uses `checked_div` to satisfy `clippy::manual_checked_ops`
- All four contracts registered in `contracts/Cargo.toml` workspace members

## Test plan
- [x] `prize-streamer`: 6 tests — outflow summary (success, paused, missing), funding gap (underfunded, fully-funded, missing)
- [x] `mission-pass`: 6 tests — progress snapshot (success, complete, missing), unlock gap (locked, unlocked, missing)
- [x] `arena-ladder`: 6 tests — pressure snapshot (success, critical, missing), promotion window (open, closed, missing)
- [x] `clan-seasons`: 7 tests — carryover snapshot (success, unlocked, missing), roster lock (season-end, admin, not-locked, missing)
- [x] `cargo clippy -- -D warnings` passes cleanly on all four contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arena Ladder: New competitive ranking system with bracket-based promotions and advancement windows
  * Clan Seasons: Seasonal clan progression tracking with roster management and carryover mechanics
  * Mission Pass: Mission tracking system with completion milestones and unlock gates
  * Prize Streamer: Prize distribution system with funding and outflow management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->