### PR TITLE
feat(hooks): add useFocusRecovery hook for accessible error region focus management

### DIFF
--- a/frontend/src/hooks/v1/index.ts
+++ b/frontend/src/hooks/v1/index.ts
@@ -10,3 +10,4 @@ export * from './useWalletStatus';
 export * from './useAsyncAction';
 export * from './useDebouncedValue';
 export * from './useContractEvents';
+export * from './useFocusRecovery';

--- a/frontend/src/hooks/v1/useFocusRecovery.ts
+++ b/frontend/src/hooks/v1/useFocusRecovery.ts
@@ -1,0 +1,54 @@
+/**
+ * useFocusRecovery — predictable focus recovery for dynamic error regions.
+ *
+ * When an error region mounts or updates, focus is moved to the region
+ * container so screen readers announce the error immediately. When the
+ * error clears the focus is returned to the element that had it before.
+ *
+ * Usage:
+ *   const { regionRef } = useFocusRecovery(hasError);
+ *   <div ref={regionRef} tabIndex={-1}>{hasError && <ErrorNotice ... />}</div>
+ */
+
+import { useEffect, useRef } from 'react';
+
+export interface UseFocusRecoveryOptions {
+  /** Move focus into the error region when it becomes active. @default true */
+  focusOnError?: boolean;
+  /** Restore focus to the previously focused element when error clears. @default true */
+  restoreOnClear?: boolean;
+}
+
+export interface UseFocusRecoveryReturn {
+  /** Attach to the error region container. */
+  regionRef: React.RefObject<HTMLElement | null>;
+}
+
+export function useFocusRecovery(
+  hasError: boolean,
+  options: UseFocusRecoveryOptions = {},
+): UseFocusRecoveryReturn {
+  const { focusOnError = true, restoreOnClear = true } = options;
+  const regionRef = useRef<HTMLElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (hasError) {
+      // Capture where focus was before the error appeared.
+      if (document.activeElement instanceof HTMLElement) {
+        previousFocusRef.current = document.activeElement;
+      }
+      if (focusOnError && regionRef.current) {
+        regionRef.current.focus();
+      }
+    } else {
+      // Error cleared — restore focus.
+      if (restoreOnClear && previousFocusRef.current) {
+        previousFocusRef.current.focus();
+        previousFocusRef.current = null;
+      }
+    }
+  }, [hasError, focusOnError, restoreOnClear]);
+
+  return { regionRef };
+}

--- a/frontend/tests/hooks/v1/useFocusRecovery.test.tsx
+++ b/frontend/tests/hooks/v1/useFocusRecovery.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFocusRecovery } from "../../../src/hooks/v1/useFocusRecovery";
+
+describe("useFocusRecovery", () => {
+  let container: HTMLDivElement;
+  let errorRegion: HTMLDivElement;
+  let triggerButton: HTMLButtonElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    errorRegion = document.createElement("div");
+    errorRegion.tabIndex = -1;
+    triggerButton = document.createElement("button");
+    container.appendChild(triggerButton);
+    container.appendChild(errorRegion);
+    document.body.appendChild(container);
+    triggerButton.focus();
+  });
+
+  it("moves focus to the error region when hasError becomes true", () => {
+    const focusSpy = vi.spyOn(errorRegion, "focus");
+    const { result, rerender } = renderHook(
+      ({ hasError }) => useFocusRecovery(hasError),
+      { initialProps: { hasError: false } },
+    );
+
+    // Attach the ref manually
+    Object.defineProperty(result.current.regionRef, "current", {
+      writable: true,
+      value: errorRegion,
+    });
+
+    act(() => {
+      rerender({ hasError: true });
+    });
+
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("restores focus to previous element when error clears", () => {
+    const restoreSpy = vi.spyOn(triggerButton, "focus");
+    triggerButton.focus();
+
+    const { result, rerender } = renderHook(
+      ({ hasError }) => useFocusRecovery(hasError),
+      { initialProps: { hasError: false } },
+    );
+
+    Object.defineProperty(result.current.regionRef, "current", {
+      writable: true,
+      value: errorRegion,
+    });
+
+    // Trigger error — captures triggerButton as previous focus
+    act(() => {
+      rerender({ hasError: true });
+    });
+
+    // Clear error — should restore focus
+    act(() => {
+      rerender({ hasError: false });
+    });
+
+    expect(restoreSpy).toHaveBeenCalled();
+  });
+
+  it("does not move focus when focusOnError is false", () => {
+    const focusSpy = vi.spyOn(errorRegion, "focus");
+    const { result, rerender } = renderHook(
+      ({ hasError }) => useFocusRecovery(hasError, { focusOnError: false }),
+      { initialProps: { hasError: false } },
+    );
+
+    Object.defineProperty(result.current.regionRef, "current", {
+      writable: true,
+      value: errorRegion,
+    });
+
+    act(() => {
+      rerender({ hasError: true });
+    });
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not restore focus when restoreOnClear is false", () => {
+    triggerButton.focus();
+    const restoreSpy = vi.spyOn(triggerButton, "focus");
+
+    const { result, rerender } = renderHook(
+      ({ hasError }) => useFocusRecovery(hasError, { restoreOnClear: false }),
+      { initialProps: { hasError: false } },
+    );
+
+    Object.defineProperty(result.current.regionRef, "current", {
+      writable: true,
+      value: errorRegion,
+    });
+
+    act(() => {
+      rerender({ hasError: true });
+    });
+
+    act(() => {
+      rerender({ hasError: false });
+    });
+
+    expect(restoreSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #746

## Summary
- Adds `useFocusRecovery` hook that moves focus to an error region container when `hasError` becomes true
- Captures previously focused element and restores it when the error clears
- Configurable via `focusOnError` and `restoreOnClear` options (both default `true`)
- Exported from `hooks/v1/index.ts`

## Test plan
- [ ] Focus moves to error region on error
- [ ] Focus restored on clear
- [ ] `focusOnError: false` skips focus move
- [ ] `restoreOnClear: false` skips restore