### PR TITLE
feat(components): add InterruptedFlowPrompt for queued user action return flows

### DIFF
--- a/frontend/src/components/v1/InterruptedFlowPrompt.css
+++ b/frontend/src/components/v1/InterruptedFlowPrompt.css
@@ -1,0 +1,103 @@
+.interrupted-flow-prompt {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  background: var(--color-surface-raised, #1e2435);
+  border: 1px solid var(--color-border-accent, #3b4a6b);
+  color: var(--color-text-primary, #e2e8f0);
+}
+
+.interrupted-flow-prompt--compact {
+  padding: 0.625rem 1rem;
+}
+
+.interrupted-flow-prompt__icon {
+  flex-shrink: 0;
+  font-size: 1.125rem;
+  line-height: 1.5;
+  color: var(--color-warning, #f59e0b);
+}
+
+.interrupted-flow-prompt__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.interrupted-flow-prompt__title {
+  margin: 0 0 0.25rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-text-primary, #e2e8f0);
+}
+
+.interrupted-flow-prompt__description {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.interrupted-flow-prompt__description:last-child {
+  margin-bottom: 0;
+}
+
+.interrupted-flow-prompt__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.interrupted-flow-prompt__action {
+  padding: 0.375rem 0.875rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: opacity 0.15s ease;
+}
+
+.interrupted-flow-prompt__action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.interrupted-flow-prompt__action--resume {
+  background: var(--color-brand, #6366f1);
+  color: #fff;
+  border-color: var(--color-brand, #6366f1);
+}
+
+.interrupted-flow-prompt__action--resume:not(:disabled):hover {
+  opacity: 0.88;
+}
+
+.interrupted-flow-prompt__action--discard {
+  background: transparent;
+  color: var(--color-text-secondary, #94a3b8);
+  border-color: var(--color-border, #334155);
+}
+
+.interrupted-flow-prompt__action--discard:not(:disabled):hover {
+  color: var(--color-text-primary, #e2e8f0);
+  border-color: var(--color-border-accent, #3b4a6b);
+}
+
+.interrupted-flow-prompt__dismiss {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted, #64748b);
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.125rem;
+  margin-top: 0.125rem;
+}
+
+.interrupted-flow-prompt__dismiss:hover {
+  color: var(--color-text-secondary, #94a3b8);
+}

--- a/frontend/src/components/v1/InterruptedFlowPrompt.tsx
+++ b/frontend/src/components/v1/InterruptedFlowPrompt.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import "./InterruptedFlowPrompt.css";
+
+export interface InterruptedFlowAction {
+  /** Button text. */
+  label: string;
+  onClick: () => void | Promise<void>;
+  /** @default 'discard' */
+  variant?: "resume" | "discard";
+  disabled?: boolean;
+  testId?: string;
+}
+
+export interface InterruptedFlowPromptProps {
+  /**
+   * Short human-readable name of the queued action that was interrupted.
+   * e.g. "Token swap", "Place bid"
+   */
+  actionLabel: string;
+  /** Optional description shown below the title. */
+  description?: string;
+  /** Resume / discard / custom action buttons. */
+  actions?: InterruptedFlowAction[];
+  /** Called when the user dismisses without choosing. Hides dismiss button when omitted. */
+  onDismiss?: () => void;
+  /** Visually compact variant for inline surfaces. @default false */
+  compact?: boolean;
+  testId?: string;
+  className?: string;
+}
+
+export const InterruptedFlowPrompt: React.FC<InterruptedFlowPromptProps> = ({
+  actionLabel,
+  description,
+  actions = [],
+  onDismiss,
+  compact = false,
+  testId = "interrupted-flow-prompt",
+  className = "",
+}) => {
+  const rootClass = [
+    "interrupted-flow-prompt",
+    compact ? "interrupted-flow-prompt--compact" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <aside
+      className={rootClass}
+      role="status"
+      aria-live="polite"
+      data-testid={testId}
+    >
+      <span
+        className="interrupted-flow-prompt__icon"
+        aria-hidden="true"
+        data-testid={`${testId}-icon`}
+      >
+        ↩
+      </span>
+
+      <div className="interrupted-flow-prompt__body">
+        <h3 className="interrupted-flow-prompt__title">
+          Resume: {actionLabel}
+        </h3>
+
+        {description && (
+          <p className="interrupted-flow-prompt__description">{description}</p>
+        )}
+
+        {actions.length > 0 && (
+          <div
+            className="interrupted-flow-prompt__actions"
+            data-testid={`${testId}-actions`}
+          >
+            {actions.map((action, idx) => {
+              const btnVariant = action.variant ?? "discard";
+              return (
+                <button
+                  key={`${action.label}-${idx}`}
+                  type="button"
+                  className={`interrupted-flow-prompt__action interrupted-flow-prompt__action--${btnVariant}`}
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  data-testid={action.testId ?? `${testId}-action-${idx}`}
+                >
+                  {action.label}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {onDismiss && (
+        <button
+          type="button"
+          className="interrupted-flow-prompt__dismiss"
+          onClick={onDismiss}
+          aria-label="Dismiss interrupted flow prompt"
+          data-testid={`${testId}-dismiss`}
+        >
+          ×
+        </button>
+      )}
+    </aside>
+  );
+};
+
+export default InterruptedFlowPrompt;

--- a/frontend/src/components/v1/index.ts
+++ b/frontend/src/components/v1/index.ts
@@ -356,3 +356,13 @@ export type {
   SparklineTrend,
   RewardCardStatus,
 } from "./RewardBalanceSparklineCard";
+
+// Issue #745
+export {
+  InterruptedFlowPrompt,
+  default as InterruptedFlowPromptDefault,
+} from "./InterruptedFlowPrompt";
+export type {
+  InterruptedFlowPromptProps,
+  InterruptedFlowAction,
+} from "./InterruptedFlowPrompt";

--- a/frontend/tests/components/v1/InterruptedFlowPrompt.test.tsx
+++ b/frontend/tests/components/v1/InterruptedFlowPrompt.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { InterruptedFlowPrompt } from "@/components/v1/InterruptedFlowPrompt";
+
+describe("InterruptedFlowPrompt (#745)", () => {
+  it("renders the action label in the title", () => {
+    render(<InterruptedFlowPrompt actionLabel="Token swap" />);
+    expect(screen.getByTestId("interrupted-flow-prompt")).toHaveTextContent(
+      "Resume: Token swap",
+    );
+  });
+
+  it("renders description when provided", () => {
+    render(
+      <InterruptedFlowPrompt
+        actionLabel="Place bid"
+        description="Your bid was interrupted by a network error."
+      />,
+    );
+    expect(screen.getByTestId("interrupted-flow-prompt")).toHaveTextContent(
+      "Your bid was interrupted by a network error.",
+    );
+  });
+
+  it("renders resume and discard action buttons and calls their handlers", () => {
+    const onResume = vi.fn();
+    const onDiscard = vi.fn();
+
+    render(
+      <InterruptedFlowPrompt
+        actionLabel="Token swap"
+        actions={[
+          { label: "Resume", onClick: onResume, variant: "resume" },
+          { label: "Discard", onClick: onDiscard, variant: "discard" },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("interrupted-flow-prompt-action-0"));
+    expect(onResume).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("interrupted-flow-prompt-action-1"));
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows dismiss button and calls onDismiss", () => {
+    const onDismiss = vi.fn();
+    render(
+      <InterruptedFlowPrompt actionLabel="Place bid" onDismiss={onDismiss} />,
+    );
+    fireEvent.click(screen.getByTestId("interrupted-flow-prompt-dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides dismiss button when onDismiss is not provided", () => {
+    render(<InterruptedFlowPrompt actionLabel="Place bid" />);
+    expect(
+      screen.queryByTestId("interrupted-flow-prompt-dismiss"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies compact CSS class when compact prop is true", () => {
+    const { container } = render(
+      <InterruptedFlowPrompt actionLabel="Place bid" compact />,
+    );
+    expect(
+      container.querySelector(".interrupted-flow-prompt--compact"),
+    ).toBeInTheDocument();
+  });
+
+  it("disables action button when disabled prop is set", () => {
+    render(
+      <InterruptedFlowPrompt
+        actionLabel="Token swap"
+        actions={[{ label: "Resume", onClick: vi.fn(), variant: "resume", disabled: true }]}
+      />,
+    );
+    expect(screen.getByTestId("interrupted-flow-prompt-action-0")).toBeDisabled();
+  });
+
+  it("renders no actions section when actions array is empty", () => {
+    render(<InterruptedFlowPrompt actionLabel="Token swap" actions={[]} />);
+    expect(
+      screen.queryByTestId("interrupted-flow-prompt-actions"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #745

## Summary
- Adds `InterruptedFlowPrompt` component that surfaces a return prompt when a queued user action was interrupted mid-flow
- Renders action label, optional description, configurable resume/discard buttons, and optional dismiss control
- Compact prop for inline surfaces; `role="status"` + `aria-live="polite"` for accessibility
- Exported from `components/v1/index.ts`

## Test plan
- [ ] Title, description, resume/discard click handlers, dismiss button
- [ ] No dismiss button when `onDismiss` omitted
- [ ] Compact CSS class, disabled button, empty actions