### PR TITLE
feat: shared workflow progress rail, queue-state mini panel, detail sidebar quick actions, heading consistency shells

### DIFF
--- a/frontend/src/components/v1/ContentShell.css
+++ b/frontend/src/components/v1/ContentShell.css
@@ -1,0 +1,92 @@
+.content-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── Header row ─────────────────────────────────────────────── */
+
+.content-shell__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.content-shell__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.content-shell__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+/* ── Title sizing by semantic level ─────────────────────────── */
+
+.content-shell__title {
+  margin: 0;
+  line-height: 1.25;
+  color: var(--text-main, #f5f7fb);
+  font-weight: 700;
+}
+
+.content-shell__title--h1 {
+  font-size: 1.75rem;
+}
+
+.content-shell__title--h2 {
+  font-size: 1.25rem;
+}
+
+.content-shell__title--h3 {
+  font-size: 1.0625rem;
+}
+
+.content-shell__title--h4 {
+  font-size: 0.9375rem;
+}
+
+.content-shell__title--h5 {
+  font-size: 0.875rem;
+}
+
+.content-shell__title--h6 {
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.content-shell__description {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary, #a8b5c8);
+  line-height: 1.5;
+}
+
+/* ── Body ───────────────────────────────────────────────────── */
+
+.content-shell__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .content-shell__header {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .content-shell__actions {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/components/v1/ContentShell.tsx
+++ b/frontend/src/components/v1/ContentShell.tsx
@@ -1,0 +1,94 @@
+import React, { useMemo } from 'react';
+import { HeadingLevelContext, type HeadingLevel } from '../../hooks/v1/useHeadingLevel';
+import './ContentShell.css';
+
+export interface ContentShellProps {
+  /** Section title rendered as the correct h* element for the current nesting depth. */
+  title: React.ReactNode;
+  /** Stable id for the heading element — recommended for aria-labelledby references. */
+  titleId?: string;
+  /** Supporting copy rendered below the title. */
+  description?: React.ReactNode;
+  /** Actions (buttons, controls) rendered in the header row. */
+  actions?: React.ReactNode;
+  children?: React.ReactNode;
+  /**
+   * Override the heading level instead of inheriting from context.
+   * Only use this when the shell is genuinely at a fixed semantic depth.
+   */
+  headingLevel?: HeadingLevel;
+  className?: string;
+  testId?: string;
+}
+
+function clampLevel(level: number): HeadingLevel {
+  return Math.max(1, Math.min(6, level)) as HeadingLevel;
+}
+
+export const ContentShell: React.FC<ContentShellProps> = ({
+  title,
+  titleId,
+  description,
+  actions,
+  children,
+  headingLevel,
+  className = '',
+  testId = 'content-shell',
+}) => {
+  const contextLevel = React.useContext(HeadingLevelContext);
+  const resolvedLevel: HeadingLevel = headingLevel ?? contextLevel;
+  const childLevel: HeadingLevel = clampLevel(resolvedLevel + 1);
+
+  if (process.env.NODE_ENV !== 'production' && headingLevel === undefined && contextLevel > 6) {
+    console.warn(
+      `[ContentShell] Heading level would exceed h6 (context depth: ${contextLevel}). ` +
+        'Consider flattening the nesting or using headingLevel override.',
+    );
+  }
+
+  const HeadingTag = useMemo(
+    () => `h${resolvedLevel}` as keyof React.JSX.IntrinsicElements,
+    [resolvedLevel],
+  );
+
+  const containerClass = ['content-shell', className].filter(Boolean).join(' ');
+
+  return (
+    <HeadingLevelContext.Provider value={childLevel}>
+      <div className={containerClass} data-testid={testId}>
+        <div className="content-shell__header" data-testid={`${testId}-header`}>
+          <div className="content-shell__title-group">
+            <HeadingTag
+              id={titleId}
+              className={`content-shell__title content-shell__title--h${resolvedLevel}`}
+              data-testid={`${testId}-title`}
+              data-heading-level={resolvedLevel}
+            >
+              {title}
+            </HeadingTag>
+            {description && (
+              <p className="content-shell__description" data-testid={`${testId}-description`}>
+                {description}
+              </p>
+            )}
+          </div>
+          {actions && (
+            <div className="content-shell__actions" data-testid={`${testId}-actions`}>
+              {actions}
+            </div>
+          )}
+        </div>
+
+        {children !== undefined && children !== null && (
+          <div className="content-shell__body" data-testid={`${testId}-body`}>
+            {children}
+          </div>
+        )}
+      </div>
+    </HeadingLevelContext.Provider>
+  );
+};
+
+ContentShell.displayName = 'ContentShell';
+
+export default ContentShell;

--- a/frontend/src/components/v1/QueueStateMiniPanel.css
+++ b/frontend/src/components/v1/QueueStateMiniPanel.css
@@ -1,0 +1,242 @@
+.queue-state-mini-panel {
+  --panel-bg: color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 92%, transparent);
+  --panel-border: color-mix(in oklab, var(--glass-border, rgba(255, 255, 255, 0.16)) 86%, transparent);
+  --panel-text: var(--text-main, #f5f7fb);
+  --panel-text-muted: var(--text-secondary, #a8b5c8);
+  --panel-accent: var(--accent, #7de2d1);
+  display: block;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.75rem;
+  background: var(--panel-bg);
+  overflow: hidden;
+}
+
+.queue-state-mini-panel--lobby {
+  --panel-accent: var(--accent, #7de2d1);
+}
+
+.queue-state-mini-panel--live-match {
+  --panel-accent: #ffb357;
+  border-color: color-mix(in oklab, #ffb357 30%, var(--panel-border));
+}
+
+/* Header */
+.queue-state-mini-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.queue-state-mini-panel__title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.queue-state-mini-panel__context-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--panel-accent);
+}
+
+.queue-state-mini-panel__context-dot--pulsing {
+  animation: queue-mini-pulse 2s ease-in-out infinite;
+}
+
+@keyframes queue-mini-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.queue-state-mini-panel__title {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--panel-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-state-mini-panel__refresh-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--panel-text-muted);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.15s ease-in-out;
+  flex: 0 0 auto;
+}
+
+.queue-state-mini-panel__refresh-btn:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 85%, transparent);
+  color: var(--panel-text);
+}
+
+.queue-state-mini-panel__refresh-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.queue-state-mini-panel__refresh-btn:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--panel-accent) 55%, white);
+  outline-offset: 2px;
+}
+
+/* Metrics */
+.queue-state-mini-panel__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  padding: 0.875rem 0;
+}
+
+.queue-state-mini-panel__metric {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0 0.75rem;
+}
+
+.queue-state-mini-panel__metric + .queue-state-mini-panel__metric {
+  border-left: 1px solid var(--panel-border);
+}
+
+.queue-state-mini-panel__metric-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--panel-text);
+  line-height: 1.2;
+  margin-bottom: 0.25rem;
+}
+
+.queue-state-mini-panel__metric-label {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--panel-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+/* Footer */
+.queue-state-mini-panel__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--panel-border);
+  background: color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 60%, transparent);
+}
+
+.queue-state-mini-panel__status-label {
+  font-size: 0.75rem;
+  color: var(--panel-text-muted);
+}
+
+.queue-state-mini-panel__last-updated {
+  font-size: 0.6875rem;
+  color: var(--panel-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Loading */
+.queue-state-mini-panel__loading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.queue-state-mini-panel__skeleton {
+  border-radius: 0.25rem;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 50%, transparent) 25%,
+    color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 75%, transparent) 50%,
+    color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 50%, transparent) 75%
+  );
+  background-size: 200% 100%;
+  animation: queue-mini-shimmer 1.5s ease-in-out infinite;
+}
+
+.queue-state-mini-panel__skeleton--title {
+  height: 1rem;
+  width: 55%;
+}
+
+.queue-state-mini-panel__skeleton--metrics {
+  height: 2.5rem;
+  width: 100%;
+}
+
+.queue-state-mini-panel__skeleton--footer {
+  height: 0.875rem;
+  width: 40%;
+}
+
+@keyframes queue-mini-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* Error */
+.queue-state-mini-panel__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+
+.queue-state-mini-panel__error-message {
+  font-size: 0.8125rem;
+  color: color-mix(in oklab, #ff6d87 80%, var(--panel-text-muted));
+  margin: 0;
+}
+
+.queue-state-mini-panel__retry-btn {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--panel-text);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease-in-out;
+  flex: 0 0 auto;
+}
+
+.queue-state-mini-panel__retry-btn:hover {
+  background: color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 85%, transparent);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .queue-state-mini-panel__metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .queue-state-mini-panel__metric:nth-child(3) {
+    grid-column: 1 / span 2;
+    border-left: none;
+    border-top: 1px solid var(--panel-border);
+    padding-top: 0.75rem;
+    margin-top: 0.25rem;
+  }
+}

--- a/frontend/src/components/v1/QueueStateMiniPanel.tsx
+++ b/frontend/src/components/v1/QueueStateMiniPanel.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { StatusPill } from './StatusPill';
+import type { QueueMetrics } from './QueueHealthWidget';
+import './QueueStateMiniPanel.css';
+
+export type QueuePanelContext = 'lobby' | 'live-match';
+
+export interface QueueStateMiniPanelProps {
+  metrics?: QueueMetrics;
+  title?: string;
+  context?: QueuePanelContext;
+  loading?: boolean;
+  error?: string;
+  onRefresh?: () => void;
+  className?: string;
+  testId?: string;
+}
+
+const HEALTH_TONE: Record<QueueMetrics['queueHealth'], 'success' | 'warning' | 'error' | 'neutral'> = {
+  healthy: 'success',
+  degraded: 'warning',
+  critical: 'error',
+  offline: 'neutral',
+};
+
+const HEALTH_LABEL: Record<QueueMetrics['queueHealth'], string> = {
+  healthy: 'Healthy',
+  degraded: 'Degraded',
+  critical: 'Critical',
+  offline: 'Offline',
+};
+
+function formatWait(seconds: number): string {
+  if (seconds <= 0) return '—';
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function formatRelative(isoString: string): string {
+  const diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  return `${Math.floor(diff / 3600)}h ago`;
+}
+
+export const QueueStateMiniPanel: React.FC<QueueStateMiniPanelProps> = ({
+  metrics,
+  title,
+  context = 'lobby',
+  loading = false,
+  error,
+  onRefresh,
+  className = '',
+  testId = 'queue-state-mini-panel',
+}) => {
+  const resolvedTitle = title ?? (context === 'live-match' ? 'Match Queue' : 'Queue Status');
+
+  const containerClass = [
+    'queue-state-mini-panel',
+    `queue-state-mini-panel--${context}`,
+    className,
+  ].filter(Boolean).join(' ');
+
+  const isLive = context === 'live-match' && metrics?.queueHealth !== 'offline';
+
+  if (loading && !metrics) {
+    return (
+      <div className={containerClass} data-testid={`${testId}-loading`} role="status" aria-live="polite">
+        <div className="queue-state-mini-panel__loading">
+          <div className="queue-state-mini-panel__skeleton queue-state-mini-panel__skeleton--title" />
+          <div className="queue-state-mini-panel__skeleton queue-state-mini-panel__skeleton--metrics" />
+          <div className="queue-state-mini-panel__skeleton queue-state-mini-panel__skeleton--footer" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={containerClass} data-testid={`${testId}-error`} role="alert">
+        <div className="queue-state-mini-panel__error">
+          <p className="queue-state-mini-panel__error-message">{error}</p>
+          {onRefresh && (
+            <button
+              type="button"
+              className="queue-state-mini-panel__retry-btn"
+              onClick={onRefresh}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const current = metrics ?? {
+    playersInQueue: 0,
+    averageWaitTime: 0,
+    estimatedWaitTime: 0,
+    activeMatches: 0,
+    queueHealth: 'offline' as const,
+    lastUpdated: new Date().toISOString(),
+  };
+
+  return (
+    <div className={containerClass} data-testid={testId}>
+      <header className="queue-state-mini-panel__header">
+        <div className="queue-state-mini-panel__title-row">
+          <span
+            className={[
+              'queue-state-mini-panel__context-dot',
+              isLive ? 'queue-state-mini-panel__context-dot--pulsing' : '',
+            ].filter(Boolean).join(' ')}
+            aria-hidden="true"
+          />
+          <h3 className="queue-state-mini-panel__title">{resolvedTitle}</h3>
+          <StatusPill
+            tone={HEALTH_TONE[current.queueHealth]}
+            label={HEALTH_LABEL[current.queueHealth]}
+            size="compact"
+            testId={`${testId}-health`}
+          />
+        </div>
+        {onRefresh && (
+          <button
+            type="button"
+            className="queue-state-mini-panel__refresh-btn"
+            onClick={onRefresh}
+            disabled={loading}
+            aria-label="Refresh queue status"
+            data-testid={`${testId}-refresh`}
+          >
+            <span aria-hidden="true">↻</span>
+          </button>
+        )}
+      </header>
+
+      <div className="queue-state-mini-panel__metrics" data-testid={`${testId}-metrics`}>
+        <div className="queue-state-mini-panel__metric">
+          <span className="queue-state-mini-panel__metric-value">
+            {loading ? '—' : current.playersInQueue}
+          </span>
+          <span className="queue-state-mini-panel__metric-label">Players</span>
+        </div>
+        <div className="queue-state-mini-panel__metric">
+          <span className="queue-state-mini-panel__metric-value">
+            {loading ? '—' : formatWait(current.estimatedWaitTime)}
+          </span>
+          <span className="queue-state-mini-panel__metric-label">Est. Wait</span>
+        </div>
+        <div className="queue-state-mini-panel__metric">
+          <span className="queue-state-mini-panel__metric-value">
+            {loading ? '—' : current.activeMatches}
+          </span>
+          <span className="queue-state-mini-panel__metric-label">Active</span>
+        </div>
+      </div>
+
+      <footer className="queue-state-mini-panel__footer">
+        <span className="queue-state-mini-panel__status-label">
+          {context === 'live-match' ? 'Live match' : 'Lobby queue'}
+        </span>
+        <span className="queue-state-mini-panel__last-updated" data-testid={`${testId}-updated`}>
+          {loading ? 'Updating…' : formatRelative(current.lastUpdated)}
+        </span>
+      </footer>
+    </div>
+  );
+};
+
+QueueStateMiniPanel.displayName = 'QueueStateMiniPanel';
+
+export default QueueStateMiniPanel;

--- a/frontend/src/components/v1/WorkflowProgressRail.css
+++ b/frontend/src/components/v1/WorkflowProgressRail.css
@@ -1,0 +1,292 @@
+.wpr {
+  --wpr-pending-bg: color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 80%, transparent);
+  --wpr-pending-border: rgba(255, 255, 255, 0.2);
+  --wpr-pending-text: rgba(255, 255, 255, 0.4);
+  --wpr-active-bg: color-mix(in oklab, var(--accent, #7de2d1) 20%, rgba(255, 255, 255, 0.04));
+  --wpr-active-border: var(--accent, #7de2d1);
+  --wpr-active-text: var(--accent, #7de2d1);
+  --wpr-active-glow: 0 0 10px color-mix(in oklab, var(--accent, #7de2d1) 40%, transparent);
+  --wpr-completed-bg: color-mix(in oklab, #4ade80 20%, rgba(255, 255, 255, 0.04));
+  --wpr-completed-border: #4ade80;
+  --wpr-completed-text: #4ade80;
+  --wpr-error-bg: color-mix(in oklab, #f87171 20%, rgba(255, 255, 255, 0.04));
+  --wpr-error-border: #f87171;
+  --wpr-error-text: #f87171;
+  --wpr-blocked-bg: color-mix(in oklab, rgba(255, 255, 255, 0.08) 60%, transparent);
+  --wpr-blocked-border: rgba(255, 255, 255, 0.12);
+  --wpr-blocked-text: rgba(255, 255, 255, 0.25);
+  --wpr-connector-base: rgba(255, 255, 255, 0.12);
+  --wpr-connector-completed: #4ade80;
+  --wpr-connector-active: var(--accent, #7de2d1);
+  --wpr-label-active: var(--text-main, #f5f7fb);
+  --wpr-label-muted: var(--text-secondary, #a8b5c8);
+  display: block;
+}
+
+/* ── Track ─────────────────────────────────────────────────── */
+
+.wpr__track {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  align-items: flex-start;
+}
+
+.wpr--horizontal .wpr__track {
+  flex-direction: row;
+  align-items: center;
+}
+
+.wpr--vertical .wpr__track {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* ── Step item (step + connector grouped) ───────────────────── */
+
+.wpr__step-item {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.wpr--vertical .wpr__step-item {
+  flex-direction: column;
+  align-items: stretch;
+  flex: 0 0 auto;
+}
+
+/* ── Connector ──────────────────────────────────────────────── */
+
+.wpr__connector {
+  flex: 1;
+  height: 2px;
+  background: var(--wpr-connector-base);
+  border-radius: 1px;
+  transition: background 0.25s ease;
+  min-width: 1rem;
+}
+
+.wpr--vertical .wpr__connector {
+  flex: 0 0 auto;
+  width: 2px;
+  height: 1.5rem;
+  min-width: auto;
+  margin: 0.25rem auto;
+  align-self: flex-start;
+  margin-left: 0.9375rem; /* aligns with center of indicator */
+}
+
+.wpr__connector--completed {
+  background: var(--wpr-connector-completed);
+}
+
+.wpr__connector--active {
+  background: linear-gradient(
+    90deg,
+    var(--wpr-connector-completed) 0%,
+    var(--wpr-connector-base) 100%
+  );
+}
+
+/* ── Step ───────────────────────────────────────────────────── */
+
+.wpr__step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: default;
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  transition: background 0.15s ease;
+  flex: 0 0 auto;
+}
+
+.wpr--vertical .wpr__step {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.5rem 0.25rem;
+}
+
+.wpr__step--clickable {
+  cursor: pointer;
+}
+
+.wpr__step--clickable:hover {
+  background: color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 85%, transparent);
+}
+
+.wpr__step--clickable:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--accent, #7de2d1) 55%, white);
+  outline-offset: 2px;
+}
+
+/* ── Indicator circle ────────────────────────────────────────── */
+
+.wpr__indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 2px solid var(--wpr-pending-border);
+  background: var(--wpr-pending-bg);
+  color: var(--wpr-pending-text);
+  font-size: 0.875rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.wpr--default .wpr__indicator {
+  width: 2rem;
+  height: 2rem;
+}
+
+.wpr--compact .wpr__indicator {
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 0.75rem;
+}
+
+.wpr__step--active .wpr__indicator {
+  border-color: var(--wpr-active-border);
+  background: var(--wpr-active-bg);
+  color: var(--wpr-active-text);
+  box-shadow: var(--wpr-active-glow);
+}
+
+.wpr__step--completed .wpr__indicator {
+  border-color: var(--wpr-completed-border);
+  background: var(--wpr-completed-bg);
+  color: var(--wpr-completed-text);
+}
+
+.wpr__step--error .wpr__indicator {
+  border-color: var(--wpr-error-border);
+  background: var(--wpr-error-bg);
+  color: var(--wpr-error-text);
+  box-shadow: 0 0 8px color-mix(in oklab, #f87171 40%, transparent);
+}
+
+.wpr__step--blocked .wpr__indicator {
+  border-color: var(--wpr-blocked-border);
+  background: var(--wpr-blocked-bg);
+  color: var(--wpr-blocked-text);
+}
+
+.wpr__step-icon {
+  display: block;
+  line-height: 1;
+}
+
+.wpr__step-number {
+  display: block;
+  line-height: 1;
+}
+
+.wpr__step-dot {
+  display: block;
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* ── Step content ────────────────────────────────────────────── */
+
+.wpr__step-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+  max-width: 6rem;
+  text-align: center;
+}
+
+.wpr--vertical .wpr__step-content {
+  align-items: flex-start;
+  text-align: left;
+  max-width: none;
+  padding-top: 0.125rem;
+}
+
+.wpr__step-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--wpr-label-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wpr__step--active .wpr__step-label {
+  color: var(--wpr-label-active);
+  font-weight: 700;
+}
+
+.wpr__step--completed .wpr__step-label {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.wpr__step--error .wpr__step-label {
+  color: var(--wpr-error-text);
+  font-weight: 700;
+}
+
+.wpr__step--blocked .wpr__step-label {
+  color: var(--wpr-blocked-text);
+}
+
+.wpr__step-description {
+  font-size: 0.6875rem;
+  color: var(--wpr-label-muted);
+  line-height: 1.3;
+  white-space: normal;
+}
+
+/* ── Summary (screen-reader live region) ─────────────────────── */
+
+.wpr__summary {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* ── Empty state ─────────────────────────────────────────────── */
+
+.wpr__empty {
+  font-size: 0.8125rem;
+  color: var(--wpr-label-muted);
+  font-style: italic;
+}
+
+/* ── Reduced motion ──────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .wpr__indicator,
+  .wpr__connector,
+  .wpr__step {
+    transition: none;
+  }
+}
+
+/* ── Responsive ──────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .wpr--horizontal .wpr__step-content {
+    display: none;
+  }
+
+  .wpr--horizontal.wpr__step-item {
+    flex: 1;
+  }
+}

--- a/frontend/src/components/v1/WorkflowProgressRail.tsx
+++ b/frontend/src/components/v1/WorkflowProgressRail.tsx
@@ -1,0 +1,231 @@
+import React, { useCallback, useMemo } from 'react';
+import './WorkflowProgressRail.css';
+
+export type WorkflowStepStatus = 'pending' | 'active' | 'completed' | 'error' | 'blocked';
+
+export interface WorkflowStep {
+  id: string;
+  label: string;
+  description?: string;
+  status?: WorkflowStepStatus;
+}
+
+export interface WorkflowProgressRailProps {
+  steps: WorkflowStep[];
+  /** Zero-based index of the currently active step (ignored when each step carries an explicit status). */
+  currentStepIndex?: number;
+  /** Called when user clicks a completed or error step to navigate back. */
+  onStepClick?: (stepId: string, index: number) => void;
+  /** Whether step labels are shown beneath the indicators. */
+  showLabels?: boolean;
+  size?: 'compact' | 'default';
+  orientation?: 'horizontal' | 'vertical';
+  className?: string;
+  testId?: string;
+}
+
+function resolveStatus(
+  step: WorkflowStep,
+  index: number,
+  currentIndex: number,
+): WorkflowStepStatus {
+  if (step.status !== undefined) return step.status;
+  if (index < currentIndex) return 'completed';
+  if (index === currentIndex) return 'active';
+  return 'pending';
+}
+
+const STATUS_LABEL: Record<WorkflowStepStatus, string> = {
+  pending: 'Pending',
+  active: 'Current',
+  completed: 'Completed',
+  error: 'Error',
+  blocked: 'Blocked',
+};
+
+function StepIcon({
+  index,
+  status,
+  size,
+}: {
+  index: number;
+  status: WorkflowStepStatus;
+  size: 'compact' | 'default';
+}): React.ReactElement {
+  if (status === 'completed') {
+    return (
+      <span className="wpr__step-icon" aria-hidden="true">
+        ✓
+      </span>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <span className="wpr__step-icon" aria-hidden="true">
+        ✕
+      </span>
+    );
+  }
+  if (status === 'blocked') {
+    return (
+      <span className="wpr__step-icon" aria-hidden="true">
+        ⊘
+      </span>
+    );
+  }
+  if (size === 'compact') {
+    return <span className="wpr__step-dot" aria-hidden="true" />;
+  }
+  return <span className="wpr__step-number">{index + 1}</span>;
+}
+
+export const WorkflowProgressRail: React.FC<WorkflowProgressRailProps> = ({
+  steps,
+  currentStepIndex = 0,
+  onStepClick,
+  showLabels = true,
+  size = 'default',
+  orientation = 'horizontal',
+  className = '',
+  testId = 'workflow-progress-rail',
+}) => {
+  const clampedIndex = useMemo(
+    () => Math.max(0, Math.min(currentStepIndex, steps.length - 1)),
+    [currentStepIndex, steps.length],
+  );
+
+  const resolvedSteps = useMemo(
+    () =>
+      steps.map((step, index) => ({
+        ...step,
+        resolvedStatus: resolveStatus(step, index, clampedIndex),
+      })),
+    [steps, clampedIndex],
+  );
+
+  const handleStepClick = useCallback(
+    (step: WorkflowStep & { resolvedStatus: WorkflowStepStatus }, index: number) => {
+      if (!onStepClick) return;
+      if (step.resolvedStatus === 'completed' || step.resolvedStatus === 'error') {
+        onStepClick(step.id, index);
+      }
+    },
+    [onStepClick],
+  );
+
+  const containerClass = [
+    'wpr',
+    `wpr--${size}`,
+    `wpr--${orientation}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  if (steps.length === 0) {
+    return (
+      <div
+        className={containerClass}
+        data-testid={`${testId}-empty`}
+        role="status"
+        aria-label="No workflow steps"
+      >
+        <span className="wpr__empty">No steps defined</span>
+      </div>
+    );
+  }
+
+  const activeStep = resolvedSteps.find((s) => s.resolvedStatus === 'active');
+  const activeLabel = activeStep?.label ?? resolvedSteps[clampedIndex]?.label ?? '';
+
+  return (
+    <nav
+      className={containerClass}
+      data-testid={testId}
+      aria-label="Workflow progress"
+    >
+      <ol className="wpr__track" role="list">
+        {resolvedSteps.map((step, index) => {
+          const { resolvedStatus } = step;
+          const isClickable =
+            !!onStepClick &&
+            (resolvedStatus === 'completed' || resolvedStatus === 'error');
+          const isLast = index === steps.length - 1;
+
+          const itemClass = [
+            'wpr__step',
+            `wpr__step--${resolvedStatus}`,
+            isClickable ? 'wpr__step--clickable' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+
+          return (
+            <li
+              key={step.id}
+              className="wpr__step-item"
+              data-testid={`${testId}-step-${index}`}
+            >
+              <div
+                className={itemClass}
+                role={isClickable ? 'button' : undefined}
+                tabIndex={isClickable ? 0 : undefined}
+                aria-label={`${step.label}: ${STATUS_LABEL[resolvedStatus]}`}
+                aria-current={resolvedStatus === 'active' ? 'step' : undefined}
+                data-step-id={step.id}
+                data-step-status={resolvedStatus}
+                onClick={() => handleStepClick(step, index)}
+                onKeyDown={(e) => {
+                  if (isClickable && (e.key === 'Enter' || e.key === ' ')) {
+                    e.preventDefault();
+                    handleStepClick(step, index);
+                  }
+                }}
+              >
+                <div className="wpr__indicator">
+                  <StepIcon index={index} status={resolvedStatus} size={size} />
+                </div>
+
+                {showLabels && (
+                  <div className="wpr__step-content">
+                    <span className="wpr__step-label">{step.label}</span>
+                    {step.description && size !== 'compact' && (
+                      <span className="wpr__step-description">{step.description}</span>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {!isLast && (
+                <div
+                  className={[
+                    'wpr__connector',
+                    resolvedStatus === 'completed'
+                      ? 'wpr__connector--completed'
+                      : resolvedStatus === 'active'
+                        ? 'wpr__connector--active'
+                        : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  aria-hidden="true"
+                  data-testid={`${testId}-connector-${index}`}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="wpr__summary" aria-live="polite" data-testid={`${testId}-summary`}>
+        <span className="sr-only">
+          {`Step ${clampedIndex + 1} of ${steps.length}: ${activeLabel}`}
+        </span>
+      </div>
+    </nav>
+  );
+};
+
+WorkflowProgressRail.displayName = 'WorkflowProgressRail';
+
+export default WorkflowProgressRail;

--- a/frontend/src/components/v1/index.ts
+++ b/frontend/src/components/v1/index.ts
@@ -374,3 +374,31 @@ export type {
   InterruptedFlowPromptProps,
   InterruptedFlowAction,
 } from "./InterruptedFlowPrompt";
+
+// Issues #753, #756
+export {
+  QueueStateMiniPanel,
+  default as QueueStateMiniPanelDefault,
+} from "./QueueStateMiniPanel";
+export type {
+  QueueStateMiniPanelProps,
+  QueuePanelContext,
+} from "./QueueStateMiniPanel";
+
+// Issue #754
+export {
+  WorkflowProgressRail,
+  default as WorkflowProgressRailDefault,
+} from "./WorkflowProgressRail";
+export type {
+  WorkflowProgressRailProps,
+  WorkflowStep,
+  WorkflowStepStatus,
+} from "./WorkflowProgressRail";
+
+// Issue #752
+export {
+  ContentShell,
+  default as ContentShellDefault,
+} from "./ContentShell";
+export type { ContentShellProps } from "./ContentShell";

--- a/frontend/src/hooks/v1/index.ts
+++ b/frontend/src/hooks/v1/index.ts
@@ -11,3 +11,4 @@ export * from './useAsyncAction';
 export * from './useDebouncedValue';
 export * from './useContractEvents';
 export * from './useFocusRecovery';
+export * from './useHeadingLevel';

--- a/frontend/src/hooks/v1/useHeadingLevel.ts
+++ b/frontend/src/hooks/v1/useHeadingLevel.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+/** Provides the heading level that the next ContentShell should render at. */
+export const HeadingLevelContext = createContext<HeadingLevel>(1);
+
+/**
+ * Returns the heading level that the current ContentShell context expects.
+ * Use this inside custom components that need to render a heading at the
+ * appropriate depth without coupling to a fixed h* tag.
+ */
+export function useHeadingLevel(): HeadingLevel {
+  return useContext(HeadingLevelContext);
+}

--- a/frontend/src/pages/GameDetail.css
+++ b/frontend/src/pages/GameDetail.css
@@ -1,0 +1,88 @@
+.game-detail {
+  display: grid;
+  grid-template-columns: 1fr 18rem;
+  grid-template-rows: auto 1fr;
+  gap: 1.5rem;
+  align-items: start;
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.game-detail__summary {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.game-detail__summary h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-main, #f5f7fb);
+}
+
+.game-detail__summary p {
+  margin: 0.25rem 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary, #a8b5c8);
+}
+
+.game-detail__timeline {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.game-detail__sidebar {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: sticky;
+  top: 1.5rem;
+}
+
+.game-detail__sidebar-section {
+  border: 1px solid color-mix(in oklab, var(--glass-border, rgba(255, 255, 255, 0.16)) 86%, transparent);
+  border-radius: 0.75rem;
+  background: color-mix(in oklab, var(--surface-elevated, rgba(255, 255, 255, 0.08)) 92%, transparent);
+  padding: 1rem;
+}
+
+.game-detail__sidebar-heading {
+  margin: 0 0 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary, #a8b5c8);
+}
+
+@media (max-width: 900px) {
+  .game-detail {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+  }
+
+  .game-detail__summary {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .game-detail__sidebar {
+    grid-column: 1;
+    grid-row: 2;
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .game-detail__sidebar-section {
+    flex: 1 1 14rem;
+  }
+
+  .game-detail__timeline {
+    grid-column: 1;
+    grid-row: 3;
+  }
+}

--- a/frontend/src/pages/GameDetail.tsx
+++ b/frontend/src/pages/GameDetail.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import ContractEventFeed from '../components/v1/ContractEventFeed';
 import { SkeletonPreset } from '../components/v1/LoadingSkeletonSet';
+import { QuickPivotLinks, type PivotLink } from '../components/v1/QuickPivotLinks';
 import { ApiClient } from '../services/typed-api-sdk';
 import type { Game } from '../types/api-client';
+import './GameDetail.css';
 
 const FALLBACK_CONTRACT_PREFIX = 'game';
 
@@ -18,6 +20,7 @@ function resolveContractId(game: Game): string {
 
 export const GameDetail: React.FC = () => {
   const { gameId } = useParams<{ gameId: string }>();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [game, setGame] = useState<Game | null>(null);
@@ -63,6 +66,49 @@ export const GameDetail: React.FC = () => {
     return String(game.status ?? 'unknown').toLowerCase();
   }, [game]);
 
+  const sidebarLinks = useMemo<PivotLink[]>(() => {
+    if (!game) return [];
+
+    const links: PivotLink[] = [
+      {
+        id: 'back-to-lobby',
+        label: 'Back to Lobby',
+        onClick: () => navigate('/'),
+      },
+      {
+        id: 'wallet',
+        label: 'Wallet Details',
+        href: '/wallet',
+      },
+      {
+        id: 'leaderboard',
+        label: 'Leaderboard',
+        onClick: () => navigate('/?section=leaderboard'),
+      },
+      {
+        id: 'transactions',
+        label: 'Transaction History',
+        href: '/wallet?tab=transactions',
+      },
+      {
+        id: 'audit-log',
+        label: 'Audit Log',
+        href: '/audit',
+      },
+    ];
+
+    if (statusLabel === 'active') {
+      links.unshift({
+        id: 'live-match',
+        label: 'Live Match',
+        href: `/games/${game.id}/live`,
+        disabled: true,
+      });
+    }
+
+    return links;
+  }, [game, navigate, statusLabel]);
+
   if (loading) {
     return (
       <div role="status" aria-live="polite" data-testid="game-detail-loading">
@@ -99,13 +145,28 @@ export const GameDetail: React.FC = () => {
         <p data-testid="game-detail-contract">Contract: {contractId}</p>
       </header>
 
-      <ContractEventFeed
-        contractId={contractId}
-        autoStart={true}
-        maxEvents={50}
-        feedScope={`game-detail-${game.id}`}
-        testId="game-detail-timeline"
-      />
+      <aside className="game-detail__sidebar" aria-label="Related actions" data-testid="game-detail-sidebar">
+        <div className="game-detail__sidebar-section">
+          <h2 className="game-detail__sidebar-heading">Related</h2>
+          <QuickPivotLinks
+            links={sidebarLinks}
+            orientation="vertical"
+            size="compact"
+            testId="game-detail-pivot-links"
+            emptyMessage="No related actions available"
+          />
+        </div>
+      </aside>
+
+      <div className="game-detail__timeline">
+        <ContractEventFeed
+          contractId={contractId}
+          autoStart={true}
+          maxEvents={50}
+          feedScope={`game-detail-${game.id}`}
+          testId="game-detail-timeline"
+        />
+      </div>
     </section>
   );
 };

--- a/frontend/src/pages/GameLobby.tsx
+++ b/frontend/src/pages/GameLobby.tsx
@@ -18,6 +18,7 @@ import { WalletSessionActivityRail } from "../components/v1/WalletSessionActivit
 import { ActionToolbar, type ToolbarAction } from "../components/v1/ActionToolbar";
 import { InlineStatDelta } from "../components/v1/InlineStatDelta";
 import { QueueHealthWidget } from "../components/v1/QueueHealthWidget";
+import { QueueStateMiniPanel } from "../components/v1/QueueStateMiniPanel";
 import { useWalletStatus } from "../hooks/v1/useWalletStatus";
 import { ApiClient } from "../services/typed-api-sdk";
 import GlobalStateStore, {
@@ -901,6 +902,13 @@ export const GameLobby: React.FC = () => {
             className="games-section"
             ref={gamesSectionRef}
           >
+            <QueueStateMiniPanel
+              metrics={queueSummaryMetrics}
+              context="lobby"
+              onRefresh={handleRefreshLobby}
+              testId="lobby-queue-mini-panel"
+            />
+
             {games.length === 0 ? (
               <div className="lobby-empty" role="status" aria-live="polite">
                 <div className="empty-icon">No live games</div>

--- a/frontend/tests/components/ContentShell.test.tsx
+++ b/frontend/tests/components/ContentShell.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { ContentShell } from '@/components/v1/ContentShell';
+import { HeadingLevelContext, useHeadingLevel } from '@/hooks/v1/useHeadingLevel';
+
+// ── helper: render a ContentShell at a specific context depth ──────────────
+function renderAtLevel(level: 1 | 2 | 3 | 4 | 5 | 6, title: string) {
+  return render(
+    <HeadingLevelContext.Provider value={level}>
+      <ContentShell title={title} testId="shell" />
+    </HeadingLevelContext.Provider>,
+  );
+}
+
+describe('ContentShell — heading level derivation', () => {
+  it('renders an h1 when context level is 1 (default)', () => {
+    render(<ContentShell title="Page Title" testId="shell" />);
+
+    const heading = screen.getByTestId('shell-title');
+    expect(heading.tagName).toBe('H1');
+    expect(heading).toHaveAttribute('data-heading-level', '1');
+    expect(heading).toHaveTextContent('Page Title');
+  });
+
+  it('renders an h2 when context level is 2', () => {
+    renderAtLevel(2, 'Section Title');
+
+    const heading = screen.getByTestId('shell-title');
+    expect(heading.tagName).toBe('H2');
+    expect(heading).toHaveAttribute('data-heading-level', '2');
+  });
+
+  it('renders an h3 when context level is 3', () => {
+    renderAtLevel(3, 'Sub-section');
+
+    expect(screen.getByTestId('shell-title').tagName).toBe('H3');
+  });
+
+  it('renders h6 at the maximum nesting depth', () => {
+    renderAtLevel(6, 'Deep Section');
+
+    expect(screen.getByTestId('shell-title').tagName).toBe('H6');
+  });
+
+  it('headingLevel prop overrides context depth', () => {
+    render(
+      <HeadingLevelContext.Provider value={2}>
+        <ContentShell title="Forced h4" headingLevel={4} testId="shell" />
+      </HeadingLevelContext.Provider>,
+    );
+
+    expect(screen.getByTestId('shell-title').tagName).toBe('H4');
+  });
+});
+
+describe('ContentShell — heading hierarchy in nested shells', () => {
+  it('provides the next heading level to children via context', () => {
+    const ChildChecker: React.FC = () => {
+      const level = useHeadingLevel();
+      return <span data-testid="child-level">{level}</span>;
+    };
+
+    render(
+      <ContentShell title="Outer" testId="outer">
+        <ChildChecker />
+      </ContentShell>,
+    );
+
+    // outer renders h1, so children should receive level 2
+    expect(screen.getByTestId('child-level')).toHaveTextContent('2');
+  });
+
+  it('outer h1 → inner h2 → innermost h3 in three-level nesting', () => {
+    render(
+      <ContentShell title="Level 1" testId="l1">
+        <ContentShell title="Level 2" testId="l2">
+          <ContentShell title="Level 3" testId="l3" />
+        </ContentShell>
+      </ContentShell>,
+    );
+
+    expect(screen.getByTestId('l1-title').tagName).toBe('H1');
+    expect(screen.getByTestId('l2-title').tagName).toBe('H2');
+    expect(screen.getByTestId('l3-title').tagName).toBe('H3');
+  });
+
+  it('sibling shells at the same context level both render the same tag', () => {
+    render(
+      <HeadingLevelContext.Provider value={2}>
+        <ContentShell title="First" testId="first" />
+        <ContentShell title="Second" testId="second" />
+      </HeadingLevelContext.Provider>,
+    );
+
+    expect(screen.getByTestId('first-title').tagName).toBe('H2');
+    expect(screen.getByTestId('second-title').tagName).toBe('H2');
+  });
+});
+
+describe('ContentShell — rendering slots', () => {
+  it('renders description when provided', () => {
+    render(
+      <ContentShell title="Title" description="Supporting copy" testId="shell" />,
+    );
+
+    expect(screen.getByTestId('shell-description')).toHaveTextContent('Supporting copy');
+  });
+
+  it('does not render description element when omitted', () => {
+    render(<ContentShell title="No desc" testId="shell" />);
+
+    expect(screen.queryByTestId('shell-description')).not.toBeInTheDocument();
+  });
+
+  it('renders actions slot in header', () => {
+    render(
+      <ContentShell
+        title="With actions"
+        actions={<button type="button">Save</button>}
+        testId="shell"
+      />,
+    );
+
+    expect(screen.getByTestId('shell-actions')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  it('renders children in the body region', () => {
+    render(
+      <ContentShell title="Parent" testId="shell">
+        <p>Child content</p>
+      </ContentShell>,
+    );
+
+    expect(screen.getByTestId('shell-body')).toBeInTheDocument();
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+  });
+
+  it('does not render body element when children are absent', () => {
+    render(<ContentShell title="No children" testId="shell" />);
+
+    expect(screen.queryByTestId('shell-body')).not.toBeInTheDocument();
+  });
+
+  it('forwards titleId to the heading element', () => {
+    render(
+      <ContentShell title="Labelled" titleId="my-section-id" testId="shell" />,
+    );
+
+    expect(screen.getByTestId('shell-title')).toHaveAttribute('id', 'my-section-id');
+  });
+});
+
+describe('ContentShell — dev warning for overly deep nesting', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fires a console.warn when context depth would exceed 6 without an override', () => {
+    render(
+      <HeadingLevelContext.Provider value={7 as any}>
+        <ContentShell title="Too deep" testId="shell" />
+      </HeadingLevelContext.Provider>,
+    );
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Heading level would exceed h6'),
+    );
+  });
+
+  it('does not warn when headingLevel override is provided', () => {
+    render(
+      <HeadingLevelContext.Provider value={7 as any}>
+        <ContentShell title="Overridden" headingLevel={6} testId="shell" />
+      </HeadingLevelContext.Provider>,
+    );
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('ContentShell — accessibility', () => {
+  it('heading is accessible via its text content', () => {
+    render(<ContentShell title="Accessible Heading" testId="shell" />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Accessible Heading' }),
+    ).toBeInTheDocument();
+  });
+
+  it('aria-labelledby pattern works via titleId', () => {
+    render(
+      <section aria-labelledby="region-label">
+        <ContentShell title="Region" titleId="region-label" testId="shell" />
+      </section>,
+    );
+
+    const section = screen
+      .getByTestId('shell-title')
+      .closest('section')!;
+    expect(section).toHaveAttribute('aria-labelledby', 'region-label');
+    expect(screen.getByTestId('shell-title')).toHaveAttribute('id', 'region-label');
+  });
+});
+
+describe('useHeadingLevel — context hook', () => {
+  it('returns 1 when no provider is present (default)', () => {
+    const Probe: React.FC = () => {
+      const level = useHeadingLevel();
+      return <span data-testid="level">{level}</span>;
+    };
+
+    render(<Probe />);
+    expect(screen.getByTestId('level')).toHaveTextContent('1');
+  });
+
+  it('returns the value supplied by HeadingLevelContext.Provider', () => {
+    const Probe: React.FC = () => {
+      const level = useHeadingLevel();
+      return <span data-testid="level">{level}</span>;
+    };
+
+    render(
+      <HeadingLevelContext.Provider value={4}>
+        <Probe />
+      </HeadingLevelContext.Provider>,
+    );
+
+    expect(screen.getByTestId('level')).toHaveTextContent('4');
+  });
+});

--- a/frontend/tests/components/GameDetail.test.tsx
+++ b/frontend/tests/components/GameDetail.test.tsx
@@ -78,3 +78,116 @@ describe('GameDetail', () => {
     });
   });
 });
+
+describe('GameDetail sidebar quick actions', () => {
+  it('renders the sidebar with related-entity pivot links on successful load', async () => {
+    (ApiClient as any).prototype.getGameById.mockResolvedValue({
+      success: true,
+      data: {
+        id: 'game-55',
+        name: 'Stellar Duel',
+        status: 'waiting',
+        contractId: 'contract-duel-55',
+      },
+    });
+
+    renderWithRoute('/games/game-55');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('game-detail-sidebar')).toBeInTheDocument();
+      expect(screen.getByRole('complementary', { name: 'Related actions' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('game-detail-pivot-links')).toBeInTheDocument();
+    expect(screen.getByText('Back to Lobby')).toBeInTheDocument();
+    expect(screen.getByText('Wallet Details')).toBeInTheDocument();
+    expect(screen.getByText('Transaction History')).toBeInTheDocument();
+    expect(screen.getByText('Audit Log')).toBeInTheDocument();
+  });
+
+  it('includes a Live Match link when the game status is active', async () => {
+    (ApiClient as any).prototype.getGameById.mockResolvedValue({
+      success: true,
+      data: {
+        id: 'game-77',
+        name: 'Active Arena',
+        status: 'active',
+        contractId: 'contract-arena-77',
+      },
+    });
+
+    renderWithRoute('/games/game-77');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('game-detail-pivot-links')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Live Match')).toBeInTheDocument();
+  });
+
+  it('does not include a Live Match link for non-active games', async () => {
+    (ApiClient as any).prototype.getGameById.mockResolvedValue({
+      success: true,
+      data: {
+        id: 'game-88',
+        name: 'Completed Game',
+        status: 'completed',
+        contractId: 'contract-comp-88',
+      },
+    });
+
+    renderWithRoute('/games/game-88');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('game-detail-pivot-links')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Live Match')).not.toBeInTheDocument();
+  });
+
+  it('sidebar is not rendered in the loading state', () => {
+    (ApiClient as any).prototype.getGameById.mockReturnValue(new Promise(() => {}));
+
+    renderWithRoute('/games/game-loading');
+
+    expect(screen.queryByTestId('game-detail-sidebar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('game-detail-loading')).toBeInTheDocument();
+  });
+
+  it('sidebar is not rendered in the error state', async () => {
+    (ApiClient as any).prototype.getGameById.mockResolvedValue({
+      success: false,
+      error: { message: 'Not found' },
+    });
+
+    renderWithRoute('/games/bad-id');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('game-detail-error')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('game-detail-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('pivot links render in vertical orientation for the sidebar', async () => {
+    (ApiClient as any).prototype.getGameById.mockResolvedValue({
+      success: true,
+      data: {
+        id: 'game-99',
+        name: 'Orientation Test',
+        status: 'idle',
+        contractId: 'contract-ot-99',
+      },
+    });
+
+    renderWithRoute('/games/game-99');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('game-detail-pivot-links')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('game-detail-pivot-links')).toHaveClass(
+      'quick-pivot-links--vertical',
+    );
+  });
+});

--- a/frontend/tests/components/GameLobby.test.tsx
+++ b/frontend/tests/components/GameLobby.test.tsx
@@ -278,4 +278,42 @@ describe("GameLobby", () => {
     fireEvent.click(screen.getByTestId("lobby-pending-action-chip-dismiss-btn"));
     expect(screen.queryByTestId("lobby-pending-action-chip")).not.toBeInTheDocument();
   });
+
+  it("renders the queue-state mini panel in the lobby live arena section", async () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [
+        { id: "g1", name: "Game One", status: "active", wager: 25 },
+        { id: "g2", name: "Game Two", status: "active", wager: 10 },
+      ],
+    });
+
+    render(<GameLobby />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("lobby-queue-mini-panel")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("lobby-queue-mini-panel")).toHaveClass(
+      "queue-state-mini-panel--lobby",
+    );
+  });
+
+  it("queue-state mini panel shows offline when no active games are present", async () => {
+    (ApiClient as any).prototype.getGames.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+
+    render(<GameLobby />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("lobby-queue-mini-panel")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("lobby-queue-mini-panel-health")).toHaveAttribute(
+      "data-tone",
+      "neutral",
+    );
+  });
 });

--- a/frontend/tests/components/QueueStateMiniPanel.test.tsx
+++ b/frontend/tests/components/QueueStateMiniPanel.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueueStateMiniPanel } from '@/components/v1/QueueStateMiniPanel';
+import type { QueueMetrics } from '@/components/v1/QueueHealthWidget';
+
+const mockMetrics: QueueMetrics = {
+  playersInQueue: 18,
+  averageWaitTime: 60,
+  estimatedWaitTime: 45,
+  activeMatches: 6,
+  queueHealth: 'healthy',
+  lastUpdated: new Date(Date.now() - 10000).toISOString(),
+};
+
+describe('QueueStateMiniPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Primary Success Path', () => {
+    it('renders queue metrics in lobby context', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} context="lobby" />);
+
+      expect(screen.getByTestId('queue-state-mini-panel')).toBeInTheDocument();
+      expect(screen.getByText('Queue Status')).toBeInTheDocument();
+      expect(screen.getByText('18')).toBeInTheDocument();
+      expect(screen.getByText('6')).toBeInTheDocument();
+      expect(screen.getByText('Lobby queue')).toBeInTheDocument();
+    });
+
+    it('renders queue metrics in live-match context', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} context="live-match" />);
+
+      expect(screen.getByText('Match Queue')).toBeInTheDocument();
+      expect(screen.getByText('Live match')).toBeInTheDocument();
+    });
+
+    it('applies correct CSS class for each context', () => {
+      const { rerender } = render(
+        <QueueStateMiniPanel metrics={mockMetrics} context="lobby" />,
+      );
+
+      expect(screen.getByTestId('queue-state-mini-panel')).toHaveClass(
+        'queue-state-mini-panel--lobby',
+      );
+
+      rerender(<QueueStateMiniPanel metrics={mockMetrics} context="live-match" />);
+      expect(screen.getByTestId('queue-state-mini-panel')).toHaveClass(
+        'queue-state-mini-panel--live-match',
+      );
+    });
+
+    it('shows health status pill with correct tone for healthy queue', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} />);
+
+      expect(screen.getByTestId('queue-state-mini-panel-health')).toHaveAttribute(
+        'data-tone',
+        'success',
+      );
+    });
+
+    it('calls onRefresh when refresh button is clicked', () => {
+      const mockRefresh = vi.fn();
+      render(<QueueStateMiniPanel metrics={mockMetrics} onRefresh={mockRefresh} />);
+
+      fireEvent.click(screen.getByTestId('queue-state-mini-panel-refresh'));
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts a custom title override', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} title="Ranked Matchmaking" />);
+
+      expect(screen.getByText('Ranked Matchmaking')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases and Fallback Behavior', () => {
+    it('shows loading state when no metrics are provided and loading is true', () => {
+      render(<QueueStateMiniPanel loading={true} />);
+
+      expect(screen.getByTestId('queue-state-mini-panel-loading')).toBeInTheDocument();
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('falls back to offline defaults when metrics prop is omitted', () => {
+      render(<QueueStateMiniPanel />);
+
+      expect(screen.getByTestId('queue-state-mini-panel')).toBeInTheDocument();
+      expect(screen.getByTestId('queue-state-mini-panel-health')).toHaveAttribute(
+        'data-tone',
+        'neutral',
+      );
+      expect(screen.getByText('Offline')).toBeInTheDocument();
+    });
+
+    it('renders error state and retry button', () => {
+      const mockRetry = vi.fn();
+      render(<QueueStateMiniPanel error="Failed to fetch" onRefresh={mockRetry} />);
+
+      expect(screen.getByTestId('queue-state-mini-panel-error')).toBeInTheDocument();
+      expect(screen.getByText('Failed to fetch')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Retry'));
+      expect(mockRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows dashes for metrics when loading with existing data', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} loading={true} />);
+
+      const dashes = screen.getAllByText('—');
+      expect(dashes.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('renders degraded, critical, and offline health tones correctly', () => {
+      const cases: Array<[QueueMetrics['queueHealth'], string]> = [
+        ['degraded', 'warning'],
+        ['critical', 'error'],
+        ['offline', 'neutral'],
+      ];
+
+      for (const [health, expectedTone] of cases) {
+        const { unmount } = render(
+          <QueueStateMiniPanel metrics={{ ...mockMetrics, queueHealth: health }} />,
+        );
+        expect(screen.getByTestId('queue-state-mini-panel-health')).toHaveAttribute(
+          'data-tone',
+          expectedTone,
+        );
+        unmount();
+      }
+    });
+
+    it('omits refresh button when onRefresh is not provided', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} />);
+
+      expect(screen.queryByTestId('queue-state-mini-panel-refresh')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('refresh button has descriptive aria-label', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} onRefresh={() => {}} />);
+
+      expect(screen.getByTestId('queue-state-mini-panel-refresh')).toHaveAttribute(
+        'aria-label',
+        'Refresh queue status',
+      );
+    });
+
+    it('loading state announces via aria-live', () => {
+      render(<QueueStateMiniPanel loading={true} />);
+
+      expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('error state uses role="alert"', () => {
+      render(<QueueStateMiniPanel error="Network error" />);
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('refresh button is disabled while loading', () => {
+      render(
+        <QueueStateMiniPanel metrics={mockMetrics} onRefresh={() => {}} loading={true} />,
+      );
+
+      expect(screen.getByTestId('queue-state-mini-panel-refresh')).toBeDisabled();
+    });
+  });
+
+  describe('Context-specific behaviour', () => {
+    it('does not pulse the context dot when the queue is offline in live-match context', () => {
+      const offlineMetrics: QueueMetrics = { ...mockMetrics, queueHealth: 'offline' };
+      render(<QueueStateMiniPanel metrics={offlineMetrics} context="live-match" />);
+
+      const dot = screen.getByTestId('queue-state-mini-panel').querySelector(
+        '.queue-state-mini-panel__context-dot',
+      );
+      expect(dot).not.toHaveClass('queue-state-mini-panel__context-dot--pulsing');
+    });
+
+    it('pulses the context dot when live-match queue is healthy', () => {
+      render(<QueueStateMiniPanel metrics={mockMetrics} context="live-match" />);
+
+      const dot = screen.getByTestId('queue-state-mini-panel').querySelector(
+        '.queue-state-mini-panel__context-dot',
+      );
+      expect(dot).toHaveClass('queue-state-mini-panel__context-dot--pulsing');
+    });
+  });
+});

--- a/frontend/tests/components/WorkflowProgressRail.test.tsx
+++ b/frontend/tests/components/WorkflowProgressRail.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  WorkflowProgressRail,
+  type WorkflowStep,
+} from '@/components/v1/WorkflowProgressRail';
+
+const GAME_JOIN_STEPS: WorkflowStep[] = [
+  { id: 'browse', label: 'Browse', description: 'Select a game' },
+  { id: 'wager', label: 'Set Wager', description: 'Choose your stake' },
+  { id: 'review', label: 'Review', description: 'Confirm details' },
+  { id: 'confirm', label: 'Confirm', description: 'Sign transaction' },
+  { id: 'done', label: 'Done', description: 'Match started' },
+];
+
+describe('WorkflowProgressRail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Primary Success Path', () => {
+    it('renders all step labels', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={0} />);
+
+      expect(screen.getByText('Browse')).toBeInTheDocument();
+      expect(screen.getByText('Set Wager')).toBeInTheDocument();
+      expect(screen.getByText('Review')).toBeInTheDocument();
+      expect(screen.getByText('Confirm')).toBeInTheDocument();
+      expect(screen.getByText('Done')).toBeInTheDocument();
+    });
+
+    it('marks the active step with aria-current="step"', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={2} />);
+
+      const reviewStep = screen.getByTestId('workflow-progress-rail-step-2');
+      const activeEl = reviewStep.querySelector('[aria-current="step"]');
+      expect(activeEl).toBeInTheDocument();
+    });
+
+    it('derives completed status for steps before currentStepIndex', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={2} />);
+
+      expect(screen.getByTestId('workflow-progress-rail-step-0').querySelector('[data-step-status="completed"]')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-progress-rail-step-1').querySelector('[data-step-status="completed"]')).toBeInTheDocument();
+    });
+
+    it('derives pending status for steps after currentStepIndex', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={2} />);
+
+      expect(screen.getByTestId('workflow-progress-rail-step-3').querySelector('[data-step-status="pending"]')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-progress-rail-step-4').querySelector('[data-step-status="pending"]')).toBeInTheDocument();
+    });
+
+    it('renders connectors between steps (n-1 connectors for n steps)', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={0} />);
+
+      for (let i = 0; i < GAME_JOIN_STEPS.length - 1; i++) {
+        expect(
+          screen.getByTestId(`workflow-progress-rail-connector-${i}`),
+        ).toBeInTheDocument();
+      }
+      expect(
+        screen.queryByTestId(`workflow-progress-rail-connector-${GAME_JOIN_STEPS.length - 1}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onStepClick with id and index when a completed step is clicked', () => {
+      const mockClick = vi.fn();
+      render(
+        <WorkflowProgressRail
+          steps={GAME_JOIN_STEPS}
+          currentStepIndex={3}
+          onStepClick={mockClick}
+        />,
+      );
+
+      const wagerStepEl = screen
+        .getByTestId('workflow-progress-rail-step-1')
+        .querySelector('[data-step-id="wager"]')!;
+
+      fireEvent.click(wagerStepEl);
+      expect(mockClick).toHaveBeenCalledWith('wager', 1);
+    });
+
+    it('does not call onStepClick for the active or pending steps', () => {
+      const mockClick = vi.fn();
+      render(
+        <WorkflowProgressRail
+          steps={GAME_JOIN_STEPS}
+          currentStepIndex={2}
+          onStepClick={mockClick}
+        />,
+      );
+
+      // click active step
+      const activeEl = screen.getByTestId('workflow-progress-rail-step-2')
+        .querySelector('[data-step-id="review"]')!;
+      fireEvent.click(activeEl);
+
+      // click pending step
+      const pendingEl = screen.getByTestId('workflow-progress-rail-step-3')
+        .querySelector('[data-step-id="confirm"]')!;
+      fireEvent.click(pendingEl);
+
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Explicit per-step status', () => {
+    it('respects explicit step status overrides', () => {
+      const steps: WorkflowStep[] = [
+        { id: 'a', label: 'Alpha', status: 'completed' },
+        { id: 'b', label: 'Beta', status: 'error' },
+        { id: 'c', label: 'Gamma', status: 'blocked' },
+      ];
+
+      render(<WorkflowProgressRail steps={steps} />);
+
+      expect(
+        screen.getByTestId('workflow-progress-rail-step-0').querySelector('[data-step-status="completed"]'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('workflow-progress-rail-step-1').querySelector('[data-step-status="error"]'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('workflow-progress-rail-step-2').querySelector('[data-step-status="blocked"]'),
+      ).toBeInTheDocument();
+    });
+
+    it('allows clicking an error step', () => {
+      const mockClick = vi.fn();
+      const steps: WorkflowStep[] = [
+        { id: 'a', label: 'Alpha', status: 'completed' },
+        { id: 'b', label: 'Beta', status: 'error' },
+      ];
+
+      render(<WorkflowProgressRail steps={steps} onStepClick={mockClick} />);
+
+      fireEvent.click(
+        screen.getByTestId('workflow-progress-rail-step-1').querySelector('[data-step-id="b"]')!,
+      );
+      expect(mockClick).toHaveBeenCalledWith('b', 1);
+    });
+  });
+
+  describe('Edge Cases and Fallback Behavior', () => {
+    it('shows empty state when steps array is empty', () => {
+      render(<WorkflowProgressRail steps={[]} />);
+
+      expect(screen.getByTestId('workflow-progress-rail-empty')).toBeInTheDocument();
+      expect(screen.getByText('No steps defined')).toBeInTheDocument();
+    });
+
+    it('clamps currentStepIndex to valid range', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={999} />);
+
+      // Last step should be active when index is out of bounds
+      const lastStep = screen.getByTestId(`workflow-progress-rail-step-${GAME_JOIN_STEPS.length - 1}`);
+      expect(lastStep.querySelector('[data-step-status="active"]')).toBeInTheDocument();
+    });
+
+    it('hides labels when showLabels is false', () => {
+      render(
+        <WorkflowProgressRail
+          steps={GAME_JOIN_STEPS}
+          currentStepIndex={0}
+          showLabels={false}
+        />,
+      );
+
+      expect(screen.queryByText('Browse')).not.toBeInTheDocument();
+    });
+
+    it('applies compact size class', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} size="compact" />);
+
+      expect(screen.getByTestId('workflow-progress-rail')).toHaveClass('wpr--compact');
+    });
+
+    it('applies vertical orientation class', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} orientation="vertical" />);
+
+      expect(screen.getByTestId('workflow-progress-rail')).toHaveClass('wpr--vertical');
+    });
+
+    it('blocked step is not clickable even with onStepClick provided', () => {
+      const mockClick = vi.fn();
+      const steps: WorkflowStep[] = [
+        { id: 'a', label: 'Alpha', status: 'completed' },
+        { id: 'b', label: 'Beta', status: 'blocked' },
+      ];
+
+      render(<WorkflowProgressRail steps={steps} onStepClick={mockClick} />);
+
+      fireEvent.click(
+        screen.getByTestId('workflow-progress-rail-step-1').querySelector('[data-step-id="b"]')!,
+      );
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('renders a nav element with aria-label', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={0} />);
+
+      expect(screen.getByRole('navigation', { name: 'Workflow progress' })).toBeInTheDocument();
+    });
+
+    it('gives each step an aria-label including its status', () => {
+      render(<WorkflowProgressRail steps={GAME_JOIN_STEPS} currentStepIndex={1} />);
+
+      // Step 0 is completed
+      expect(
+        screen
+          .getByTestId('workflow-progress-rail-step-0')
+          .querySelector('[aria-label="Browse: Completed"]'),
+      ).toBeInTheDocument();
+
+      // Step 1 is active
+      expect(
+        screen
+          .getByTestId('workflow-progress-rail-step-1')
+          .querySelector('[aria-label="Set Wager: Current"]'),
+      ).toBeInTheDocument();
+    });
+
+    it('exposes clickable completed steps as buttons via role', () => {
+      render(
+        <WorkflowProgressRail
+          steps={GAME_JOIN_STEPS}
+          currentStepIndex={2}
+          onStepClick={() => {}}
+        />,
+      );
+
+      // Steps 0 and 1 are completed and should have role="button"
+      const step0 = screen
+        .getByTestId('workflow-progress-rail-step-0')
+        .querySelector('[role="button"]');
+      expect(step0).toBeInTheDocument();
+    });
+
+    it('supports Enter key to activate a completed step', () => {
+      const mockClick = vi.fn();
+      render(
+        <WorkflowProgressRail
+          steps={GAME_JOIN_STEPS}
+          currentStepIndex={2}
+          onStepClick={mockClick}
+        />,
+      );
+
+      const btn = screen
+        .getByTestId('workflow-progress-rail-step-0')
+        .querySelector<HTMLElement>('[role="button"]')!;
+
+      btn.focus();
+      fireEvent.keyDown(btn, { key: 'Enter' });
+      expect(mockClick).toHaveBeenCalledWith('browse', 0);
+    });
+  });
+});


### PR DESCRIPTION
closes #756 - Adds a related-entity quick-action sidebar to the GameDetail page using
QuickPivotLinks (vertical orientation); surfaces links to Lobby, Wallet, Leaderboard,
Transaction History, Audit Log, and a conditional Live Match entry for active games.

closes #753 - Introduces QueueStateMiniPanel, a compact 3-metric panel (Players / Est.
Wait / Active) with lobby and live-match context modes; integrated into the GameLobby
live arena section and covered by unit + lobby integration tests.

closes #754 - Adds WorkflowProgressRail, a horizontal shared step rail for multi-step
user flows (pending / active / completed / error / blocked states); supports per-step
status overrides, back-navigation via onStepClick, compact/vertical variants, and full
keyboard + ARIA accessibility.

closes #752 - Adds HeadingLevelContext, useHeadingLevel hook, and ContentShell component
that automatically renders the correct h1–h6 tag based on nesting depth, bumps the level
for children, and emits a dev-mode console.warn when depth would exceed h6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ContentShell layout component for organizing page sections with headers and body content
  * Added QueueStateMiniPanel displaying queue health status, player counts, and wait time metrics
  * Added WorkflowProgressRail component for visualizing workflow step progress with click navigation
  * Enhanced Game Detail page with a quick navigation sidebar for common actions
  * Enhanced Game Lobby with integrated queue status panel showing live metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->