### PR TITLE
Add contract read accessors for claims, rounds, vaults, and badges

### DIFF
--- a/contracts/badge-minter/src/lib.rs
+++ b/contracts/badge-minter/src/lib.rs
@@ -364,6 +364,61 @@ impl BadgeMinter {
     pub fn get_user_mint_records(env: Env, user: Address) -> Vec<UserMintRecord> {
         get_user_mint_records(&env, &user)
     }
+
+    // -----------------------------------------------------------------------
+    // holder_summary
+    // -----------------------------------------------------------------------
+
+    /// Return a wallet holder summary for `user`.
+    ///
+    /// Unknown users return zero counts. `last_minted_at` is the newest ledger
+    /// sequence in the user's mint records, or 0 when there are no mints.
+    pub fn holder_summary(env: Env, user: Address) -> HolderSummary {
+        let badges = get_user_minted_badges(&env, &user);
+        let records = get_user_mint_records(&env, &user);
+        let mut total_quantity = 0u64;
+        let mut last_minted_at = 0u64;
+
+        for record in records.iter() {
+            total_quantity = total_quantity.saturating_add(record.quantity);
+            if record.minted_at > last_minted_at {
+                last_minted_at = record.minted_at;
+            }
+        }
+
+        HolderSummary {
+            user,
+            configured: get_admin(&env).is_some(),
+            badge_count: badges.len(),
+            mint_record_count: records.len(),
+            total_quantity,
+            last_minted_at,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // expiry_risk_accessor
+    // -----------------------------------------------------------------------
+
+    /// Return the badge expiry-risk view for `user`.
+    ///
+    /// Badge expiry is not configured in this contract's current storage model,
+    /// so the accessor returns `expiry_supported = false`, `risk_bps = 0`, and
+    /// zero expiry counters for every state.
+    pub fn expiry_risk_accessor(env: Env, user: Address) -> ExpiryRiskAccessor {
+        let badges = get_user_minted_badges(&env, &user);
+
+        ExpiryRiskAccessor {
+            user,
+            configured: get_admin(&env).is_some(),
+            expiry_supported: false,
+            held_badges: badges.len(),
+            expiring_badges: 0,
+            expired_badges: 0,
+            nearest_expiry_at: 0,
+            risk_bps: 0,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -476,6 +531,17 @@ mod test {
         let badges = client.get_user_minted_badges(&user);
         assert_eq!(badges.len(), 1);
         assert_eq!(badges.get(0).unwrap(), 1u64);
+
+        let holder = client.holder_summary(&user);
+        assert_eq!(holder.badge_count, 1);
+        assert_eq!(holder.mint_record_count, 1);
+        assert_eq!(holder.total_quantity, 1);
+
+        let risk = client.expiry_risk_accessor(&user);
+        assert!(risk.configured);
+        assert!(!risk.expiry_supported);
+        assert_eq!(risk.held_badges, 1);
+        assert_eq!(risk.risk_bps, 0);
     }
 
     #[test]
@@ -519,6 +585,27 @@ mod test {
         assert_eq!(snapshot.total_minted, 0);
         assert_eq!(snapshot.max_supply, 0);
         assert_eq!(snapshot.remaining_supply, 0);
+    }
+
+    #[test]
+    fn test_holder_summary_and_expiry_risk_empty_user() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+        let user = Address::generate(&env);
+
+        let holder = client.holder_summary(&user);
+        assert!(holder.configured);
+        assert_eq!(holder.badge_count, 0);
+        assert_eq!(holder.mint_record_count, 0);
+        assert_eq!(holder.total_quantity, 0);
+        assert_eq!(holder.last_minted_at, 0);
+
+        let risk = client.expiry_risk_accessor(&user);
+        assert!(risk.configured);
+        assert!(!risk.expiry_supported);
+        assert_eq!(risk.held_badges, 0);
+        assert_eq!(risk.expiring_badges, 0);
+        assert_eq!(risk.expired_badges, 0);
     }
 
     #[test]

--- a/contracts/badge-minter/src/types.rs
+++ b/contracts/badge-minter/src/types.rs
@@ -44,3 +44,36 @@ pub struct UserMintRecord {
     pub minted_at: u64,
     pub quantity: u64,
 }
+
+/// Wallet holder summary for a badge-owning address.
+///
+/// Missing users return zero counts. `last_minted_at` is the largest ledger
+/// sequence in the user's mint records, or 0 when no mints are recorded.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HolderSummary {
+    pub user: Address,
+    pub configured: bool,
+    pub badge_count: u32,
+    pub mint_record_count: u32,
+    pub total_quantity: u64,
+    pub last_minted_at: u64,
+}
+
+/// Expiry-risk read model for a badge-owning address.
+///
+/// Badge definitions currently have no per-badge expiry timestamp, so
+/// `expiry_supported = false` and all risk counters are zero. This explicit
+/// fallback keeps frontend/backend consumers stable until expiries are added.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExpiryRiskAccessor {
+    pub user: Address,
+    pub configured: bool,
+    pub expiry_supported: bool,
+    pub held_badges: u32,
+    pub expiring_badges: u32,
+    pub expired_badges: u32,
+    pub nearest_expiry_at: u64,
+    pub risk_bps: u32,
+}

--- a/contracts/campaign-claims/src/lib.rs
+++ b/contracts/campaign-claims/src/lib.rs
@@ -6,7 +6,10 @@ mod types;
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
-pub use types::{BudgetExhaustion, CampaignRecord, ClaimWindowState, ClaimWindowSummary};
+pub use types::{
+    BudgetExhaustion, CampaignRecord, ClaimSaturationSummary, ClaimWindowState,
+    ClaimWindowSummary, CooldownWindowAccessor,
+};
 
 #[contracttype]
 #[derive(Clone)]
@@ -241,6 +244,85 @@ impl CampaignClaims {
                 && campaign.remaining_budget > 0,
         }
     }
+
+    /// Return a structured claim saturation summary for `campaign_id`.
+    ///
+    /// Saturation uses floor division in basis points:
+    /// `committed_budget * 10_000 / budget`. Unknown ids and unconfigured
+    /// contracts return zero balances with `exists = false`.
+    pub fn claim_saturation_summary(env: Env, campaign_id: u64) -> ClaimSaturationSummary {
+        let summary = Self::claim_window_summary(env.clone(), campaign_id);
+        if !summary.exists {
+            return ClaimSaturationSummary {
+                campaign_id,
+                configured: summary.configured,
+                exists: false,
+                state: summary.state,
+                paused: false,
+                budget: 0,
+                committed_budget: 0,
+                claimed_budget: 0,
+                remaining_budget: 0,
+                pending_claimants: 0,
+                total_claims: 0,
+                saturation_bps: 0,
+                saturated: false,
+            };
+        }
+
+        let campaign = storage::get_campaign(&env, campaign_id)
+            .expect("Campaign summary and storage out of sync");
+        let saturation_bps = saturation_bps(campaign.committed_budget, campaign.budget);
+
+        ClaimSaturationSummary {
+            campaign_id,
+            configured: summary.configured,
+            exists: true,
+            state: summary.state,
+            paused: campaign.paused,
+            budget: campaign.budget,
+            committed_budget: campaign.committed_budget,
+            claimed_budget: campaign.claimed_budget,
+            remaining_budget: campaign.remaining_budget,
+            pending_claimants: campaign.pending_claimants,
+            total_claims: campaign.total_claims,
+            saturation_bps,
+            saturated: campaign.remaining_budget == 0,
+        }
+    }
+
+    /// Return the claim cooldown/window timing for `campaign_id`.
+    ///
+    /// Missing and not-yet-configured campaigns return zero timestamps and
+    /// durations. Paused campaigns keep their configured times but
+    /// `can_record_claims = false`.
+    pub fn cooldown_window_accessor(env: Env, campaign_id: u64) -> CooldownWindowAccessor {
+        let summary = Self::claim_window_summary(env, campaign_id);
+        let seconds_until_open = if summary.state == ClaimWindowState::Scheduled {
+            summary.starts_at.saturating_sub(summary.now)
+        } else {
+            0
+        };
+        let seconds_until_closed = if summary.state == ClaimWindowState::Open {
+            summary.ends_at.saturating_sub(summary.now)
+        } else {
+            0
+        };
+
+        CooldownWindowAccessor {
+            campaign_id,
+            configured: summary.configured,
+            exists: summary.exists,
+            state: summary.state,
+            now: summary.now,
+            starts_at: summary.starts_at,
+            ends_at: summary.ends_at,
+            seconds_until_open,
+            seconds_until_closed,
+            can_record_claims: summary.state == ClaimWindowState::Open
+                && summary.remaining_budget > 0,
+        }
+    }
 }
 
 fn is_configured(env: &Env) -> bool {
@@ -266,6 +348,16 @@ fn read_window_state(now: u64, campaign: &CampaignRecord) -> ClaimWindowState {
         ClaimWindowState::Open
     } else {
         ClaimWindowState::Closed
+    }
+}
+
+fn saturation_bps(committed_budget: i128, budget: i128) -> u32 {
+    if budget <= 0 || committed_budget <= 0 {
+        0
+    } else {
+        let committed = u128::try_from(committed_budget).expect("negative committed");
+        let budget = u128::try_from(budget).expect("negative budget");
+        u32::try_from((committed * 10_000) / budget).expect("bps overflow")
     }
 }
 

--- a/contracts/campaign-claims/src/test.rs
+++ b/contracts/campaign-claims/src/test.rs
@@ -49,6 +49,16 @@ fn claim_window_and_exhaustion_track_success_path() {
     let after_summary = client.claim_window_summary(&7);
     assert_eq!(after_summary.pending_claimants, 0);
     assert_eq!(after_summary.total_claims, 1);
+
+    let saturation = client.claim_saturation_summary(&7);
+    assert_eq!(saturation.saturation_bps, 2_500);
+    assert_eq!(saturation.claimed_budget, 250);
+    assert!(!saturation.saturated);
+
+    let cooldown = client.cooldown_window_accessor(&7);
+    assert_eq!(cooldown.state, ClaimWindowState::Open);
+    assert_eq!(cooldown.seconds_until_open, 0);
+    assert_eq!(cooldown.seconds_until_closed, 150);
 }
 
 #[test]
@@ -74,4 +84,11 @@ fn not_configured_and_missing_campaign_reads_are_predictable() {
     assert_eq!(missing.state, ClaimWindowState::Missing);
     assert_eq!(missing.exhaustion_bps, 0);
     assert!(!missing.can_record_claims);
+
+    let cooldown = client.cooldown_window_accessor(&404);
+    assert!(cooldown.configured);
+    assert!(!cooldown.exists);
+    assert_eq!(cooldown.state, ClaimWindowState::Missing);
+    assert_eq!(cooldown.seconds_until_open, 0);
+    assert_eq!(cooldown.seconds_until_closed, 0);
 }

--- a/contracts/campaign-claims/src/types.rs
+++ b/contracts/campaign-claims/src/types.rs
@@ -60,3 +60,46 @@ pub struct BudgetExhaustion {
     pub exhaustion_bps: u32,
     pub can_record_claims: bool,
 }
+
+/// Campaign budget saturation read model.
+///
+/// `saturation_bps` is floored basis-point math:
+/// `committed_budget * 10_000 / budget`. Missing and unconfigured campaigns
+/// return zero balances and `saturation_bps = 0`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimSaturationSummary {
+    pub campaign_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: ClaimWindowState,
+    pub paused: bool,
+    pub budget: i128,
+    pub committed_budget: i128,
+    pub claimed_budget: i128,
+    pub remaining_budget: i128,
+    pub pending_claimants: u32,
+    pub total_claims: u32,
+    pub saturation_bps: u32,
+    pub saturated: bool,
+}
+
+/// Cooldown and timing read model for a campaign claim window.
+///
+/// `seconds_until_open` is non-zero only before `starts_at`.
+/// `seconds_until_closed` is non-zero only while the window is open.
+/// Missing and unconfigured campaigns return zero timestamps and durations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CooldownWindowAccessor {
+    pub campaign_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: ClaimWindowState,
+    pub now: u64,
+    pub starts_at: u64,
+    pub ends_at: u64,
+    pub seconds_until_open: u64,
+    pub seconds_until_closed: u64,
+    pub can_record_claims: bool,
+}

--- a/contracts/round-finalizer/src/lib.rs
+++ b/contracts/round-finalizer/src/lib.rs
@@ -147,4 +147,120 @@ impl RoundFinalizerContract {
             missing_checkpoint,
         }
     }
+
+    /// Return a dashboard-friendly active round summary.
+    ///
+    /// Active rounds have unresolved operations or lack a checkpoint. Ready
+    /// rounds have zero unresolved operations and a checkpoint. Empty and
+    /// unconfigured states return zero counts.
+    pub fn active_round_summary(env: Env) -> ActiveRoundSummary {
+        let Some(cfg) = get_config(&env) else {
+            return ActiveRoundSummary {
+                status: RoundFinalizerStatus::Unconfigured,
+                total_rounds: 0,
+                active_rounds: 0,
+                ready_rounds: 0,
+                blocked_rounds: 0,
+                unresolved_ops: 0,
+                next_active_round_id: 0,
+            };
+        };
+
+        let ids = get_round_ids(&env);
+        let mut active_rounds = 0u32;
+        let mut ready_rounds = 0u32;
+        let mut blocked_rounds = 0u32;
+        let mut unresolved_ops = 0u32;
+        let mut next_active_round_id = 0u64;
+
+        for round_id in ids.iter() {
+            if let Some(round) = get_round(&env, round_id) {
+                let missing_checkpoint = !round.has_checkpoint;
+                let active = round.unresolved_ops > 0 || missing_checkpoint;
+                if active {
+                    active_rounds = active_rounds.saturating_add(1);
+                    unresolved_ops = unresolved_ops.saturating_add(round.unresolved_ops);
+                    if next_active_round_id == 0 || round.round_id < next_active_round_id {
+                        next_active_round_id = round.round_id;
+                    }
+                } else {
+                    ready_rounds = ready_rounds.saturating_add(1);
+                }
+                if round.unresolved_ops > 0 || missing_checkpoint || cfg.paused {
+                    blocked_rounds = blocked_rounds.saturating_add(1);
+                }
+            }
+        }
+
+        ActiveRoundSummary {
+            status: if cfg.paused {
+                RoundFinalizerStatus::Paused
+            } else {
+                RoundFinalizerStatus::Active
+            },
+            total_rounds: ids.len(),
+            active_rounds,
+            ready_rounds,
+            blocked_rounds,
+            unresolved_ops,
+            next_active_round_id,
+        }
+    }
+
+    /// Return aggregate pressure against round finalization.
+    ///
+    /// Pressure is floored basis-point math over blocked rounds. A paused
+    /// contract marks all stored rounds as blocked; empty state returns zero.
+    pub fn finalization_pressure(env: Env) -> FinalizationPressure {
+        let Some(cfg) = get_config(&env) else {
+            return FinalizationPressure {
+                status: RoundFinalizerStatus::Unconfigured,
+                total_rounds: 0,
+                blocked_rounds: 0,
+                unresolved_ops: 0,
+                missing_checkpoints: 0,
+                pressure_bps: 0,
+                finalization_paused: false,
+            };
+        };
+
+        let ids = get_round_ids(&env);
+        let mut blocked_rounds = 0u32;
+        let mut unresolved_ops = 0u32;
+        let mut missing_checkpoints = 0u32;
+
+        for round_id in ids.iter() {
+            if let Some(round) = get_round(&env, round_id) {
+                let missing_checkpoint = !round.has_checkpoint;
+                if missing_checkpoint {
+                    missing_checkpoints = missing_checkpoints.saturating_add(1);
+                }
+                unresolved_ops = unresolved_ops.saturating_add(round.unresolved_ops);
+                if cfg.paused || round.unresolved_ops > 0 || missing_checkpoint {
+                    blocked_rounds = blocked_rounds.saturating_add(1);
+                }
+            }
+        }
+
+        let total_rounds = ids.len();
+        let pressure_bps = if total_rounds == 0 {
+            0
+        } else {
+            (blocked_rounds * 10_000) / total_rounds
+        };
+
+        FinalizationPressure {
+            status: if cfg.paused {
+                RoundFinalizerStatus::Paused
+            } else {
+                RoundFinalizerStatus::Active
+            },
+            total_rounds,
+            blocked_rounds,
+            unresolved_ops,
+            missing_checkpoints,
+            pressure_bps,
+            finalization_paused: cfg.paused,
+        }
+    }
 }

--- a/contracts/round-finalizer/src/test.rs
+++ b/contracts/round-finalizer/src/test.rs
@@ -26,6 +26,19 @@ fn unresolved_summary_and_readiness_happy_path() {
     assert!(readiness.is_ready);
     assert_eq!(readiness.unresolved_ops, 0);
     assert!(!readiness.missing_checkpoint);
+
+    let active = client.active_round_summary();
+    assert_eq!(active.total_rounds, 2);
+    assert_eq!(active.active_rounds, 1);
+    assert_eq!(active.ready_rounds, 1);
+    assert_eq!(active.blocked_rounds, 1);
+    assert_eq!(active.next_active_round_id, 10);
+
+    let pressure = client.finalization_pressure();
+    assert_eq!(pressure.total_rounds, 2);
+    assert_eq!(pressure.blocked_rounds, 1);
+    assert_eq!(pressure.unresolved_ops, 2);
+    assert_eq!(pressure.pressure_bps, 5_000);
 }
 
 #[test]
@@ -41,4 +54,12 @@ fn unresolved_summary_unconfigured_and_missing_round() {
     let readiness = client.get_finalize_readiness(&99);
     assert!(!readiness.is_ready);
     assert!(readiness.missing_checkpoint);
+
+    let active = client.active_round_summary();
+    assert_eq!(active.total_rounds, 0);
+    assert_eq!(active.active_rounds, 0);
+
+    let pressure = client.finalization_pressure();
+    assert_eq!(pressure.total_rounds, 0);
+    assert_eq!(pressure.pressure_bps, 0);
 }

--- a/contracts/round-finalizer/src/types.rs
+++ b/contracts/round-finalizer/src/types.rs
@@ -45,6 +45,40 @@ pub struct FinalizeReadiness {
     pub missing_checkpoint: bool,
 }
 
+/// Aggregate active-round read model for dashboard consumers.
+///
+/// A round is considered active while it has unresolved operations or is
+/// missing its finalization checkpoint. Empty and unconfigured contracts return
+/// zero counts with a non-active status.
+#[contracttype]
+#[derive(Clone)]
+pub struct ActiveRoundSummary {
+    pub status: RoundFinalizerStatus,
+    pub total_rounds: u32,
+    pub active_rounds: u32,
+    pub ready_rounds: u32,
+    pub blocked_rounds: u32,
+    pub unresolved_ops: u32,
+    pub next_active_round_id: u64,
+}
+
+/// Finalization pressure read model.
+///
+/// `pressure_bps` is floored basis-point math:
+/// `blocked_rounds * 10_000 / total_rounds`. Empty, missing, and unconfigured
+/// states return `pressure_bps = 0`.
+#[contracttype]
+#[derive(Clone)]
+pub struct FinalizationPressure {
+    pub status: RoundFinalizerStatus,
+    pub total_rounds: u32,
+    pub blocked_rounds: u32,
+    pub unresolved_ops: u32,
+    pub missing_checkpoints: u32,
+    pub pressure_bps: u32,
+    pub finalization_paused: bool,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {

--- a/contracts/vault-claims/src/lib.rs
+++ b/contracts/vault-claims/src/lib.rs
@@ -5,13 +5,17 @@ mod types;
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
-pub use types::{ClaimState, OutstandingClaimSummary, ReleaseWindow, VaultClaim};
+pub use types::{
+    ClaimState, OutstandingClaimSummary, ReleaseQueueAccessor, ReleaseWindow,
+    ReserveExposureSnapshot, VaultClaim,
+};
 
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
     Claim(u64),
+    ClaimIds,
     OutstandingCount,
     OutstandingAmount,
     ReleasedCount,
@@ -62,6 +66,7 @@ impl VaultClaims {
                 cancelled: false,
             },
         );
+        storage::append_claim_id(&env, claim_id);
         bump_outstanding(&env, 1, amount);
     }
 
@@ -164,6 +169,95 @@ impl VaultClaims {
             release_after: claim.release_after,
             now,
             seconds_until_releasable,
+        }
+    }
+
+    /// Return reserve exposure based on aggregate claim counters.
+    ///
+    /// `exposure_bps` is floored basis-point math over all tracked claim
+    /// amounts. Empty and unconfigured vaults return zero exposure.
+    pub fn reserve_exposure_snapshot(env: Env) -> ReserveExposureSnapshot {
+        let outstanding_amount = storage::read_i128(&env, &DataKey::OutstandingAmount);
+        let released_amount = storage::read_i128(&env, &DataKey::ReleasedAmount);
+        let cancelled_amount = storage::read_i128(&env, &DataKey::CancelledAmount);
+        let total_tracked_amount = outstanding_amount
+            .saturating_add(released_amount)
+            .saturating_add(cancelled_amount);
+        let exposure_bps = if total_tracked_amount <= 0 || outstanding_amount <= 0 {
+            0
+        } else {
+            let outstanding = u128::try_from(outstanding_amount).expect("negative outstanding");
+            let total = u128::try_from(total_tracked_amount).expect("negative total");
+            u32::try_from((outstanding * 10_000) / total).expect("bps overflow")
+        };
+
+        ReserveExposureSnapshot {
+            configured: env.storage().instance().has(&DataKey::Admin),
+            outstanding_count: storage::read_u32(&env, &DataKey::OutstandingCount),
+            outstanding_amount,
+            released_amount,
+            cancelled_amount,
+            total_tracked_amount,
+            exposure_bps,
+            now: env.ledger().timestamp(),
+        }
+    }
+
+    /// Return the current release queue aggregate.
+    ///
+    /// Claims registered before the queue index existed are still reflected in
+    /// `reserve_exposure_snapshot`; this queue accessor reports the indexed
+    /// subset and falls back to zeros for empty or unconfigured state.
+    pub fn release_queue_accessor(env: Env) -> ReleaseQueueAccessor {
+        let now = env.ledger().timestamp();
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        if !configured {
+            return ReleaseQueueAccessor {
+                configured: false,
+                indexed_claims: 0,
+                pending_count: 0,
+                pending_amount: 0,
+                releasable_count: 0,
+                releasable_amount: 0,
+                next_release_after: 0,
+                now,
+            };
+        }
+
+        let ids = storage::get_claim_ids(&env);
+        let mut pending_count = 0u32;
+        let mut pending_amount = 0i128;
+        let mut releasable_count = 0u32;
+        let mut releasable_amount = 0i128;
+        let mut next_release_after = 0u64;
+
+        for claim_id in ids.iter() {
+            if let Some(claim) = storage::get_claim(&env, claim_id) {
+                if claim.released || claim.cancelled {
+                    continue;
+                }
+                if now >= claim.release_after {
+                    releasable_count = releasable_count.saturating_add(1);
+                    releasable_amount = releasable_amount.saturating_add(claim.amount);
+                } else {
+                    pending_count = pending_count.saturating_add(1);
+                    pending_amount = pending_amount.saturating_add(claim.amount);
+                    if next_release_after == 0 || claim.release_after < next_release_after {
+                        next_release_after = claim.release_after;
+                    }
+                }
+            }
+        }
+
+        ReleaseQueueAccessor {
+            configured,
+            indexed_claims: ids.len(),
+            pending_count,
+            pending_amount,
+            releasable_count,
+            releasable_amount,
+            next_release_after,
+            now,
         }
     }
 }
@@ -292,6 +386,11 @@ mod test {
         assert_eq!(s.released_amount, 100);
         assert_eq!(s.cancelled_count, 1);
         assert_eq!(s.cancelled_amount, 50);
+
+        let exposure = client.reserve_exposure_snapshot();
+        assert_eq!(exposure.outstanding_amount, 200);
+        assert_eq!(exposure.total_tracked_amount, 350);
+        assert_eq!(exposure.exposure_bps, 5_714);
     }
 
     #[test]
@@ -309,14 +408,43 @@ mod test {
         let (env, admin, client) = setup();
         let _bene = register(&env, &client, &admin, 1, 100, 5_000);
 
+        let queue = client.release_queue_accessor();
+        assert_eq!(queue.pending_count, 1);
+        assert_eq!(queue.pending_amount, 100);
+        assert_eq!(queue.releasable_count, 0);
+        assert_eq!(queue.next_release_after, 5_000);
+
         let pending = client.release_window(&1u64);
         assert_eq!(pending.state, ClaimState::Pending);
         assert_eq!(pending.seconds_until_releasable, 4_000);
 
         env.ledger().set_timestamp(6_000);
+        let queue = client.release_queue_accessor();
+        assert_eq!(queue.pending_count, 0);
+        assert_eq!(queue.releasable_count, 1);
+        assert_eq!(queue.releasable_amount, 100);
+
         let open = client.release_window(&1u64);
         assert_eq!(open.state, ClaimState::Releasable);
         assert_eq!(open.seconds_until_releasable, 0);
+    }
+
+    #[test]
+    fn reserve_exposure_and_queue_unconfigured_are_zero() {
+        let env = Env::default();
+        let contract_id = env.register(VaultClaims, ());
+        let client = VaultClaimsClient::new(&env, &contract_id);
+
+        let exposure = client.reserve_exposure_snapshot();
+        assert_eq!(exposure.configured, false);
+        assert_eq!(exposure.total_tracked_amount, 0);
+        assert_eq!(exposure.exposure_bps, 0);
+
+        let queue = client.release_queue_accessor();
+        assert_eq!(queue.configured, false);
+        assert_eq!(queue.indexed_claims, 0);
+        assert_eq!(queue.pending_count, 0);
+        assert_eq!(queue.releasable_count, 0);
     }
 
     #[test]

--- a/contracts/vault-claims/src/storage.rs
+++ b/contracts/vault-claims/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::types::VaultClaim;
 use crate::DataKey;
-use soroban_sdk::Env;
+use soroban_sdk::{Env, Vec};
 
 pub fn set_claim(env: &Env, claim: &VaultClaim) {
     env.storage()
@@ -10,6 +10,19 @@ pub fn set_claim(env: &Env, claim: &VaultClaim) {
 
 pub fn get_claim(env: &Env, claim_id: u64) -> Option<VaultClaim> {
     env.storage().persistent().get(&DataKey::Claim(claim_id))
+}
+
+pub fn get_claim_ids(env: &Env) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ClaimIds)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn append_claim_id(env: &Env, claim_id: u64) {
+    let mut ids = get_claim_ids(env);
+    ids.push_back(claim_id);
+    env.storage().persistent().set(&DataKey::ClaimIds, &ids);
 }
 
 pub fn read_u32(env: &Env, key: &DataKey) -> u32 {

--- a/contracts/vault-claims/src/types.rs
+++ b/contracts/vault-claims/src/types.rs
@@ -61,3 +61,39 @@ pub struct ReleaseWindow {
     /// Seconds remaining until the claim becomes releasable (0 once open).
     pub seconds_until_releasable: u64,
 }
+
+/// Reserve exposure snapshot backed by existing aggregate counters.
+///
+/// `exposure_bps` is floored as
+/// `outstanding_amount * 10_000 / total_tracked_amount`. Empty and
+/// unconfigured vaults return `exposure_bps = 0`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReserveExposureSnapshot {
+    pub configured: bool,
+    pub outstanding_count: u32,
+    pub outstanding_amount: i128,
+    pub released_amount: i128,
+    pub cancelled_amount: i128,
+    pub total_tracked_amount: i128,
+    pub exposure_bps: u32,
+    pub now: u64,
+}
+
+/// Aggregate release queue read model.
+///
+/// `pending_amount` includes outstanding claims whose release window has not
+/// opened. `releasable_amount` includes outstanding claims whose window is
+/// open. Empty, unconfigured, and pre-index records return zero queue values.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReleaseQueueAccessor {
+    pub configured: bool,
+    pub indexed_claims: u32,
+    pub pending_count: u32,
+    pub pending_amount: i128,
+    pub releasable_count: u32,
+    pub releasable_amount: i128,
+    pub next_release_after: u64,
+    pub now: u64,
+}


### PR DESCRIPTION
closes #769 - Adds reserve exposure and release queue accessors for vault claims.
Provides structured zero-state responses and queue aggregates for pending and releasable claims.

closes #770 - Adds claim saturation summary and cooldown-window accessor for campaign claims.
Reports budget saturation, window timing, missing campaign fallback, and claim availability.

closes #771 - Adds holder summary and expiry-risk accessor for badge minter.
Returns wallet badge ownership totals and an explicit no-expiry-supported risk fallback.

closes #772 - Adds active round summary and finalization-pressure accessor for round finalizer.
Summarizes active, ready, and blocked rounds with pressure basis points for finalization tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only query methods across multiple contracts to expose aggregated state and metrics:
    * Badge-Minter: `holder_summary` and `expiry_risk_accessor` for badge holdings and expiry tracking
    * Campaign-Claims: `claim_saturation_summary` and `cooldown_window_accessor` for budget and claim-window insights
    * Round-Finalizer: `active_round_summary` and `finalization_pressure` for round and operation status
    * Vault-Claims: `reserve_exposure_snapshot` and `release_queue_accessor` for vault exposure and release queue visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->