### PR TITLE
Add frontend empty states and contract health snapshots

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2000,6 +2000,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-asset-escrow-v3"
+version = "0.3.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-attendance-pass"
 version = "0.1.0"
 dependencies = [
@@ -2327,6 +2334,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-guild-progress"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-guild-season"
 version = "0.1.0"
 dependencies = [
@@ -2561,6 +2575,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-reward-stream"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-reward-unlocker"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/contracts/fanout-distributor/src/lib.rs
+++ b/contracts/fanout-distributor/src/lib.rs
@@ -5,7 +5,12 @@ mod types;
 
 use soroban_sdk::{contract, contractimpl, contracttype, Env};
 
-pub use types::{BatchProgressSummary, BatchRecord, BatchStatus, RetryableFailure};
+pub use types::{
+    BatchHealthBand, BatchHealthSnapshot, BatchProgressSummary, BatchRecord, BatchStatus, RetryGap,
+    RetryableFailure,
+};
+
+const DEFAULT_RETRY_GAP_LEDGERS: u32 = 120;
 
 #[contracttype]
 #[derive(Clone)]
@@ -155,6 +160,148 @@ impl FanoutDistributor {
             now,
         }
     }
+
+    /// Return a structured health snapshot for one payout batch.
+    ///
+    /// Missing batch ids are not errors. They return `exists = false`,
+    /// zeroed amounts, and either `Missing` or `NotConfigured` depending on
+    /// whether the contract has been initialized. `progress_bps` is floored
+    /// basis-point math and returns zero when `total_amount <= 0`.
+    pub fn batch_health_snapshot(env: Env, batch_id: u64) -> BatchHealthSnapshot {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+
+        let Some(record) = storage::get_batch(&env, batch_id) else {
+            return BatchHealthSnapshot {
+                batch_id,
+                configured,
+                exists: false,
+                status: if configured {
+                    BatchStatus::Pending
+                } else {
+                    BatchStatus::NotConfigured
+                },
+                health_band: if configured {
+                    BatchHealthBand::Missing
+                } else {
+                    BatchHealthBand::NotConfigured
+                },
+                total_amount: 0,
+                distributed_amount: 0,
+                remaining_amount: 0,
+                recipient_count: 0,
+                progress_bps: 0,
+                failed: false,
+            };
+        };
+
+        let status = batch_status(&record);
+        let remaining_amount = (record.total_amount - record.distributed_amount).max(0);
+
+        BatchHealthSnapshot {
+            batch_id,
+            configured,
+            exists: true,
+            status: status.clone(),
+            health_band: batch_health_band(&record, &status),
+            total_amount: record.total_amount,
+            distributed_amount: record.distributed_amount,
+            remaining_amount,
+            recipient_count: record.recipient_count,
+            progress_bps: batch_progress_bps(record.total_amount, record.distributed_amount),
+            failed: record.failed,
+        }
+    }
+
+    /// Return the retry gap for a payout batch using ledger-based fallback math.
+    ///
+    /// The current storage model does not persist a failure timestamp, so failed
+    /// batches use `current_ledger + retry_gap_ledgers` as a conservative
+    /// `retry_after_ledger` until a mutation path records richer retry history.
+    /// Completed, healthy, missing, and not-configured states return gap zero
+    /// and `can_retry = false`.
+    pub fn retry_gap(env: Env, batch_id: u64) -> RetryGap {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        let current_ledger = env.ledger().sequence();
+
+        let Some(record) = storage::get_batch(&env, batch_id) else {
+            return RetryGap {
+                batch_id,
+                configured,
+                exists: false,
+                status: if configured {
+                    BatchStatus::Pending
+                } else {
+                    BatchStatus::NotConfigured
+                },
+                failed: false,
+                retry_gap_ledgers: 0,
+                retry_after_ledger: 0,
+                current_ledger,
+                can_retry: false,
+            };
+        };
+
+        let status = batch_status(&record);
+        let retry_gap_ledgers = if record.failed && !record.completed {
+            DEFAULT_RETRY_GAP_LEDGERS
+        } else {
+            0
+        };
+        let retry_after_ledger = if retry_gap_ledgers > 0 {
+            current_ledger.saturating_add(retry_gap_ledgers)
+        } else {
+            0
+        };
+
+        RetryGap {
+            batch_id,
+            configured,
+            exists: true,
+            status,
+            failed: record.failed,
+            retry_gap_ledgers,
+            retry_after_ledger,
+            current_ledger,
+            can_retry: record.failed && !record.completed,
+        }
+    }
+}
+
+fn batch_status(record: &BatchRecord) -> BatchStatus {
+    if record.completed {
+        BatchStatus::Completed
+    } else if record.failed {
+        BatchStatus::Pending
+    } else if record.distributed_amount > 0 {
+        BatchStatus::InProgress
+    } else {
+        BatchStatus::Pending
+    }
+}
+
+fn batch_health_band(record: &BatchRecord, status: &BatchStatus) -> BatchHealthBand {
+    if record.completed {
+        return BatchHealthBand::Completed;
+    }
+
+    if record.failed {
+        return BatchHealthBand::Failed;
+    }
+
+    if *status == BatchStatus::InProgress {
+        BatchHealthBand::Partial
+    } else {
+        BatchHealthBand::Healthy
+    }
+}
+
+fn batch_progress_bps(total_amount: i128, distributed_amount: i128) -> u32 {
+    if total_amount <= 0 || distributed_amount <= 0 {
+        return 0;
+    }
+
+    let distributed = distributed_amount.min(total_amount);
+    ((distributed * 10_000) / total_amount) as u32
 }
 
 #[cfg(test)]
@@ -162,31 +309,39 @@ mod test {
     use super::*;
     use soroban_sdk::testutils::Address as _;
 
+    fn setup(env: &Env) -> (FanoutDistributorClient<'_>, soroban_sdk::Address) {
+        let admin = soroban_sdk::Address::generate(env);
+        let contract_id = env.register(FanoutDistributor, ());
+        let client = FanoutDistributorClient::new(env, &contract_id);
+        env.mock_all_auths();
+        (client, admin)
+    }
+
     #[test]
     fn test_init() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::random(&env);
-        FanoutDistributor::init(env.clone(), admin);
+        let (client, admin) = setup(&env);
+        client.init(&admin);
     }
 
     #[test]
     fn test_batch_lifecycle() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::random(&env);
+        let (client, admin) = setup(&env);
 
-        FanoutDistributor::init(env.clone(), admin.clone());
-        FanoutDistributor::create_batch(env.clone(), admin.clone(), 1, 1000, 5);
+        client.init(&admin);
+        client.create_batch(&admin, &1, &1000, &5);
 
-        let summary = FanoutDistributor::batch_progress_summary(env.clone());
+        let summary = client.batch_progress_summary();
         assert_eq!(summary.total_batches, 1);
         assert_eq!(summary.pending_batches, 1);
 
-        FanoutDistributor::distribute(env.clone(), admin.clone(), 1, 500);
-        let summary = FanoutDistributor::batch_progress_summary(env.clone());
+        client.distribute(&admin, &1, &500);
+        let summary = client.batch_progress_summary();
         assert_eq!(summary.total_distributed, 500);
 
-        FanoutDistributor::complete_batch(env.clone(), admin, 1);
-        let summary = FanoutDistributor::batch_progress_summary(env);
+        client.complete_batch(&admin, &1);
+        let summary = client.batch_progress_summary();
         assert_eq!(summary.completed_batches, 1);
         assert_eq!(summary.pending_batches, 0);
     }
@@ -194,11 +349,52 @@ mod test {
     #[test]
     fn test_retryable_failure_missing() {
         let env = Env::default();
-        let admin = soroban_sdk::Address::random(&env);
-        FanoutDistributor::init(env.clone(), admin);
+        let (client, admin) = setup(&env);
+        client.init(&admin);
 
-        let failure = FanoutDistributor::retryable_failure(env, 999);
+        let failure = client.retryable_failure(&999);
         assert_eq!(failure.exists, false);
         assert_eq!(failure.configured, true);
+    }
+
+    #[test]
+    fn test_batch_health_snapshot_and_retry_gap_failed_batch() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+
+        client.init(&admin);
+        client.create_batch(&admin, &7, &1_000, &4);
+        client.distribute(&admin, &7, &250);
+        client.mark_failed(&admin, &7);
+
+        let snapshot = client.batch_health_snapshot(&7);
+        assert_eq!(snapshot.exists, true);
+        assert_eq!(snapshot.health_band, BatchHealthBand::Failed);
+        assert_eq!(snapshot.remaining_amount, 750);
+        assert_eq!(snapshot.progress_bps, 2_500);
+
+        let gap = client.retry_gap(&7);
+        assert_eq!(gap.exists, true);
+        assert_eq!(gap.failed, true);
+        assert_eq!(gap.retry_gap_ledgers, DEFAULT_RETRY_GAP_LEDGERS);
+        assert_eq!(gap.retry_after_ledger, gap.current_ledger + DEFAULT_RETRY_GAP_LEDGERS);
+        assert_eq!(gap.can_retry, true);
+    }
+
+    #[test]
+    fn test_batch_health_snapshot_missing_state() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+
+        let snapshot = client.batch_health_snapshot(&404);
+        assert_eq!(snapshot.configured, false);
+        assert_eq!(snapshot.exists, false);
+        assert_eq!(snapshot.health_band, BatchHealthBand::NotConfigured);
+        assert_eq!(snapshot.progress_bps, 0);
+
+        let gap = client.retry_gap(&404);
+        assert_eq!(gap.exists, false);
+        assert_eq!(gap.can_retry, false);
+        assert_eq!(gap.retry_gap_ledgers, 0);
     }
 }

--- a/contracts/fanout-distributor/src/types.rs
+++ b/contracts/fanout-distributor/src/types.rs
@@ -43,3 +43,44 @@ pub struct RetryableFailure {
     pub distributed_amount: i128,
     pub now: u64,
 }
+
+#[contracttype]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum BatchHealthBand {
+    NotConfigured,
+    Missing,
+    Healthy,
+    Partial,
+    Failed,
+    Completed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BatchHealthSnapshot {
+    pub batch_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub status: BatchStatus,
+    pub health_band: BatchHealthBand,
+    pub total_amount: i128,
+    pub distributed_amount: i128,
+    pub remaining_amount: i128,
+    pub recipient_count: u32,
+    pub progress_bps: u32,
+    pub failed: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RetryGap {
+    pub batch_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub status: BatchStatus,
+    pub failed: bool,
+    pub retry_gap_ledgers: u32,
+    pub retry_after_ledger: u32,
+    pub current_ledger: u32,
+    pub can_retry: bool,
+}

--- a/contracts/reward-stream/src/lib.rs
+++ b/contracts/reward-stream/src/lib.rs
@@ -7,7 +7,9 @@ mod types;
 #[cfg(test)]
 mod test;
 
-pub use types::{StreamData, StreamHealthSummary, WithdrawalReadiness};
+pub use types::{
+    DepletionBand, StreamData, StreamHealthSummary, StreamPressureSnapshot, WithdrawalReadiness,
+};
 
 #[contract]
 pub struct RewardStream;
@@ -94,5 +96,82 @@ impl RewardStream {
                 blocked_reason_code: 4,
             }
         }
+    }
+
+    /// Return stream pressure and depletion state for the configured stream.
+    ///
+    /// `pressure_bps` uses floored basis-point math:
+    /// `min(total_withdrawn, total_allocated) * 10_000 / total_allocated`.
+    /// Missing, empty, or non-positive allocations return a zero pressure and
+    /// `DepletionBand::NotConfigured` so consumers can render a predictable
+    /// zero state without treating it as an error.
+    pub fn stream_pressure_snapshot(env: Env) -> StreamPressureSnapshot {
+        if let Some(s) = storage::get_stream(&env) {
+            let remaining = (s.total_allocated - s.total_withdrawn).max(0);
+            let pressure_bps = pressure_bps(s.total_allocated, s.total_withdrawn);
+            let depletion_band = depletion_band_for(&s, remaining);
+
+            StreamPressureSnapshot {
+                is_configured: s.total_allocated > 0,
+                stream_id: s.stream_id,
+                total_allocated: s.total_allocated,
+                total_withdrawn: s.total_withdrawn,
+                remaining,
+                pressure_bps,
+                depletion_band,
+                paused: s.paused,
+            }
+        } else {
+            StreamPressureSnapshot {
+                is_configured: false,
+                stream_id: 0,
+                total_allocated: 0,
+                total_withdrawn: 0,
+                remaining: 0,
+                pressure_bps: 0,
+                depletion_band: DepletionBand::NotConfigured,
+                paused: false,
+            }
+        }
+    }
+
+    /// Return only the depletion band from `stream_pressure_snapshot`.
+    ///
+    /// This accessor is intentionally narrow for UI badge reads. Missing or
+    /// not-yet-configured state returns `DepletionBand::NotConfigured`.
+    pub fn depletion_band(env: Env) -> DepletionBand {
+        Self::stream_pressure_snapshot(env).depletion_band
+    }
+}
+
+fn pressure_bps(total_allocated: i128, total_withdrawn: i128) -> u32 {
+    if total_allocated <= 0 || total_withdrawn <= 0 {
+        return 0;
+    }
+
+    let withdrawn = total_withdrawn.min(total_allocated);
+    ((withdrawn * 10_000) / total_allocated) as u32
+}
+
+fn depletion_band_for(stream: &StreamData, remaining: i128) -> DepletionBand {
+    if stream.total_allocated <= 0 {
+        return DepletionBand::NotConfigured;
+    }
+
+    if stream.paused {
+        return DepletionBand::Paused;
+    }
+
+    if remaining <= 0 {
+        return DepletionBand::Depleted;
+    }
+
+    let remaining_bps = ((remaining * 10_000) / stream.total_allocated) as u32;
+    if remaining_bps <= 1_000 {
+        DepletionBand::Critical
+    } else if remaining_bps <= 2_500 {
+        DepletionBand::Watch
+    } else {
+        DepletionBand::Stable
     }
 }

--- a/contracts/reward-stream/src/test.rs
+++ b/contracts/reward-stream/src/test.rs
@@ -2,7 +2,7 @@ extern crate std;
 
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
-use crate::{RewardStream, RewardStreamClient};
+use crate::{DepletionBand, RewardStream, RewardStreamClient};
 
 #[test]
 fn stream_health_and_readiness_success_path() {
@@ -35,4 +35,38 @@ fn readiness_reports_missing_state() {
     let readiness = client.withdrawal_readiness(&10);
     assert!(!readiness.is_ready);
     assert_eq!(readiness.blocked_reason_code, 4);
+}
+
+#[test]
+fn stream_pressure_snapshot_reports_depletion_band() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    client.configure_stream(&admin, &27, &1_000, &800, &0, &false);
+
+    let snapshot = client.stream_pressure_snapshot();
+    assert!(snapshot.is_configured);
+    assert_eq!(snapshot.stream_id, 27);
+    assert_eq!(snapshot.remaining, 200);
+    assert_eq!(snapshot.pressure_bps, 8_000);
+    assert_eq!(snapshot.depletion_band, DepletionBand::Watch);
+    assert_eq!(client.depletion_band(), DepletionBand::Watch);
+}
+
+#[test]
+fn stream_pressure_snapshot_missing_is_predictable_zero_state() {
+    let env = Env::default();
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+
+    let snapshot = client.stream_pressure_snapshot();
+    assert!(!snapshot.is_configured);
+    assert_eq!(snapshot.stream_id, 0);
+    assert_eq!(snapshot.remaining, 0);
+    assert_eq!(snapshot.pressure_bps, 0);
+    assert_eq!(snapshot.depletion_band, DepletionBand::NotConfigured);
 }

--- a/contracts/reward-stream/src/types.rs
+++ b/contracts/reward-stream/src/types.rs
@@ -31,3 +31,27 @@ pub struct WithdrawalReadiness {
     pub claimable_now: i128,
     pub blocked_reason_code: u32,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DepletionBand {
+    NotConfigured,
+    Paused,
+    Stable,
+    Watch,
+    Critical,
+    Depleted,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamPressureSnapshot {
+    pub is_configured: bool,
+    pub stream_id: u64,
+    pub total_allocated: i128,
+    pub total_withdrawn: i128,
+    pub remaining: i128,
+    pub pressure_bps: u32,
+    pub depletion_band: DepletionBand,
+    pub paused: bool,
+}

--- a/frontend/src/components/v1/BalanceHealthBadge.css
+++ b/frontend/src/components/v1/BalanceHealthBadge.css
@@ -1,0 +1,7 @@
+.balance-health-badge {
+  flex-shrink: 0;
+}
+
+.balance-health-badge--unknown {
+  opacity: 0.82;
+}

--- a/frontend/src/components/v1/BalanceHealthBadge.tsx
+++ b/frontend/src/components/v1/BalanceHealthBadge.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { StatusPill, type StatusPillTone } from "./StatusPill";
+import "./BalanceHealthBadge.css";
+
+export type BalanceHealth = "healthy" | "low" | "empty" | "unknown" | "loading";
+
+export interface BalanceHealthBadgeProps {
+  balance?: number | null;
+  loading?: boolean;
+  lowBalanceThreshold?: number;
+  testId?: string;
+}
+
+export interface BalanceHealthMeta {
+  health: BalanceHealth;
+  label: string;
+  tone: StatusPillTone;
+  ariaLabel: string;
+}
+
+export function getBalanceHealthMeta({
+  balance,
+  loading = false,
+  lowBalanceThreshold = 10,
+}: BalanceHealthBadgeProps): BalanceHealthMeta {
+  if (loading) {
+    return {
+      health: "loading",
+      label: "Checking",
+      tone: "pending",
+      ariaLabel: "Balance health: checking",
+    };
+  }
+
+  if (balance === null || balance === undefined || Number.isNaN(balance)) {
+    return {
+      health: "unknown",
+      label: "Unknown",
+      tone: "neutral",
+      ariaLabel: "Balance health: unknown",
+    };
+  }
+
+  if (balance <= 0) {
+    return {
+      health: "empty",
+      label: "Empty",
+      tone: "error",
+      ariaLabel: "Balance health: empty",
+    };
+  }
+
+  if (balance < lowBalanceThreshold) {
+    return {
+      health: "low",
+      label: "Low",
+      tone: "warning",
+      ariaLabel: "Balance health: low",
+    };
+  }
+
+  return {
+    health: "healthy",
+    label: "Healthy",
+    tone: "success",
+    ariaLabel: "Balance health: healthy",
+  };
+}
+
+export const BalanceHealthBadge: React.FC<BalanceHealthBadgeProps> = ({
+  balance,
+  loading = false,
+  lowBalanceThreshold = 10,
+  testId = "balance-health-badge",
+}) => {
+  const meta = getBalanceHealthMeta({ balance, loading, lowBalanceThreshold });
+
+  return (
+    <StatusPill
+      tone={meta.tone}
+      label={meta.label}
+      size="compact"
+      className={`balance-health-badge balance-health-badge--${meta.health}`}
+      testId={testId}
+      ariaLabel={meta.ariaLabel}
+    />
+  );
+};
+
+BalanceHealthBadge.displayName = "BalanceHealthBadge";
+
+export default BalanceHealthBadge;

--- a/frontend/src/components/v1/ContractEventFeed.tsx
+++ b/frontend/src/components/v1/ContractEventFeed.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useContractEvents } from '../../hooks/v1/useContractEvents';
 import { ErrorNotice } from './ErrorNotice';
 import { EmptyStateBlock } from './EmptyStateBlock';
+import { EmptyResultCallout } from './EmptyResultCallout';
 import { StatusPill } from './StatusPill';
 import type { TimelineItemData } from './Timeline';
 import { toAppError } from '../../utils/v1/errorMapper';
@@ -470,6 +471,35 @@ export const ContractEventFeed: React.FC<ContractEventFeedProps> = ({
       .map((filter) => filter.value);
   }, [eventTypeFilters, persistFilters, persistedActiveFilters]);
 
+  const activeFilterLabels = useMemo(() => {
+    const labels: string[] = [];
+
+    if (eventTypeFilter?.trim()) {
+      labels.push(`type: ${eventTypeFilter.trim()}`);
+    }
+
+    if (contractSourceFilter?.trim()) {
+      labels.push(`source: ${contractSourceFilter.trim().slice(0, 10)}`);
+    }
+
+    if (timeWindowMs !== undefined && timeWindowMs > 0) {
+      labels.push(`window: ${Math.round(timeWindowMs / 1000)}s`);
+    }
+
+    currentActiveFilters.forEach((value) => {
+      const match = eventTypeFilters?.find((filter) => filter.value === value);
+      labels.push(match?.label ?? value);
+    });
+
+    return labels;
+  }, [
+    contractSourceFilter,
+    currentActiveFilters,
+    eventTypeFilter,
+    eventTypeFilters,
+    timeWindowMs,
+  ]);
+
   /**
    * Persistence-aware filter toggle handler.
    * When persistFilters=true, updates internal persisted state and writes to
@@ -578,6 +608,12 @@ export const ContractEventFeed: React.FC<ContractEventFeedProps> = ({
     setRecentFilters([]);
   }, [resolvedScope]);
 
+  const handleClearResultFilters = useCallback(() => {
+    if (currentActiveFilters.length > 0) {
+      applyPresetValues([]);
+    }
+  }, [applyPresetValues, currentActiveFilters.length]);
+
   const handleDensityChange = useCallback(
     (nextDensity: TableDensityPreference) => {
       setDensity(nextDensity);
@@ -600,6 +636,10 @@ export const ContractEventFeed: React.FC<ContractEventFeedProps> = ({
           Math.max(0, (currentPage - 1) * pageSize),
           Math.max(0, (currentPage - 1) * pageSize) + pageSize,
         );
+  const hasRawEvents = Array.isArray(rawEvents) && rawEvents.length > 0;
+  const hasActiveResultFilters = activeFilterLabels.length > 0;
+  const hasFilteredOutResults =
+    hasRawEvents && filteredEvents.length === 0 && hasActiveResultFilters;
 
   const shouldVirtualize =
     renderedEvents.length >= virtualizationThreshold &&
@@ -1015,16 +1055,29 @@ export const ContractEventFeed: React.FC<ContractEventFeedProps> = ({
         </>
       ) : (
         !mappedError && (
-          <EmptyStateBlock
-            icon={isListening ? 'radio' : 'pause'}
-            title={isListening ? 'Listening for events...' : 'Feed paused'}
-            description={
-              isListening
-                ? 'Events will appear here as they are emitted by the contract.'
-                : 'Press Resume to start receiving contract events.'
-            }
-            testId={`${testId}-empty`}
-          />
+          hasFilteredOutResults ? (
+            <EmptyResultCallout
+              title="No events match these filters"
+              activeFilters={activeFilterLabels}
+              onClear={
+                currentActiveFilters.length > 0
+                  ? handleClearResultFilters
+                  : undefined
+              }
+              testId={`${testId}-empty-results`}
+            />
+          ) : (
+            <EmptyStateBlock
+              icon={isListening ? 'radio' : 'pause'}
+              title={isListening ? 'Listening for events...' : 'Feed paused'}
+              description={
+                isListening
+                  ? 'Events will appear here as they are emitted by the contract.'
+                  : 'Press Resume to start receiving contract events.'
+              }
+              testId={`${testId}-empty`}
+            />
+          )
         )
       )}
     </section>

--- a/frontend/src/components/v1/EmptyResultCallout.css
+++ b/frontend/src/components/v1/EmptyResultCallout.css
@@ -1,0 +1,4 @@
+.empty-result-callout {
+  min-height: 180px;
+  padding-block: 2rem;
+}

--- a/frontend/src/components/v1/EmptyResultCallout.tsx
+++ b/frontend/src/components/v1/EmptyResultCallout.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { EmptyStateBlock } from "./EmptyStateBlock";
+import type { EmptyStateAction } from "./EmptyStateBlock.types";
+import "./EmptyResultCallout.css";
+
+export interface EmptyResultCalloutProps {
+  title?: string;
+  query?: string | null;
+  activeFilters?: string[];
+  onClear?: () => void;
+  clearLabel?: string;
+  disabled?: boolean;
+  testId?: string;
+}
+
+function buildDescription(query?: string | null, activeFilters: string[] = []) {
+  const parts: string[] = [];
+  const trimmedQuery = query?.trim();
+
+  if (trimmedQuery) {
+    parts.push(`search "${trimmedQuery}"`);
+  }
+
+  if (activeFilters.length > 0) {
+    parts.push(`${activeFilters.length} active filter${activeFilters.length === 1 ? "" : "s"}`);
+  }
+
+  if (parts.length === 0) {
+    return "No items match the current search or filter state.";
+  }
+
+  return `No items match ${parts.join(" and ")}.`;
+}
+
+export const EmptyResultCallout: React.FC<EmptyResultCalloutProps> = ({
+  title = "No matching results",
+  query,
+  activeFilters = [],
+  onClear,
+  clearLabel = "Clear filters",
+  disabled = false,
+  testId = "empty-result-callout",
+}) => {
+  const actions: EmptyStateAction[] =
+    onClear !== undefined
+      ? [
+          {
+            label: clearLabel,
+            onClick: onClear,
+            variant: "primary",
+            disabled,
+          },
+        ]
+      : [];
+
+  return (
+    <EmptyStateBlock
+      variant="no-results"
+      icon="search"
+      title={title}
+      description={buildDescription(query, activeFilters)}
+      actions={actions}
+      className="empty-result-callout"
+      testId={testId}
+    />
+  );
+};
+
+EmptyResultCallout.displayName = "EmptyResultCallout";
+
+export default EmptyResultCallout;

--- a/frontend/src/components/v1/WalletBalanceDeltaCards.css
+++ b/frontend/src/components/v1/WalletBalanceDeltaCards.css
@@ -11,13 +11,21 @@
   background: rgba(12, 18, 30, 0.9);
 }
 
+.wallet-balance-delta-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  min-height: 1.65rem;
+}
+
 .wallet-balance-delta-card__title {
-  margin: 0 0 0.35rem;
+  margin: 0;
   font-size: 0.9rem;
 }
 
 .wallet-balance-delta-card__amount {
-  margin: 0 0 0.4rem;
+  margin: 0.35rem 0 0.4rem;
   font-size: 1.25rem;
   font-weight: 700;
   color: #7de2d1;

--- a/frontend/src/components/v1/WalletBalanceDeltaCards.tsx
+++ b/frontend/src/components/v1/WalletBalanceDeltaCards.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { BalanceHealthBadge } from "./BalanceHealthBadge";
 import { InlineStatDelta } from "./InlineStatDelta";
 import "./WalletBalanceDeltaCards.css";
 
@@ -41,7 +42,14 @@ function ComparisonCard({
   const delta = balanceDelta(balance);
   return (
     <article className="wallet-balance-delta-card" data-testid={testId}>
-      <h3 className="wallet-balance-delta-card__title">{balance.label}</h3>
+      <div className="wallet-balance-delta-card__header">
+        <h3 className="wallet-balance-delta-card__title">{balance.label}</h3>
+        <BalanceHealthBadge
+          balance={balance.currentBalance}
+          loading={loading}
+          testId={`${testId}-health`}
+        />
+      </div>
       <p className="wallet-balance-delta-card__amount">
         {loading ? "Loading..." : formatBalance(balance.currentBalance)}
       </p>

--- a/frontend/src/components/v1/index.ts
+++ b/frontend/src/components/v1/index.ts
@@ -75,6 +75,23 @@ export type {
   StatusPillSize,
 } from "./StatusPill";
 
+export {
+  BalanceHealthBadge,
+  default as BalanceHealthBadgeDefault,
+  getBalanceHealthMeta,
+} from "./BalanceHealthBadge";
+export type {
+  BalanceHealth,
+  BalanceHealthBadgeProps,
+  BalanceHealthMeta,
+} from "./BalanceHealthBadge";
+
+export {
+  EmptyResultCallout,
+  default as EmptyResultCalloutDefault,
+} from "./EmptyResultCallout";
+export type { EmptyResultCalloutProps } from "./EmptyResultCallout";
+
 export { AsyncStateBoundary } from "./AsyncStateBoundary";
 export type { AsyncStateBoundaryProps } from "./AsyncStateBoundary";
 

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { EmptyStateBlock } from "../components/v1/EmptyStateBlock";
+import { BalanceHealthBadge } from "../components/v1/BalanceHealthBadge";
 import { CampaignRewardsSpotlightCard } from "../components/v1/CampaignRewardsSpotlightCard";
 import { PinnedWalletActionTray } from "../components/v1/PinnedWalletActionTray";
 import {
@@ -130,36 +131,76 @@ export const Portfolio: React.FC<PortfolioProps> = ({
   onBrowseRewards,
   onBrowseCollectibles,
 }) => {
-  const walletSnapshot = state.wallet.items[0] ?? {
-    availableBalance: 0,
-    networkLabel: "Wallet",
-  };
-  const walletIsEmpty = walletSnapshot.availableBalance <= 0;
-  const walletContent = walletIsEmpty ? (
-    <EmptyStateBlock
-      testId="portfolio-wallet-empty"
-      icon="W"
-      title="Your wallet balance is still at zero"
-      description="Fund your wallet to join paid matches, claim drops, and unlock balance-aware actions."
-      actions={[
-        {
-          label: "Open wallet tools",
-          onClick: onOpenWallet ?? (() => {}),
-          variant: "primary",
-        },
-      ]}
-    />
+  const walletSnapshot = state.wallet.items[0];
+  const walletBalance = walletSnapshot?.availableBalance ?? null;
+  const walletIsMissing = walletSnapshot === undefined;
+  const walletIsEmpty = walletBalance !== null && walletBalance <= 0;
+  const walletContent = walletIsMissing ? (
+    <div
+      className="portfolio-page__content-card"
+      data-testid="portfolio-wallet-missing"
+    >
+      <div className="portfolio-page__content-header">
+        <BalanceHealthBadge
+          balance={null}
+          testId="portfolio-wallet-health"
+        />
+        <span>Wallet</span>
+      </div>
+      <EmptyStateBlock
+        testId="portfolio-wallet-missing-empty"
+        icon="W"
+        title="Wallet balance is unavailable"
+        description="Reconnect or refresh your wallet before using balance-aware actions."
+        actions={[
+          {
+            label: "Open wallet tools",
+            onClick: onOpenWallet ?? (() => {}),
+            variant: "primary",
+          },
+        ]}
+      />
+    </div>
+  ) : walletIsEmpty ? (
+    <div
+      className="portfolio-page__content-card"
+      data-testid="portfolio-wallet-zero"
+    >
+      <div className="portfolio-page__content-header">
+        <BalanceHealthBadge
+          balance={walletBalance}
+          testId="portfolio-wallet-health"
+        />
+        <span>{walletSnapshot?.networkLabel ?? "Wallet"}</span>
+      </div>
+      <EmptyStateBlock
+        testId="portfolio-wallet-empty"
+        icon="W"
+        title="Your wallet balance is still at zero"
+        description="Fund your wallet to join paid matches, claim drops, and unlock balance-aware actions."
+        actions={[
+          {
+            label: "Open wallet tools",
+            onClick: onOpenWallet ?? (() => {}),
+            variant: "primary",
+          },
+        ]}
+      />
+    </div>
   ) : (
     <div
       className="portfolio-page__content-card"
       data-testid="portfolio-wallet-populated"
     >
       <div className="portfolio-page__content-header">
-        <StatusPill tone="success" label="Funded" size="compact" />
-        <span>{walletSnapshot.networkLabel}</span>
+        <BalanceHealthBadge
+          balance={walletBalance}
+          testId="portfolio-wallet-health"
+        />
+        <span>{walletSnapshot?.networkLabel ?? "Wallet"}</span>
       </div>
       <strong className="portfolio-page__metric">
-        {walletSnapshot.availableBalance.toFixed(2)} XLM
+        {walletBalance?.toFixed(2) ?? "—"} XLM
       </strong>
       <p className="portfolio-page__copy">
         Available now for deposits, game entries, and marketplace settlement

--- a/frontend/tests/components/Portfolio.test.tsx
+++ b/frontend/tests/components/Portfolio.test.tsx
@@ -34,6 +34,9 @@ describe("Portfolio page", () => {
   it("renders distinct empty states for wallet, rewards, and collectibles", () => {
     renderPortfolio();
     expect(screen.getByTestId("portfolio-wallet-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("portfolio-wallet-health")).toHaveTextContent(
+      "Empty",
+    );
     expect(screen.getByTestId("portfolio-rewards-empty")).toBeInTheDocument();
     expect(
       screen.getByTestId("portfolio-collectibles-empty"),
@@ -121,6 +124,9 @@ describe("Portfolio page", () => {
     expect(
       screen.getByTestId("portfolio-wallet-populated"),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("portfolio-wallet-health")).toHaveTextContent(
+      "Healthy",
+    );
     expect(
       screen.getByTestId("portfolio-rewards-populated"),
     ).toBeInTheDocument();
@@ -163,5 +169,19 @@ describe("Portfolio page", () => {
 
     expect(screen.getByTestId("campaign-rewards-spotlight")).toBeInTheDocument();
     expect(screen.getByTestId("pinned-wallet-action-tray")).toBeInTheDocument();
+  });
+
+  it("renders an explicit missing wallet-balance fallback", () => {
+    renderPortfolio({
+      wallet: {
+        status: "ready",
+        items: [],
+      },
+    });
+
+    expect(screen.getByTestId("portfolio-wallet-missing")).toBeInTheDocument();
+    expect(screen.getByTestId("portfolio-wallet-health")).toHaveTextContent(
+      "Unknown",
+    );
   });
 });

--- a/frontend/tests/components/WalletBalanceDeltaCards.test.tsx
+++ b/frontend/tests/components/WalletBalanceDeltaCards.test.tsx
@@ -14,6 +14,8 @@ describe("WalletBalanceDeltaCards", () => {
     expect(screen.getByTestId("wallet-balance-delta-cards-left")).toBeInTheDocument();
     expect(screen.getByTestId("wallet-balance-delta-cards-right")).toBeInTheDocument();
     expect(screen.getByText("100.00 XLM")).toBeInTheDocument();
+    expect(screen.getByTestId("wallet-balance-delta-cards-left-health")).toHaveTextContent("Healthy");
+    expect(screen.getByTestId("wallet-balance-delta-cards-right-health")).toHaveTextContent("Healthy");
   });
 
   it("renders fallback content when balances are missing", () => {
@@ -25,5 +27,18 @@ describe("WalletBalanceDeltaCards", () => {
     );
 
     expect(screen.getAllByText("—").length).toBeGreaterThan(1);
+    expect(screen.getAllByText("Unknown")).toHaveLength(2);
+  });
+
+  it("shows checking badges while balances are loading", () => {
+    render(
+      <WalletBalanceDeltaCards
+        loading
+        left={{ id: "left", label: "Primary", currentBalance: 100, previousBalance: 80 }}
+        right={{ id: "right", label: "Secondary", currentBalance: 2, previousBalance: 3 }}
+      />,
+    );
+
+    expect(screen.getAllByText("Checking")).toHaveLength(2);
   });
 });

--- a/frontend/tests/components/v1/BalanceHealthBadge.test.tsx
+++ b/frontend/tests/components/v1/BalanceHealthBadge.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  BalanceHealthBadge,
+  getBalanceHealthMeta,
+} from "../../../src/components/v1/BalanceHealthBadge";
+
+describe("BalanceHealthBadge", () => {
+  it("renders healthy balance state", () => {
+    render(<BalanceHealthBadge balance={25} />);
+
+    expect(screen.getByTestId("balance-health-badge")).toHaveTextContent("Healthy");
+    expect(screen.getByTestId("balance-health-badge")).toHaveAttribute(
+      "data-tone",
+      "success",
+    );
+  });
+
+  it("renders fallback states for loading and missing balances", () => {
+    const loading = getBalanceHealthMeta({ loading: true });
+    const unknown = getBalanceHealthMeta({ balance: null });
+
+    expect(loading.health).toBe("loading");
+    expect(loading.label).toBe("Checking");
+    expect(unknown.health).toBe("unknown");
+    expect(unknown.label).toBe("Unknown");
+  });
+});

--- a/frontend/tests/components/v1/ContractEventFeed.test.tsx
+++ b/frontend/tests/components/v1/ContractEventFeed.test.tsx
@@ -193,6 +193,18 @@ describe('ContractEventFeed - filters', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows reusable empty-result callout when filters hide available events', () => {
+    mockEvents = [makeEvent({ id: 'e1', type: 'dice_roll' })];
+    renderFeed({ eventTypeFilter: 'coin_flip' });
+
+    expect(
+      screen.getByTestId('contract-event-feed-empty-results'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('empty-title')).toHaveTextContent(
+      /no events match these filters/i,
+    );
+  });
+
   it('filters by contractSourceFilter', () => {
     mockEvents = [
       makeEvent({ id: 'e1', contractId: 'CAAA' }),

--- a/frontend/tests/components/v1/EmptyResultCallout.test.tsx
+++ b/frontend/tests/components/v1/EmptyResultCallout.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EmptyResultCallout } from "../../../src/components/v1/EmptyResultCallout";
+
+describe("EmptyResultCallout", () => {
+  it("summarizes search and filter empty results", () => {
+    render(
+      <EmptyResultCallout
+        query="coin"
+        activeFilters={["status: active", "network: testnet"]}
+      />,
+    );
+
+    expect(screen.getByTestId("empty-result-callout")).toBeInTheDocument();
+    expect(screen.getByText("No matching results")).toBeInTheDocument();
+    expect(screen.getByText(/search "coin"/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 active filters/i)).toBeInTheDocument();
+  });
+
+  it("supports a disabled clear action for blocked fallback states", () => {
+    const onClear = vi.fn();
+    render(<EmptyResultCallout onClear={onClear} disabled />);
+
+    const action = screen.getByTestId("empty-result-callout-action-0");
+    expect(action).toBeDisabled();
+    fireEvent.click(action);
+    expect(onClear).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
closes #784 - Adds reusable balance health badges for wallet summary rows.
Covers healthy, low, empty, loading, and missing balance states.

closes #792 - Adds a reusable empty-result callout for search and filter states.
Wires it into filtered contract event results with fallback coverage.

closes #775 - Adds stream pressure snapshot and depletion-band accessors.
Returns structured zero-state data for missing or not-yet-configured streams.

closes #773 - Adds batch health snapshot and retry-gap accessors.
Covers failed batch retry metadata and predictable missing-state reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wallet balance health indicators now display in Portfolio with Healthy/Low/Empty/Unknown statuses
  * New contract queries provide stream depletion band and pressure metrics for reward monitoring
  * New contract queries enable batch health snapshots and retry gap tracking for payouts
  * Event feeds now distinguish empty vs. filtered results with contextual messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->