### PR TITLE
feat: lobby-gates & perk-claims accessors + compact metadata stack & queue pulse

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2398,6 +2398,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-lobby-gates"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-loot-crate"
 version = "0.1.0"
 dependencies = [
@@ -2484,6 +2491,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-penalty-slashing"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-perk-claims"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,6 +15,8 @@ members = [
     "creator-vaults",
     "grant-ledger",
     "mission-checkins",
+    "lobby-gates",
+    "perk-claims",
     "achievement-badge",
     "ai-generated-game",
     "badge-minter",

--- a/contracts/lobby-gates/Cargo.toml
+++ b/contracts/lobby-gates/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-lobby-gates"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/lobby-gates/src/lib.rs
+++ b/contracts/lobby-gates/src/lib.rs
@@ -1,0 +1,132 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+pub mod storage;
+pub mod types;
+
+#[cfg(test)]
+mod test;
+
+use crate::storage::{get_gate, has_entered, mark_entered, set_gate};
+use crate::types::{Gate, GateStatusSnapshot, ReleaseDelay};
+
+#[contract]
+pub struct LobbyGates;
+
+#[contractimpl]
+impl LobbyGates {
+    /// Configures a new gate with a capacity and a release time. Panics if it
+    /// already exists.
+    pub fn configure_gate(env: Env, id: u64, capacity: u32, release_time: u64) {
+        if capacity == 0 {
+            panic!("capacity must be positive");
+        }
+        if get_gate(&env, id).is_some() {
+            panic!("gate already exists");
+        }
+
+        set_gate(
+            &env,
+            id,
+            &Gate {
+                id,
+                capacity,
+                occupancy: 0,
+                release_time,
+                is_paused: false,
+            },
+        );
+    }
+
+    /// Admits a player once the gate is open (released and not paused) and has
+    /// remaining capacity. Idempotent per player — re-entering is a no-op.
+    pub fn enter(env: Env, id: u64, player: Address) {
+        player.require_auth();
+
+        let mut gate = get_gate(&env, id).expect("gate not found");
+        if gate.is_paused {
+            panic!("gate is paused");
+        }
+        if env.ledger().timestamp() < gate.release_time {
+            panic!("gate is not released yet");
+        }
+        if gate.occupancy >= gate.capacity {
+            panic!("gate is full");
+        }
+        if has_entered(&env, id, player.clone()) {
+            return;
+        }
+
+        gate.occupancy += 1;
+        set_gate(&env, id, &gate);
+        mark_entered(&env, id, player);
+    }
+
+    /// Pauses or unpauses a gate.
+    pub fn set_paused(env: Env, id: u64, paused: bool) {
+        let mut gate = get_gate(&env, id).expect("gate not found");
+        gate.is_paused = paused;
+        set_gate(&env, id, &gate);
+    }
+
+    /// Gate status snapshot; predictable zero-state when the gate is missing.
+    pub fn gate_status(env: Env, id: u64) -> GateStatusSnapshot {
+        let now = env.ledger().timestamp();
+
+        match get_gate(&env, id) {
+            Some(g) => {
+                let is_full = g.occupancy >= g.capacity;
+                let is_open = !g.is_paused && now >= g.release_time;
+                let remaining_slots = g.capacity.saturating_sub(g.occupancy);
+                GateStatusSnapshot {
+                    gate_exists: true,
+                    capacity: g.capacity,
+                    occupancy: g.occupancy,
+                    remaining_slots,
+                    is_open,
+                    is_paused: g.is_paused,
+                    is_full,
+                }
+            }
+            None => GateStatusSnapshot {
+                gate_exists: false,
+                capacity: 0,
+                occupancy: 0,
+                remaining_slots: 0,
+                is_open: false,
+                is_paused: false,
+                is_full: false,
+            },
+        }
+    }
+
+    /// Time remaining until a gate releases.
+    pub fn release_delay(env: Env, id: u64) -> ReleaseDelay {
+        let now = env.ledger().timestamp();
+
+        match get_gate(&env, id) {
+            Some(g) => {
+                let is_released = now >= g.release_time;
+                let seconds_until_release = if is_released {
+                    0
+                } else {
+                    g.release_time - now
+                };
+                ReleaseDelay {
+                    gate_exists: true,
+                    release_time: g.release_time,
+                    current_time: now,
+                    seconds_until_release,
+                    is_released,
+                }
+            }
+            None => ReleaseDelay {
+                gate_exists: false,
+                release_time: 0,
+                current_time: now,
+                seconds_until_release: 0,
+                is_released: false,
+            },
+        }
+    }
+}

--- a/contracts/lobby-gates/src/storage.rs
+++ b/contracts/lobby-gates/src/storage.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::types::Gate;
+
+#[contracttype]
+pub enum DataKey {
+    Gate(u64),
+    /// Tracks whether a player has already entered a gate (prevents double-count).
+    Entrant(u64, Address),
+}
+
+pub fn get_gate(env: &Env, id: u64) -> Option<Gate> {
+    env.storage().persistent().get(&DataKey::Gate(id))
+}
+
+pub fn set_gate(env: &Env, id: u64, gate: &Gate) {
+    env.storage().persistent().set(&DataKey::Gate(id), gate);
+}
+
+pub fn has_entered(env: &Env, id: u64, player: Address) -> bool {
+    env.storage().persistent().has(&DataKey::Entrant(id, player))
+}
+
+pub fn mark_entered(env: &Env, id: u64, player: Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Entrant(id, player), &true);
+}

--- a/contracts/lobby-gates/src/test.rs
+++ b/contracts/lobby-gates/src/test.rs
@@ -1,0 +1,77 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::Env;
+
+fn setup() -> (Env, LobbyGatesClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, LobbyGates);
+    let client = LobbyGatesClient::new(&env, &contract_id);
+    (env, client)
+}
+
+#[test]
+fn status_and_release_delay_track_time() {
+    let (env, client) = setup();
+    client.configure_gate(&1, &3, &100);
+
+    // Before release.
+    let status = client.gate_status(&1);
+    assert!(status.gate_exists);
+    assert!(!status.is_open);
+    assert_eq!(status.remaining_slots, 3);
+
+    let delay = client.release_delay(&1);
+    assert!(!delay.is_released);
+    assert_eq!(delay.seconds_until_release, 100);
+
+    // After release.
+    env.ledger().with_mut(|li| li.timestamp = 150);
+    assert!(client.gate_status(&1).is_open);
+    assert!(client.release_delay(&1).is_released);
+    assert_eq!(client.release_delay(&1).seconds_until_release, 0);
+}
+
+#[test]
+fn entry_fills_capacity_and_is_idempotent() {
+    let (env, client) = setup();
+    client.configure_gate(&1, &2, &100);
+    env.ledger().with_mut(|li| li.timestamp = 200);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.enter(&1, &alice);
+    client.enter(&1, &alice); // re-entry is a no-op
+    client.enter(&1, &bob);
+
+    let status = client.gate_status(&1);
+    assert_eq!(status.occupancy, 2);
+    assert_eq!(status.remaining_slots, 0);
+    assert!(status.is_full);
+}
+
+#[test]
+#[should_panic(expected = "gate is not released yet")]
+fn entry_before_release_is_rejected() {
+    let (env, client) = setup();
+    client.configure_gate(&1, &2, &100);
+    let alice = Address::generate(&env);
+    // time 0 < release 100
+    client.enter(&1, &alice);
+}
+
+#[test]
+fn missing_gate_returns_predictable_state() {
+    let (_env, client) = setup();
+
+    let status = client.gate_status(&99);
+    assert!(!status.gate_exists);
+    assert!(!status.is_open);
+    assert_eq!(status.capacity, 0);
+
+    let delay = client.release_delay(&99);
+    assert!(!delay.gate_exists);
+    assert!(!delay.is_released);
+}

--- a/contracts/lobby-gates/src/types.rs
+++ b/contracts/lobby-gates/src/types.rs
@@ -1,0 +1,38 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Gate {
+    pub id: u64,
+    pub capacity: u32,
+    pub occupancy: u32,
+    /// Ledger time at/after which the gate releases (admits players).
+    pub release_time: u64,
+    pub is_paused: bool,
+}
+
+/// Point-in-time status of a lobby gate.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GateStatusSnapshot {
+    pub gate_exists: bool,
+    pub capacity: u32,
+    pub occupancy: u32,
+    pub remaining_slots: u32,
+    /// Released (release_time reached) and not paused.
+    pub is_open: bool,
+    pub is_paused: bool,
+    pub is_full: bool,
+}
+
+/// Time remaining until a gate releases.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseDelay {
+    pub gate_exists: bool,
+    pub release_time: u64,
+    pub current_time: u64,
+    /// Seconds until release (0 once released).
+    pub seconds_until_release: u64,
+    pub is_released: bool,
+}

--- a/contracts/perk-claims/Cargo.toml
+++ b/contracts/perk-claims/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-perk-claims"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/perk-claims/src/lib.rs
+++ b/contracts/perk-claims/src/lib.rs
@@ -1,0 +1,133 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+pub mod storage;
+pub mod types;
+
+#[cfg(test)]
+mod test;
+
+use crate::storage::{
+    get_perk, has_claimed, is_queued, mark_claimed, mark_queued, set_perk,
+};
+use crate::types::{ClaimQueueSnapshot, Perk, ThresholdGap};
+
+#[contract]
+pub struct PerkClaims;
+
+#[contractimpl]
+impl PerkClaims {
+    /// Configures a perk with the queue threshold that must be reached before
+    /// claims unlock. Panics if the perk already exists.
+    pub fn configure_perk(env: Env, id: u64, threshold: u32) {
+        if get_perk(&env, id).is_some() {
+            panic!("perk already exists");
+        }
+
+        set_perk(
+            &env,
+            id,
+            &Perk {
+                id,
+                threshold,
+                queued_count: 0,
+                claimed_count: 0,
+                is_active: true,
+            },
+        );
+    }
+
+    /// Adds the caller to the perk's claim queue. Idempotent per user.
+    pub fn queue_claim(env: Env, id: u64, user: Address) {
+        user.require_auth();
+
+        let mut perk = get_perk(&env, id).expect("perk not found");
+        if !perk.is_active {
+            panic!("perk is not active");
+        }
+        if is_queued(&env, id, user.clone()) {
+            return;
+        }
+
+        perk.queued_count += 1;
+        set_perk(&env, id, &perk);
+        mark_queued(&env, id, user);
+    }
+
+    /// Claims the perk. Requires the threshold to be met, the caller to be
+    /// queued, and not to have already claimed.
+    pub fn claim(env: Env, id: u64, user: Address) {
+        user.require_auth();
+
+        let mut perk = get_perk(&env, id).expect("perk not found");
+        if !perk.is_active {
+            panic!("perk is not active");
+        }
+        if perk.queued_count < perk.threshold {
+            panic!("claim threshold not met");
+        }
+        if !is_queued(&env, id, user.clone()) {
+            panic!("caller is not queued");
+        }
+        if has_claimed(&env, id, user.clone()) {
+            panic!("already claimed");
+        }
+
+        perk.claimed_count += 1;
+        set_perk(&env, id, &perk);
+        mark_claimed(&env, id, user);
+    }
+
+    /// Claim queue snapshot; predictable zero-state when the perk is missing.
+    pub fn claim_queue_snapshot(env: Env, id: u64) -> ClaimQueueSnapshot {
+        match get_perk(&env, id) {
+            Some(p) => ClaimQueueSnapshot {
+                perk_exists: true,
+                threshold: p.threshold,
+                queued_count: p.queued_count,
+                claimed_count: p.claimed_count,
+                is_threshold_met: p.queued_count >= p.threshold,
+            },
+            None => ClaimQueueSnapshot {
+                perk_exists: false,
+                threshold: 0,
+                queued_count: 0,
+                claimed_count: 0,
+                is_threshold_met: false,
+            },
+        }
+    }
+
+    /// Remaining gap to the claim threshold, plus progress in basis points.
+    pub fn threshold_gap(env: Env, id: u64) -> ThresholdGap {
+        match get_perk(&env, id) {
+            Some(p) => {
+                let gap = p.threshold.saturating_sub(p.queued_count);
+                let progress_bps: u32 = if p.threshold == 0 {
+                    10_000
+                } else {
+                    let raw = (p.queued_count as u64 * 10_000) / p.threshold as u64;
+                    if raw > 10_000 {
+                        10_000
+                    } else {
+                        raw as u32
+                    }
+                };
+                ThresholdGap {
+                    perk_exists: true,
+                    threshold: p.threshold,
+                    queued_count: p.queued_count,
+                    gap,
+                    progress_bps,
+                }
+            }
+            None => ThresholdGap {
+                perk_exists: false,
+                threshold: 0,
+                queued_count: 0,
+                gap: 0,
+                progress_bps: 0,
+            },
+        }
+    }
+}

--- a/contracts/perk-claims/src/storage.rs
+++ b/contracts/perk-claims/src/storage.rs
@@ -1,0 +1,38 @@
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::types::Perk;
+
+#[contracttype]
+pub enum DataKey {
+    Perk(u64),
+    Queued(u64, Address),
+    Claimed(u64, Address),
+}
+
+pub fn get_perk(env: &Env, id: u64) -> Option<Perk> {
+    env.storage().persistent().get(&DataKey::Perk(id))
+}
+
+pub fn set_perk(env: &Env, id: u64, perk: &Perk) {
+    env.storage().persistent().set(&DataKey::Perk(id), perk);
+}
+
+pub fn is_queued(env: &Env, id: u64, user: Address) -> bool {
+    env.storage().persistent().has(&DataKey::Queued(id, user))
+}
+
+pub fn mark_queued(env: &Env, id: u64, user: Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Queued(id, user), &true);
+}
+
+pub fn has_claimed(env: &Env, id: u64, user: Address) -> bool {
+    env.storage().persistent().has(&DataKey::Claimed(id, user))
+}
+
+pub fn mark_claimed(env: &Env, id: u64, user: Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Claimed(id, user), &true);
+}

--- a/contracts/perk-claims/src/test.rs
+++ b/contracts/perk-claims/src/test.rs
@@ -1,0 +1,74 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Env;
+
+fn setup() -> (Env, PerkClaimsClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PerkClaims);
+    let client = PerkClaimsClient::new(&env, &contract_id);
+    (env, client)
+}
+
+#[test]
+fn queue_then_claim_when_threshold_met() {
+    let (env, client) = setup();
+    client.configure_perk(&1, &2);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.queue_claim(&1, &alice);
+    client.queue_claim(&1, &alice); // idempotent
+    let snap = client.claim_queue_snapshot(&1);
+    assert_eq!(snap.queued_count, 1);
+    assert!(!snap.is_threshold_met);
+    assert_eq!(client.threshold_gap(&1).gap, 1);
+    assert_eq!(client.threshold_gap(&1).progress_bps, 5_000);
+
+    client.queue_claim(&1, &bob);
+    let snap = client.claim_queue_snapshot(&1);
+    assert_eq!(snap.queued_count, 2);
+    assert!(snap.is_threshold_met);
+    assert_eq!(client.threshold_gap(&1).gap, 0);
+    assert_eq!(client.threshold_gap(&1).progress_bps, 10_000);
+
+    client.claim(&1, &alice);
+    assert_eq!(client.claim_queue_snapshot(&1).claimed_count, 1);
+}
+
+#[test]
+#[should_panic(expected = "claim threshold not met")]
+fn claim_before_threshold_is_rejected() {
+    let (env, client) = setup();
+    client.configure_perk(&1, &3);
+    let alice = Address::generate(&env);
+    client.queue_claim(&1, &alice);
+    client.claim(&1, &alice);
+}
+
+#[test]
+#[should_panic(expected = "caller is not queued")]
+fn claim_without_queueing_is_rejected() {
+    let (env, client) = setup();
+    client.configure_perk(&1, &1);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.queue_claim(&1, &alice); // meets threshold of 1
+    client.claim(&1, &bob); // bob never queued
+}
+
+#[test]
+fn missing_perk_returns_predictable_state() {
+    let (_env, client) = setup();
+
+    let snap = client.claim_queue_snapshot(&42);
+    assert!(!snap.perk_exists);
+    assert_eq!(snap.queued_count, 0);
+    assert!(!snap.is_threshold_met);
+
+    let gap = client.threshold_gap(&42);
+    assert!(!gap.perk_exists);
+    assert_eq!(gap.gap, 0);
+}

--- a/contracts/perk-claims/src/types.rs
+++ b/contracts/perk-claims/src/types.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Perk {
+    pub id: u64,
+    /// Number of queued claimants required before claiming unlocks.
+    pub threshold: u32,
+    pub queued_count: u32,
+    pub claimed_count: u32,
+    pub is_active: bool,
+}
+
+/// Point-in-time view of a perk's claim queue.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimQueueSnapshot {
+    pub perk_exists: bool,
+    pub threshold: u32,
+    pub queued_count: u32,
+    pub claimed_count: u32,
+    pub is_threshold_met: bool,
+}
+
+/// How far the queue is from unlocking claims.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThresholdGap {
+    pub perk_exists: bool,
+    pub threshold: u32,
+    pub queued_count: u32,
+    /// Additional queued claimants still needed (0 once met).
+    pub gap: u32,
+    /// Progress toward the threshold in basis points (0..10_000), integer floor.
+    pub progress_bps: u32,
+}

--- a/frontend/src/components/v1/CompactMetadataStack.tsx
+++ b/frontend/src/components/v1/CompactMetadataStack.tsx
@@ -1,0 +1,142 @@
+import { type ReactNode } from "react";
+
+export interface MetadataItem {
+  id: string;
+  label: string;
+  value: ReactNode;
+  /** Optional native title/tooltip for the value (e.g. a full hash). */
+  title?: string;
+}
+
+export interface CompactMetadataStackProps {
+  items: MetadataItem[];
+  /** Render loading skeletons instead of values. */
+  loading?: boolean;
+  /** Shown when there are no items and not loading. */
+  emptyMessage?: string;
+  /** Tighter spacing for very dense panels. */
+  dense?: boolean;
+  /** Accessible label for the metadata list. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * A compact label/value metadata stack for overview panels. Renders a semantic
+ * definition list (`<dl>`), with explicit loading and empty states.
+ */
+export function CompactMetadataStack({
+  items,
+  loading = false,
+  emptyMessage = "No details available",
+  dense = false,
+  ariaLabel = "Details",
+  className = "",
+}: CompactMetadataStackProps) {
+  const rowGap = dense ? "0.25rem" : "0.5rem";
+
+  if (!loading && items.length === 0) {
+    return (
+      <p
+        className={`compact-metadata-stack ${className}`}
+        role="note"
+        style={styles.empty}
+      >
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  if (loading) {
+    const count = Math.max(items.length, 3);
+    return (
+      <dl
+        className={`compact-metadata-stack ${className}`}
+        aria-label={ariaLabel}
+        aria-busy="true"
+        style={{ ...styles.list, rowGap }}
+      >
+        {Array.from({ length: count }).map((_, i) => (
+          <div key={i} style={styles.row} data-testid="metadata-skeleton">
+            <dt style={styles.label}>
+              <span style={styles.skeletonLabel} aria-hidden="true" />
+            </dt>
+            <dd style={styles.value}>
+              <span style={styles.skeletonValue} aria-hidden="true" />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+
+  return (
+    <dl
+      className={`compact-metadata-stack ${className}`}
+      aria-label={ariaLabel}
+      style={{ ...styles.list, rowGap }}
+    >
+      {items.map((item) => (
+        <div key={item.id} style={styles.row}>
+          <dt style={styles.label}>{item.label}</dt>
+          <dd style={styles.value} title={item.title}>
+            {item.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles (inline — avoids CSS class collisions in mixed codebases)
+// ---------------------------------------------------------------------------
+const styles = {
+  list: {
+    display: "flex",
+    flexDirection: "column" as const,
+    margin: 0,
+  },
+  row: {
+    display: "flex",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: "1rem",
+  },
+  label: {
+    flexShrink: 0,
+    fontSize: "0.75rem",
+    color: "#64748b",
+    margin: 0,
+  },
+  value: {
+    margin: 0,
+    minWidth: 0,
+    textAlign: "right" as const,
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "#0f172a",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+  },
+  empty: {
+    margin: 0,
+    fontSize: "0.8125rem",
+    color: "#94a3b8",
+  },
+  skeletonLabel: {
+    display: "block",
+    width: "4rem",
+    height: "0.6rem",
+    borderRadius: "0.25rem",
+    backgroundColor: "#e2e8f0",
+  },
+  skeletonValue: {
+    display: "block",
+    width: "3rem",
+    height: "0.6rem",
+    borderRadius: "0.25rem",
+    backgroundColor: "#cbd5e1",
+  },
+} as const;

--- a/frontend/src/components/v1/QueuePulseIndicator.tsx
+++ b/frontend/src/components/v1/QueuePulseIndicator.tsx
@@ -1,0 +1,154 @@
+export type QueueStatus = "live" | "idle" | "paused" | "offline";
+
+export interface QueuePulseIndicatorProps {
+  /** Number of players currently queued. */
+  count?: number;
+  /** Explicit status; defaults to "live" when count > 0, otherwise "idle". */
+  status?: QueueStatus;
+  /** Visible label (e.g. the surface name). */
+  label?: string;
+  loading?: boolean;
+  className?: string;
+}
+
+const STATUS_META: Record<QueueStatus, { color: string; text: string }> = {
+  live: { color: "#22c55e", text: "Live" },
+  idle: { color: "#94a3b8", text: "Idle" },
+  paused: { color: "#f59e0b", text: "Paused" },
+  offline: { color: "#ef4444", text: "Offline" },
+};
+
+const KEYFRAMES = `
+@keyframes sc-queue-pulse {
+  0% { transform: scale(1); opacity: 0.9; }
+  50% { transform: scale(2.2); opacity: 0; }
+  100% { transform: scale(1); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sc-queue-pulse-ring { animation: none !important; }
+}
+`;
+
+/**
+ * A live queue-pulse indicator for multiplayer entry surfaces. Shows a status
+ * dot (pulsing while the queue is live and non-empty), the queued count, and a
+ * label. Announces queue changes via an `aria-live` status region; honors
+ * reduced-motion and renders explicit loading / empty / offline states.
+ */
+export function QueuePulseIndicator({
+  count,
+  status,
+  label = "Queue",
+  loading = false,
+  className = "",
+}: QueuePulseIndicatorProps) {
+  const resolvedCount = count ?? 0;
+  const resolvedStatus: QueueStatus =
+    status ?? (resolvedCount > 0 ? "live" : "idle");
+  const meta = STATUS_META[resolvedStatus];
+  const isPulsing = resolvedStatus === "live" && resolvedCount > 0;
+
+  if (loading) {
+    return (
+      <div
+        className={`queue-pulse-indicator ${className}`}
+        role="status"
+        aria-busy="true"
+        aria-label={`${label} loading`}
+        style={styles.root}
+      >
+        <span style={styles.skeletonDot} aria-hidden="true" />
+        <span style={styles.skeletonText} aria-hidden="true" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`queue-pulse-indicator ${className}`}
+      role="status"
+      aria-live="polite"
+      aria-label={`${label}: ${meta.text}, ${resolvedCount} in queue`}
+      style={styles.root}
+    >
+      <style>{KEYFRAMES}</style>
+      <span style={styles.dotWrap} aria-hidden="true">
+        {isPulsing && (
+          <span
+            className="sc-queue-pulse-ring"
+            style={{
+              ...styles.ring,
+              backgroundColor: meta.color,
+              animation: "sc-queue-pulse 1.6s ease-out infinite",
+            }}
+          />
+        )}
+        <span style={{ ...styles.dot, backgroundColor: meta.color }} />
+      </span>
+      <span style={styles.label}>{label}</span>
+      <span style={styles.count} data-testid="queue-count">
+        {resolvedCount}
+      </span>
+      <span style={{ ...styles.statusText, color: meta.color }}>
+        {meta.text}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles (inline — avoids CSS class collisions in mixed codebases)
+// ---------------------------------------------------------------------------
+const styles = {
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.5rem",
+    fontSize: "0.8125rem",
+  },
+  dotWrap: {
+    position: "relative" as const,
+    display: "inline-flex",
+    width: "0.625rem",
+    height: "0.625rem",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dot: {
+    position: "relative" as const,
+    width: "0.625rem",
+    height: "0.625rem",
+    borderRadius: "9999px",
+  },
+  ring: {
+    position: "absolute" as const,
+    inset: 0,
+    borderRadius: "9999px",
+  },
+  label: {
+    color: "#64748b",
+  },
+  count: {
+    fontWeight: 700,
+    color: "#0f172a",
+    fontVariantNumeric: "tabular-nums" as const,
+  },
+  statusText: {
+    fontSize: "0.6875rem",
+    fontWeight: 600,
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.04em",
+  },
+  skeletonDot: {
+    width: "0.625rem",
+    height: "0.625rem",
+    borderRadius: "9999px",
+    backgroundColor: "#cbd5e1",
+  },
+  skeletonText: {
+    width: "4rem",
+    height: "0.6rem",
+    borderRadius: "0.25rem",
+    backgroundColor: "#e2e8f0",
+  },
+} as const;

--- a/frontend/tests/components/CompactMetadataStack.test.tsx
+++ b/frontend/tests/components/CompactMetadataStack.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import {
+  CompactMetadataStack,
+  type MetadataItem,
+} from "@/components/v1/CompactMetadataStack";
+
+const items: MetadataItem[] = [
+  { id: "network", label: "Network", value: "Testnet" },
+  { id: "players", label: "Players", value: 128 },
+  { id: "id", label: "Lobby ID", value: "LBY-7F1C", title: "LBY-7F1C-full" },
+];
+
+describe("CompactMetadataStack", () => {
+  it("renders label/value pairs as a definition list", () => {
+    render(<CompactMetadataStack items={items} />);
+    expect(screen.getByText("Network")).toBeInTheDocument();
+    expect(screen.getByText("Testnet")).toBeInTheDocument();
+    expect(screen.getByText("128")).toBeInTheDocument();
+    // value title is forwarded for tooltips
+    expect(screen.getByText("LBY-7F1C")).toHaveAttribute(
+      "title",
+      "LBY-7F1C-full",
+    );
+  });
+
+  it("renders skeletons while loading and hides values", () => {
+    render(<CompactMetadataStack items={items} loading />);
+    const list = screen.getByLabelText("Details");
+    expect(list).toHaveAttribute("aria-busy", "true");
+    expect(screen.getAllByTestId("metadata-skeleton").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Testnet")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty message when there are no items", () => {
+    render(
+      <CompactMetadataStack items={[]} emptyMessage="Nothing configured" />,
+    );
+    expect(screen.getByText("Nothing configured")).toBeInTheDocument();
+    expect(screen.queryByRole("term")).not.toBeInTheDocument();
+  });
+
+  it("accepts a custom aria-label", () => {
+    render(<CompactMetadataStack items={items} ariaLabel="Lobby details" />);
+    expect(screen.getByLabelText("Lobby details")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/QueuePulseIndicator.test.tsx
+++ b/frontend/tests/components/QueuePulseIndicator.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import { QueuePulseIndicator } from "@/components/v1/QueuePulseIndicator";
+
+describe("QueuePulseIndicator", () => {
+  it("renders the count and label in a live status region", () => {
+    render(<QueuePulseIndicator count={12} label="Ranked" />);
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAccessibleName(/Ranked: Live, 12 in queue/);
+    expect(screen.getByTestId("queue-count")).toHaveTextContent("12");
+  });
+
+  it("derives 'live' for a non-empty queue and 'idle' when empty", () => {
+    const { rerender } = render(<QueuePulseIndicator count={3} />);
+    expect(screen.getByText("Live")).toBeInTheDocument();
+
+    rerender(<QueuePulseIndicator count={0} />);
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByTestId("queue-count")).toHaveTextContent("0");
+  });
+
+  it("respects an explicit status (paused / offline)", () => {
+    const { rerender } = render(
+      <QueuePulseIndicator count={5} status="paused" />,
+    );
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+
+    rerender(<QueuePulseIndicator count={5} status="offline" />);
+    expect(screen.getByText("Offline")).toBeInTheDocument();
+  });
+
+  it("renders a loading state", () => {
+    render(<QueuePulseIndicator loading label="Ranked" />);
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByTestId("queue-count")).not.toBeInTheDocument();
+  });
+
+  it("defaults the count to 0 when omitted", () => {
+    render(<QueuePulseIndicator />);
+    expect(screen.getByTestId("queue-count")).toHaveTextContent("0");
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Two new Soroban contracts with read accessors plus two shared frontend primitives. The target contracts (`contracts/lobby-gates/`, `contracts/perk-claims/`) did not exist, so they're created fresh at the specified paths following the repo's existing contract layout; the components follow the established `frontend/src/components/v1` conventions. (The issues referenced `apps/web/`, which doesn't exist in this repo — the frontend lives in `frontend/`.)

### #777 — lobby-gates: gate status snapshot + release-delay
New `lobby-gates` contract. Mutations: `configure_gate` / `enter` (admits a player once released, not paused, and under capacity — idempotent per player) / `set_paused`. Read accessors:
- `gate_status(id)` → capacity, occupancy, remaining slots, `is_open` (released & not paused), `is_paused`, `is_full`.
- `release_delay(id)` → release time, seconds-until-release, `is_released`.

### #779 — perk-claims: claim queue snapshot + threshold-gap
New `perk-claims` contract. Mutations: `configure_perk` / `queue_claim` (idempotent per user) / `claim` (requires the threshold met, the caller queued, and not already claimed). Read accessors:
- `claim_queue_snapshot(id)` → threshold, queued count, claimed count, `is_threshold_met`.
- `threshold_gap(id)` → remaining gap and progress in basis points.

Both contracts use named response types and return predictable results for unknown ids / empty states; write flows are unaffected.

### #785 — shared compact metadata stack (frontend)
New `CompactMetadataStack` (`frontend/src/components/v1/`) — a compact label/value stack rendered as a semantic `<dl>` for dense overview panels, with explicit **loading** (skeletons) and **empty** states, optional `dense` spacing, and a configurable `aria-label`.

### #794 — live queue pulse indicator (frontend)
New `QueuePulseIndicator` (`frontend/src/components/v1/`) — a live queue indicator for multiplayer entry surfaces: a status dot that pulses while the queue is live and non-empty (honoring `prefers-reduced-motion`), the queued count, and a status label, inside an `aria-live="polite"` `role="status"` region. Status auto-derives from count (`live`/`idle`) or can be set explicitly (`paused`/`offline`); includes a loading state.

## Test plan
- [x] `cargo test -p stellarcade-lobby-gates -p stellarcade-perk-claims` — **8 tests pass** (each contract: success path + empty/blocked/missing paths).
- [x] `vitest run` on both component tests — **9 tests pass** (render, loading, empty, status derivation, explicit status, defaults).
- [x] Contracts build cleanly; `tsc --noEmit` + `eslint` clean for the new components.

## Notes / out of scope
- `tsc --noEmit` reports **4 pre-existing errors in `src/pages/GameDetail.tsx`** (untouched by this PR); this change introduces zero new type errors.
- Both components are shared primitives; their representative usage is exercised by the new test suites (per the issues' Definition of Done).

Closes #777
Closes #779
Closes #785
Closes #794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added lobby gate management enabling time-based access control with configurable capacity limits and pause functionality.
  * Added perk claims system featuring queue-based distribution with threshold requirements and claim tracking.
  * Added metadata display component supporting loading states and skeleton placeholders.
  * Added queue status indicator with live pulsing animations and full accessibility support.

* **Tests**
  * Added comprehensive test coverage for all new smart contracts and UI components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->