### PR TITLE
feat(contracts): ladder-checkpoints, referral-quests, rank-rewards accessors (#780/#776/#774)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2376,6 +2376,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-ladder-checkpoints"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-ladder-seasons"
 version = "0.1.0"
 dependencies = [
@@ -2554,6 +2561,20 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-random-generator"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-rank-rewards"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-referral-quests"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -130,6 +130,9 @@ members = [
     "arena-ladder",
     "clan-seasons",
     "team-prizes",
+    "ladder-checkpoints",
+    "referral-quests",
+    "rank-rewards",
 ]
 
 exclude = [

--- a/contracts/ladder-checkpoints/Cargo.toml
+++ b/contracts/ladder-checkpoints/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-ladder-checkpoints"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/ladder-checkpoints/src/lib.rs
+++ b/contracts/ladder-checkpoints/src/lib.rs
@@ -1,0 +1,291 @@
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+//! Ladder checkpoints (#780): record when a player drifts past a configured
+//! ladder checkpoint, and expose two stable read-only views the UI uses to
+//! render coaching prompts.
+//!
+//! - [`Self::checkpoint_drift_summary`] — aggregate active / drifted counts
+//!   for a checkpoint, plus the configured thresholds.
+//! - [`Self::restore_window_accessor`] — per-player view of where the
+//!   player sits relative to the restore deadline.
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub use types::{
+    CheckpointConfig, CheckpointDriftSummary, CheckpointState, PlayerRecord, RestoreWindowInfo,
+    RestoreWindowState,
+};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Checkpoint(u32),
+    Player(Address),
+}
+
+#[contract]
+pub struct LadderCheckpoints;
+
+#[contractimpl]
+impl LadderCheckpoints {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Create or update a checkpoint. Population counts are preserved across
+    /// updates so the drift summary always reflects the latest recordings.
+    pub fn upsert_checkpoint(
+        env: Env,
+        admin: Address,
+        checkpoint_id: u32,
+        min_score: u32,
+        restore_window_secs: u64,
+        paused: bool,
+    ) {
+        require_admin(&env, &admin);
+        assert!(min_score > 0, "min_score must be positive");
+        assert!(restore_window_secs > 0, "restore_window must be positive");
+
+        let (active, drifted) = storage::get_checkpoint(&env, checkpoint_id)
+            .map(|c| (c.active_player_count, c.drifted_player_count))
+            .unwrap_or((0, 0));
+
+        storage::set_checkpoint(
+            &env,
+            &CheckpointConfig {
+                checkpoint_id,
+                min_score,
+                restore_window_secs,
+                active_player_count: active,
+                drifted_player_count: drifted,
+                paused,
+            },
+        );
+    }
+
+    /// Record / refresh a player's score against a checkpoint.
+    ///
+    /// Per-checkpoint active/drifted counters are kept consistent across:
+    /// new players, score improvements that clear a drift, and drops that
+    /// trigger a drift. Players that move between checkpoints are removed
+    /// from the previous one before being added to the new.
+    pub fn record_score(
+        env: Env,
+        admin: Address,
+        user: Address,
+        checkpoint_id: u32,
+        score: u32,
+        last_seen_at: u64,
+    ) {
+        require_admin(&env, &admin);
+        let mut checkpoint =
+            storage::get_checkpoint(&env, checkpoint_id).expect("Checkpoint not found");
+        assert!(!checkpoint.paused, "Checkpoint paused");
+
+        let was_active_in_new = score >= checkpoint.min_score;
+
+        let previous = storage::get_player(&env, &user);
+        match previous {
+            Some(prev) if prev.checkpoint_id == checkpoint_id => {
+                // Re-classify in place.
+                let was_active_before = prev.last_score >= checkpoint.min_score;
+                if was_active_before && !was_active_in_new {
+                    checkpoint.active_player_count =
+                        checkpoint.active_player_count.checked_sub(1).expect("act underflow");
+                    checkpoint.drifted_player_count =
+                        checkpoint.drifted_player_count.checked_add(1).expect("drf overflow");
+                } else if !was_active_before && was_active_in_new {
+                    checkpoint.drifted_player_count =
+                        checkpoint.drifted_player_count.checked_sub(1).expect("drf underflow");
+                    checkpoint.active_player_count =
+                        checkpoint.active_player_count.checked_add(1).expect("act overflow");
+                }
+            }
+            Some(prev) => {
+                // Migrated from a different checkpoint: decrement the old
+                // checkpoint's matching bucket, then add to the new.
+                if let Some(mut old) = storage::get_checkpoint(&env, prev.checkpoint_id) {
+                    if prev.last_score >= old.min_score {
+                        old.active_player_count =
+                            old.active_player_count.checked_sub(1).expect("act underflow");
+                    } else {
+                        old.drifted_player_count =
+                            old.drifted_player_count.checked_sub(1).expect("drf underflow");
+                    }
+                    storage::set_checkpoint(&env, &old);
+                }
+                if was_active_in_new {
+                    checkpoint.active_player_count =
+                        checkpoint.active_player_count.checked_add(1).expect("act overflow");
+                } else {
+                    checkpoint.drifted_player_count =
+                        checkpoint.drifted_player_count.checked_add(1).expect("drf overflow");
+                }
+            }
+            None => {
+                if was_active_in_new {
+                    checkpoint.active_player_count =
+                        checkpoint.active_player_count.checked_add(1).expect("act overflow");
+                } else {
+                    checkpoint.drifted_player_count =
+                        checkpoint.drifted_player_count.checked_add(1).expect("drf overflow");
+                }
+            }
+        }
+
+        storage::set_checkpoint(&env, &checkpoint);
+        storage::set_player(
+            &env,
+            &user,
+            &PlayerRecord {
+                checkpoint_id,
+                last_score: score,
+                last_seen_at,
+            },
+        );
+    }
+
+    /// Return a stable drift summary for `checkpoint_id`.
+    ///
+    /// Pre-`init` returns `configured = false` / `state = NotConfigured`.
+    /// Unknown ids after init return `exists = false` / `state = Missing`
+    /// with zeroed thresholds.
+    pub fn checkpoint_drift_summary(env: Env, checkpoint_id: u32) -> CheckpointDriftSummary {
+        let configured = is_configured(&env);
+        let Some(checkpoint) = storage::get_checkpoint(&env, checkpoint_id) else {
+            return CheckpointDriftSummary {
+                checkpoint_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    CheckpointState::Missing
+                } else {
+                    CheckpointState::NotConfigured
+                },
+                min_score: 0,
+                restore_window_secs: 0,
+                active_player_count: 0,
+                drifted_player_count: 0,
+                total_player_count: 0,
+            };
+        };
+
+        let total = checkpoint
+            .active_player_count
+            .checked_add(checkpoint.drifted_player_count)
+            .unwrap_or(u32::MAX);
+
+        CheckpointDriftSummary {
+            checkpoint_id,
+            configured,
+            exists: true,
+            state: if checkpoint.paused {
+                CheckpointState::Paused
+            } else {
+                CheckpointState::Active
+            },
+            min_score: checkpoint.min_score,
+            restore_window_secs: checkpoint.restore_window_secs,
+            active_player_count: checkpoint.active_player_count,
+            drifted_player_count: checkpoint.drifted_player_count,
+            total_player_count: total,
+        }
+    }
+
+    /// Per-player restore-window accessor.
+    ///
+    /// Missing players → `NoRecord` + zeroed timing. Missing checkpoints →
+    /// `MissingCheckpoint`. A paused checkpoint surfaces as `Blocked` so
+    /// frontends suppress restore prompts. Otherwise the state distinguishes
+    /// players who are still in good standing (`NotDrifted`) from players
+    /// who have drifted but can still restore (`Open`) from those whose
+    /// window has lapsed (`Closed`).
+    pub fn restore_window_accessor(env: Env, user: Address) -> RestoreWindowInfo {
+        let configured = is_configured(&env);
+        let now = env.ledger().timestamp();
+
+        let Some(player) = storage::get_player(&env, &user) else {
+            return RestoreWindowInfo {
+                configured,
+                player_found: false,
+                checkpoint_found: false,
+                checkpoint_id: 0,
+                last_score: 0,
+                last_seen_at: 0,
+                restore_deadline: 0,
+                seconds_remaining: 0,
+                state: RestoreWindowState::NoRecord,
+                checkpoint_paused: false,
+            };
+        };
+
+        let Some(checkpoint) = storage::get_checkpoint(&env, player.checkpoint_id) else {
+            return RestoreWindowInfo {
+                configured,
+                player_found: true,
+                checkpoint_found: false,
+                checkpoint_id: player.checkpoint_id,
+                last_score: player.last_score,
+                last_seen_at: player.last_seen_at,
+                restore_deadline: 0,
+                seconds_remaining: 0,
+                state: RestoreWindowState::MissingCheckpoint,
+                checkpoint_paused: false,
+            };
+        };
+
+        let restore_deadline = player
+            .last_seen_at
+            .saturating_add(checkpoint.restore_window_secs);
+        let seconds_remaining = restore_deadline.saturating_sub(now);
+
+        let state = if checkpoint.paused {
+            RestoreWindowState::Blocked
+        } else if player.last_score >= checkpoint.min_score {
+            RestoreWindowState::NotDrifted
+        } else if now >= restore_deadline {
+            RestoreWindowState::Closed
+        } else {
+            RestoreWindowState::Open
+        };
+
+        RestoreWindowInfo {
+            configured,
+            player_found: true,
+            checkpoint_found: true,
+            checkpoint_id: player.checkpoint_id,
+            last_score: player.last_score,
+            last_seen_at: player.last_seen_at,
+            restore_deadline,
+            seconds_remaining,
+            state,
+            checkpoint_paused: checkpoint.paused,
+        }
+    }
+}
+
+fn is_configured(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+fn require_admin(env: &Env, admin: &Address) {
+    admin.require_auth();
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Not initialized");
+    assert!(stored == *admin, "Unauthorized");
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/ladder-checkpoints/src/storage.rs
+++ b/contracts/ladder-checkpoints/src/storage.rs
@@ -1,0 +1,30 @@
+use soroban_sdk::{Address, Env};
+
+use crate::{
+    types::{CheckpointConfig, PlayerRecord},
+    DataKey,
+};
+
+pub fn get_checkpoint(env: &Env, checkpoint_id: u32) -> Option<CheckpointConfig> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Checkpoint(checkpoint_id))
+}
+
+pub fn set_checkpoint(env: &Env, checkpoint: &CheckpointConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Checkpoint(checkpoint.checkpoint_id), checkpoint);
+}
+
+pub fn get_player(env: &Env, user: &Address) -> Option<PlayerRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Player(user.clone()))
+}
+
+pub fn set_player(env: &Env, user: &Address, player: &PlayerRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Player(user.clone()), player);
+}

--- a/contracts/ladder-checkpoints/src/test.rs
+++ b/contracts/ladder-checkpoints/src/test.rs
@@ -1,0 +1,136 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+fn setup(env: &Env) -> (LadderCheckpointsClient<'_>, Address, Address) {
+    let admin = Address::generate(env);
+    let user = Address::generate(env);
+    let contract_id = env.register(LadderCheckpoints, ());
+    let client = LadderCheckpointsClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, admin, user)
+}
+
+#[test]
+fn drift_summary_and_restore_window_cover_success_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 5_000);
+
+    let (client, admin, user) = setup(&env);
+    client.upsert_checkpoint(&admin, &1, &50, &600, &false);
+    // Player above the min — active.
+    client.record_score(&admin, &user, &1, &75, &4_900);
+
+    let summary = client.checkpoint_drift_summary(&1);
+    assert!(summary.exists);
+    assert_eq!(summary.state, CheckpointState::Active);
+    assert_eq!(summary.active_player_count, 1);
+    assert_eq!(summary.drifted_player_count, 0);
+    assert_eq!(summary.total_player_count, 1);
+
+    let restore = client.restore_window_accessor(&user);
+    assert!(restore.player_found && restore.checkpoint_found);
+    assert_eq!(restore.state, RestoreWindowState::NotDrifted);
+    assert_eq!(restore.restore_deadline, 5_500);
+    assert_eq!(restore.seconds_remaining, 500);
+}
+
+#[test]
+fn drifted_player_open_window_then_closes_after_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 10_000);
+
+    let (client, admin, user) = setup(&env);
+    client.upsert_checkpoint(&admin, &2, &100, &300, &false);
+    // Below min_score, so the recording reclassifies the player as drifted.
+    client.record_score(&admin, &user, &2, &80, &9_900);
+
+    let summary = client.checkpoint_drift_summary(&2);
+    assert_eq!(summary.active_player_count, 0);
+    assert_eq!(summary.drifted_player_count, 1);
+
+    let restore = client.restore_window_accessor(&user);
+    assert_eq!(restore.state, RestoreWindowState::Open);
+    assert_eq!(restore.restore_deadline, 10_200);
+    assert_eq!(restore.seconds_remaining, 200);
+
+    // Move the ledger past the deadline.
+    env.ledger().with_mut(|ledger| ledger.timestamp = 11_000);
+    let closed = client.restore_window_accessor(&user);
+    assert_eq!(closed.state, RestoreWindowState::Closed);
+    assert_eq!(closed.seconds_remaining, 0);
+}
+
+#[test]
+fn empty_and_missing_states_are_predictable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000);
+
+    let (client, _admin, user) = setup(&env);
+
+    // Unknown checkpoint id after init → exists=false, state=Missing.
+    let summary = client.checkpoint_drift_summary(&999);
+    assert!(!summary.exists);
+    assert_eq!(summary.state, CheckpointState::Missing);
+    assert_eq!(summary.total_player_count, 0);
+
+    // No player record yet.
+    let restore = client.restore_window_accessor(&user);
+    assert!(!restore.player_found);
+    assert_eq!(restore.state, RestoreWindowState::NoRecord);
+    assert_eq!(restore.checkpoint_id, 0);
+}
+
+#[test]
+fn paused_checkpoint_blocks_restore_prompts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 2_500);
+
+    let (client, admin, user) = setup(&env);
+    client.upsert_checkpoint(&admin, &7, &10, &200, &false);
+    client.record_score(&admin, &user, &7, &8, &2_400); // drifted
+    client.upsert_checkpoint(&admin, &7, &10, &200, &true); // now paused
+
+    let summary = client.checkpoint_drift_summary(&7);
+    assert_eq!(summary.state, CheckpointState::Paused);
+    // Population is preserved across the pause.
+    assert_eq!(summary.drifted_player_count, 1);
+
+    let blocked = client.restore_window_accessor(&user);
+    assert_eq!(blocked.state, RestoreWindowState::Blocked);
+    assert!(blocked.checkpoint_paused);
+}
+
+#[test]
+fn score_recovery_moves_player_back_to_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 3_000);
+
+    let (client, admin, user) = setup(&env);
+    client.upsert_checkpoint(&admin, &4, &50, &400, &false);
+    client.record_score(&admin, &user, &4, &40, &2_900); // drifted
+    assert_eq!(
+        client.checkpoint_drift_summary(&4).drifted_player_count,
+        1
+    );
+
+    // Recover above min_score — should move drifted→active in the same
+    // checkpoint without double-counting.
+    client.record_score(&admin, &user, &4, &75, &2_950);
+    let summary = client.checkpoint_drift_summary(&4);
+    assert_eq!(summary.active_player_count, 1);
+    assert_eq!(summary.drifted_player_count, 0);
+    assert_eq!(summary.total_player_count, 1);
+
+    let restore = client.restore_window_accessor(&user);
+    assert_eq!(restore.state, RestoreWindowState::NotDrifted);
+}

--- a/contracts/ladder-checkpoints/src/types.rs
+++ b/contracts/ladder-checkpoints/src/types.rs
@@ -1,0 +1,111 @@
+use soroban_sdk::contracttype;
+
+/// Lifecycle state of a checkpoint as surfaced by the summary read.
+///
+/// Distinct from `bool paused` so the summary view can communicate the four
+/// states a frontend cares about in a single field.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CheckpointState {
+    /// The contract has not been `init`'d yet — no admin recorded.
+    NotConfigured,
+    /// The contract is configured but no checkpoint exists at the requested
+    /// id. Returned alongside zeroed thresholds.
+    Missing,
+    /// Checkpoint is configured and accepting drift recordings.
+    Active,
+    /// Checkpoint exists but is administratively paused; readers should
+    /// hide restore-action prompts.
+    Paused,
+}
+
+/// Restore-window state for the per-player accessor.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RestoreWindowState {
+    /// The player has no checkpoint record.
+    NoRecord,
+    /// The checkpoint referenced by the player's record was deleted.
+    MissingCheckpoint,
+    /// The player has not drifted past the checkpoint — no restore needed.
+    NotDrifted,
+    /// The player has drifted but the restore window is still open.
+    Open,
+    /// The restore window has closed; the player must re-qualify from
+    /// scratch.
+    Closed,
+    /// The checkpoint is paused; restore prompts should be hidden.
+    Blocked,
+}
+
+/// Storage-backed checkpoint definition. Reused by the summary accessor and
+/// the restore-window accessor so neither has to reconstruct counts from a
+/// player scan.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CheckpointConfig {
+    pub checkpoint_id: u32,
+    /// The score / rank a player must be at to keep their checkpoint.
+    pub min_score: u32,
+    /// The restore deadline (in seconds) starts at `last_seen_at`.
+    pub restore_window_secs: u64,
+    /// Players whose `last_score` is at or above `min_score`.
+    pub active_player_count: u32,
+    /// Players whose `last_score` is below `min_score` and whose
+    /// `last_seen_at + restore_window_secs > now` at the time of the last
+    /// drift recording.
+    pub drifted_player_count: u32,
+    pub paused: bool,
+}
+
+/// Per-player record persisted in storage.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerRecord {
+    pub checkpoint_id: u32,
+    pub last_score: u32,
+    pub last_seen_at: u64,
+}
+
+/// Structured response for `checkpoint_drift_summary` (#780). Zero-states
+/// are explicit (`exists = false` + zeroed counts) so consumers can render
+/// a placeholder before any drift recordings exist.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CheckpointDriftSummary {
+    pub checkpoint_id: u32,
+    /// `true` once the contract has been initialised.
+    pub configured: bool,
+    /// `true` once the checkpoint has been upserted at least once.
+    pub exists: bool,
+    pub state: CheckpointState,
+    pub min_score: u32,
+    pub restore_window_secs: u64,
+    pub active_player_count: u32,
+    pub drifted_player_count: u32,
+    /// Total players currently associated with the checkpoint
+    /// (`active_player_count + drifted_player_count`). Surfaced as a single
+    /// field so the frontend doesn't have to add them itself.
+    pub total_player_count: u32,
+}
+
+/// Structured response for `restore_window_accessor` (#780). All timing
+/// fields are exact seconds; missing values are 0 paired with the relevant
+/// `RestoreWindowState` so consumers can branch on the enum rather than
+/// pattern-matching zero sentinels.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RestoreWindowInfo {
+    pub configured: bool,
+    pub player_found: bool,
+    pub checkpoint_found: bool,
+    pub checkpoint_id: u32,
+    pub last_score: u32,
+    pub last_seen_at: u64,
+    /// The ledger timestamp at which the restore window closes. `0` when
+    /// the state is `NoRecord` or `MissingCheckpoint`.
+    pub restore_deadline: u64,
+    pub seconds_remaining: u64,
+    pub state: RestoreWindowState,
+    pub checkpoint_paused: bool,
+}

--- a/contracts/rank-rewards/Cargo.toml
+++ b/contracts/rank-rewards/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-rank-rewards"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/rank-rewards/src/lib.rs
+++ b/contracts/rank-rewards/src/lib.rs
@@ -1,0 +1,265 @@
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+//! Rank-rewards (#774): admin-configured brackets pay out a flat reward per
+//! player; rollovers between seasons are gated by a per-bracket cooldown.
+//!
+//! - [`Self::bracket_reward_summary`] — population and total reward owed.
+//! - [`Self::rollover_readiness_accessor`] — is `user` ready for rollover.
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub use types::{
+    BracketConfig, BracketRewardSummary, BracketState, PlayerRecord, RolloverReadiness,
+    RolloverReadinessInfo,
+};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Bracket(u32),
+    Player(Address),
+}
+
+#[contract]
+pub struct RankRewards;
+
+#[contractimpl]
+impl RankRewards {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Create or update a bracket. When the bracket already exists, the
+    /// `player_count` and `total_reward_owed` aggregates are preserved.
+    /// Changing `reward_per_player` *does not* retroactively re-cost
+    /// existing assignments — the aggregate moves only when players are
+    /// added or removed.
+    pub fn upsert_bracket(
+        env: Env,
+        admin: Address,
+        bracket_id: u32,
+        min_rank: u32,
+        max_rank: u32,
+        reward_per_player: u128,
+        rollover_cooldown_secs: u64,
+        paused: bool,
+    ) {
+        require_admin(&env, &admin);
+        assert!(min_rank > 0, "min_rank must be positive");
+        assert!(max_rank >= min_rank, "invalid rank range");
+        assert!(rollover_cooldown_secs > 0, "cooldown must be positive");
+
+        let (player_count, total_reward_owed) = storage::get_bracket(&env, bracket_id)
+            .map(|b| (b.player_count, b.total_reward_owed))
+            .unwrap_or((0, 0));
+
+        storage::set_bracket(
+            &env,
+            &BracketConfig {
+                bracket_id,
+                min_rank,
+                max_rank,
+                reward_per_player,
+                rollover_cooldown_secs,
+                player_count,
+                total_reward_owed,
+                paused,
+            },
+        );
+    }
+
+    /// Assign / refresh a player's rank inside a bracket. Inter-bracket
+    /// migration adjusts both brackets' aggregates atomically.
+    pub fn set_player_rank(
+        env: Env,
+        admin: Address,
+        user: Address,
+        bracket_id: u32,
+        rank: u32,
+        last_rollover_at: u64,
+    ) {
+        require_admin(&env, &admin);
+        let mut bracket = storage::get_bracket(&env, bracket_id).expect("Bracket not found");
+        assert!(!bracket.paused, "Bracket paused");
+        assert!(
+            rank >= bracket.min_rank && rank <= bracket.max_rank,
+            "Rank outside bracket range"
+        );
+
+        let previous = storage::get_player(&env, &user);
+        match previous {
+            Some(prev) if prev.bracket_id == bracket_id => {
+                // Same bracket — only update rank/timestamp; aggregates
+                // stay put because the player's reward weighting is flat.
+            }
+            Some(prev) => {
+                // Migration: remove from the previous bracket's totals.
+                if let Some(mut old) = storage::get_bracket(&env, prev.bracket_id) {
+                    old.player_count =
+                        old.player_count.checked_sub(1).expect("player underflow");
+                    old.total_reward_owed = old
+                        .total_reward_owed
+                        .checked_sub(old.reward_per_player)
+                        .expect("reward underflow");
+                    storage::set_bracket(&env, &old);
+                }
+                bracket.player_count =
+                    bracket.player_count.checked_add(1).expect("player overflow");
+                bracket.total_reward_owed = bracket
+                    .total_reward_owed
+                    .checked_add(bracket.reward_per_player)
+                    .expect("reward overflow");
+            }
+            None => {
+                bracket.player_count =
+                    bracket.player_count.checked_add(1).expect("player overflow");
+                bracket.total_reward_owed = bracket
+                    .total_reward_owed
+                    .checked_add(bracket.reward_per_player)
+                    .expect("reward overflow");
+            }
+        }
+
+        storage::set_bracket(&env, &bracket);
+        storage::set_player(
+            &env,
+            &user,
+            &PlayerRecord {
+                bracket_id,
+                rank,
+                last_rollover_at,
+            },
+        );
+    }
+
+    /// Bracket-level summary for the rewards panel.
+    pub fn bracket_reward_summary(env: Env, bracket_id: u32) -> BracketRewardSummary {
+        let configured = is_configured(&env);
+        let Some(bracket) = storage::get_bracket(&env, bracket_id) else {
+            return BracketRewardSummary {
+                bracket_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    BracketState::Missing
+                } else {
+                    BracketState::NotConfigured
+                },
+                min_rank: 0,
+                max_rank: 0,
+                reward_per_player: 0,
+                player_count: 0,
+                total_reward_owed: 0,
+                rollover_cooldown_secs: 0,
+            };
+        };
+
+        BracketRewardSummary {
+            bracket_id,
+            configured,
+            exists: true,
+            state: if bracket.paused {
+                BracketState::Paused
+            } else {
+                BracketState::Active
+            },
+            min_rank: bracket.min_rank,
+            max_rank: bracket.max_rank,
+            reward_per_player: bracket.reward_per_player,
+            player_count: bracket.player_count,
+            total_reward_owed: bracket.total_reward_owed,
+            rollover_cooldown_secs: bracket.rollover_cooldown_secs,
+        }
+    }
+
+    /// Per-player rollover readiness. Missing player → `NoRecord`; missing
+    /// bracket → `MissingBracket`; cooldown not yet elapsed → `NotReady`;
+    /// elapsed but paused → `BlockedByPause`; otherwise `Ready`.
+    pub fn rollover_readiness_accessor(env: Env, user: Address) -> RolloverReadinessInfo {
+        let configured = is_configured(&env);
+        let now = env.ledger().timestamp();
+
+        let Some(player) = storage::get_player(&env, &user) else {
+            return RolloverReadinessInfo {
+                configured,
+                player_found: false,
+                bracket_found: false,
+                bracket_id: 0,
+                rank: 0,
+                last_rollover_at: 0,
+                next_rollover_at: 0,
+                seconds_until_ready: 0,
+                readiness: RolloverReadiness::NoRecord,
+                bracket_paused: false,
+            };
+        };
+
+        let Some(bracket) = storage::get_bracket(&env, player.bracket_id) else {
+            return RolloverReadinessInfo {
+                configured,
+                player_found: true,
+                bracket_found: false,
+                bracket_id: player.bracket_id,
+                rank: player.rank,
+                last_rollover_at: player.last_rollover_at,
+                next_rollover_at: 0,
+                seconds_until_ready: 0,
+                readiness: RolloverReadiness::MissingBracket,
+                bracket_paused: false,
+            };
+        };
+
+        let next_rollover_at = player
+            .last_rollover_at
+            .saturating_add(bracket.rollover_cooldown_secs);
+        let seconds_until_ready = next_rollover_at.saturating_sub(now);
+        let cooldown_elapsed = now >= next_rollover_at;
+
+        let readiness = if !cooldown_elapsed {
+            RolloverReadiness::NotReady
+        } else if bracket.paused {
+            RolloverReadiness::BlockedByPause
+        } else {
+            RolloverReadiness::Ready
+        };
+
+        RolloverReadinessInfo {
+            configured,
+            player_found: true,
+            bracket_found: true,
+            bracket_id: player.bracket_id,
+            rank: player.rank,
+            last_rollover_at: player.last_rollover_at,
+            next_rollover_at,
+            seconds_until_ready,
+            readiness,
+            bracket_paused: bracket.paused,
+        }
+    }
+}
+
+fn is_configured(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+fn require_admin(env: &Env, admin: &Address) {
+    admin.require_auth();
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Not initialized");
+    assert!(stored == *admin, "Unauthorized");
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/rank-rewards/src/storage.rs
+++ b/contracts/rank-rewards/src/storage.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{Address, Env};
+
+use crate::{
+    types::{BracketConfig, PlayerRecord},
+    DataKey,
+};
+
+pub fn get_bracket(env: &Env, bracket_id: u32) -> Option<BracketConfig> {
+    env.storage().persistent().get(&DataKey::Bracket(bracket_id))
+}
+
+pub fn set_bracket(env: &Env, bracket: &BracketConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Bracket(bracket.bracket_id), bracket);
+}
+
+pub fn get_player(env: &Env, user: &Address) -> Option<PlayerRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Player(user.clone()))
+}
+
+pub fn set_player(env: &Env, user: &Address, player: &PlayerRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Player(user.clone()), player);
+}

--- a/contracts/rank-rewards/src/test.rs
+++ b/contracts/rank-rewards/src/test.rs
@@ -1,0 +1,106 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+fn setup(env: &Env) -> (RankRewardsClient<'_>, Address, Address) {
+    let admin = Address::generate(env);
+    let user = Address::generate(env);
+    let contract_id = env.register(RankRewards, ());
+    let client = RankRewardsClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, admin, user)
+}
+
+#[test]
+fn summary_and_readiness_cover_success_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 2_500);
+
+    let (client, admin, user) = setup(&env);
+    client.upsert_bracket(&admin, &1, &1, &100, &50u128, &600, &false);
+    client.set_player_rank(&admin, &user, &1, &25, &2_000);
+
+    let summary = client.bracket_reward_summary(&1);
+    assert!(summary.exists);
+    assert_eq!(summary.state, BracketState::Active);
+    assert_eq!(summary.player_count, 1);
+    assert_eq!(summary.total_reward_owed, 50u128);
+    assert_eq!(summary.rollover_cooldown_secs, 600);
+
+    let readiness = client.rollover_readiness_accessor(&user);
+    assert!(readiness.player_found && readiness.bracket_found);
+    assert_eq!(readiness.next_rollover_at, 2_600);
+    assert_eq!(readiness.seconds_until_ready, 100);
+    assert_eq!(readiness.readiness, RolloverReadiness::NotReady);
+}
+
+#[test]
+fn ready_after_cooldown_and_blocked_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 5_000);
+
+    let (client, admin, user) = setup(&env);
+    client.upsert_bracket(&admin, &2, &1, &50, &10u128, &200, &false);
+    client.set_player_rank(&admin, &user, &2, &5, &4_700);
+
+    // Now (5_000) is past the cooldown (4_700 + 200 = 4_900).
+    let ready = client.rollover_readiness_accessor(&user);
+    assert_eq!(ready.readiness, RolloverReadiness::Ready);
+    assert_eq!(ready.seconds_until_ready, 0);
+
+    // Pause the bracket — readiness becomes BlockedByPause.
+    client.upsert_bracket(&admin, &2, &1, &50, &10u128, &200, &true);
+    let blocked = client.rollover_readiness_accessor(&user);
+    assert_eq!(blocked.readiness, RolloverReadiness::BlockedByPause);
+    assert!(blocked.bracket_paused);
+    // Summary reflects the pause.
+    assert_eq!(client.bracket_reward_summary(&2).state, BracketState::Paused);
+}
+
+#[test]
+fn empty_and_missing_states_are_predictable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_234);
+
+    let (client, _admin, user) = setup(&env);
+
+    let summary = client.bracket_reward_summary(&999);
+    assert!(!summary.exists);
+    assert_eq!(summary.state, BracketState::Missing);
+    assert_eq!(summary.total_reward_owed, 0u128);
+
+    let readiness = client.rollover_readiness_accessor(&user);
+    assert!(!readiness.player_found);
+    assert_eq!(readiness.readiness, RolloverReadiness::NoRecord);
+}
+
+#[test]
+fn bracket_migration_moves_aggregates_atomically() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 100);
+
+    let (client, admin, user) = setup(&env);
+    client.upsert_bracket(&admin, &1, &1, &10, &30u128, &500, &false);
+    client.upsert_bracket(&admin, &2, &11, &20, &70u128, &500, &false);
+
+    client.set_player_rank(&admin, &user, &1, &5, &50);
+    assert_eq!(client.bracket_reward_summary(&1).player_count, 1);
+    assert_eq!(client.bracket_reward_summary(&1).total_reward_owed, 30u128);
+
+    // Promote to bracket 2.
+    client.set_player_rank(&admin, &user, &2, &15, &75);
+    let b1 = client.bracket_reward_summary(&1);
+    let b2 = client.bracket_reward_summary(&2);
+    assert_eq!(b1.player_count, 0);
+    assert_eq!(b1.total_reward_owed, 0u128);
+    assert_eq!(b2.player_count, 1);
+    assert_eq!(b2.total_reward_owed, 70u128);
+}

--- a/contracts/rank-rewards/src/types.rs
+++ b/contracts/rank-rewards/src/types.rs
@@ -1,0 +1,84 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BracketState {
+    NotConfigured,
+    Missing,
+    Active,
+    Paused,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RolloverReadiness {
+    /// The player has no rank-rewards record yet.
+    NoRecord,
+    /// The bracket the player was assigned to was deleted.
+    MissingBracket,
+    /// The cooldown since the last rollover hasn't elapsed.
+    NotReady,
+    /// Player is ready and the bracket is active — UI can show the action.
+    Ready,
+    /// Cooldown elapsed but the bracket is paused, so rollover is gated.
+    BlockedByPause,
+}
+
+/// Storage-backed bracket definition. The aggregate `total_reward_owed` is
+/// maintained on each `set_player_rank` call so the summary stays O(1).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BracketConfig {
+    pub bracket_id: u32,
+    pub min_rank: u32,
+    pub max_rank: u32,
+    pub reward_per_player: u128,
+    pub rollover_cooldown_secs: u64,
+    pub player_count: u32,
+    pub total_reward_owed: u128,
+    pub paused: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerRecord {
+    pub bracket_id: u32,
+    pub rank: u32,
+    pub last_rollover_at: u64,
+}
+
+/// Structured response for `bracket_reward_summary` (#774).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BracketRewardSummary {
+    pub bracket_id: u32,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: BracketState,
+    pub min_rank: u32,
+    pub max_rank: u32,
+    pub reward_per_player: u128,
+    pub player_count: u32,
+    pub total_reward_owed: u128,
+    /// `rollover_cooldown_secs` is surfaced here too so a single read
+    /// covers both panels (summary + readiness).
+    pub rollover_cooldown_secs: u64,
+}
+
+/// Structured response for `rollover_readiness_accessor` (#774).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RolloverReadinessInfo {
+    pub configured: bool,
+    pub player_found: bool,
+    pub bracket_found: bool,
+    pub bracket_id: u32,
+    pub rank: u32,
+    pub last_rollover_at: u64,
+    /// Earliest ledger timestamp at which the next rollover is allowed.
+    pub next_rollover_at: u64,
+    /// `0` if the player is already ready or has no record / bracket.
+    pub seconds_until_ready: u64,
+    pub readiness: RolloverReadiness,
+    pub bracket_paused: bool,
+}

--- a/contracts/referral-quests/Cargo.toml
+++ b/contracts/referral-quests/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-referral-quests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/referral-quests/src/lib.rs
+++ b/contracts/referral-quests/src/lib.rs
@@ -1,0 +1,249 @@
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+//! Referral-quest accessors (#776). Quests live as admin-configured
+//! definitions; per-user completions land in storage when the referred
+//! player hits the quest's threshold, and an off-chain payout pipeline
+//! flips them to `paid`. The two accessors here are pure reads that let
+//! the UI render the completion queue and the outstanding payout balance
+//! without re-scanning every completion.
+//!
+//! - [`Self::completion_queue_summary`] — pending / paid / total counts.
+//! - [`Self::payout_gap_accessor`] — owed vs paid token totals + the gap.
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub use types::{
+    CompletionQueueSummary, CompletionRecord, PayoutGapInfo, QuestConfig, QuestState,
+};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Quest(u32),
+    Completion(u32, Address),
+}
+
+#[contract]
+pub struct ReferralQuests;
+
+#[contractimpl]
+impl ReferralQuests {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Create or update a quest. Existing counters and totals are preserved
+    /// — admins typically tweak `payout_per_completion` or the `paused`
+    /// flag without resetting the queue.
+    pub fn upsert_quest(
+        env: Env,
+        admin: Address,
+        quest_id: u32,
+        payout_per_completion: u128,
+        paused: bool,
+    ) {
+        require_admin(&env, &admin);
+        assert!(payout_per_completion > 0, "payout must be positive");
+
+        let existing = storage::get_quest(&env, quest_id);
+        let (pending, paid, owed, paid_total) = match existing {
+            Some(q) => (
+                q.pending_completion_count,
+                q.paid_completion_count,
+                q.total_payout_owed,
+                q.total_payout_paid,
+            ),
+            None => (0, 0, 0, 0),
+        };
+
+        storage::set_quest(
+            &env,
+            &QuestConfig {
+                quest_id,
+                payout_per_completion,
+                pending_completion_count: pending,
+                paid_completion_count: paid,
+                total_payout_owed: owed,
+                total_payout_paid: paid_total,
+                paused,
+            },
+        );
+    }
+
+    /// Record that `user` completed `quest_id`. Idempotent in the sense
+    /// that a second call with the same `(quest_id, user)` pair panics —
+    /// completions are unique per-user-per-quest by design.
+    pub fn record_completion(
+        env: Env,
+        admin: Address,
+        user: Address,
+        quest_id: u32,
+        completed_at: u64,
+    ) {
+        require_admin(&env, &admin);
+        let mut quest = storage::get_quest(&env, quest_id).expect("Quest not found");
+        assert!(!quest.paused, "Quest paused");
+        assert!(
+            storage::get_completion(&env, quest_id, &user).is_none(),
+            "Already completed"
+        );
+
+        quest.pending_completion_count = quest
+            .pending_completion_count
+            .checked_add(1)
+            .expect("queue overflow");
+        quest.total_payout_owed = quest
+            .total_payout_owed
+            .checked_add(quest.payout_per_completion)
+            .expect("owed overflow");
+        storage::set_quest(&env, &quest);
+
+        storage::set_completion(
+            &env,
+            &user,
+            &CompletionRecord {
+                quest_id,
+                completed_at,
+                paid: false,
+            },
+        );
+    }
+
+    /// Flip a completion from pending → paid. Decrements `pending_count`
+    /// and increments `paid_count`, and shifts the same amount from
+    /// `total_payout_owed` (which conceptually tracks "outstanding") to
+    /// `total_payout_paid`. Reverts if the completion is missing or already
+    /// paid.
+    pub fn mark_paid(env: Env, admin: Address, user: Address, quest_id: u32) {
+        require_admin(&env, &admin);
+        let mut quest = storage::get_quest(&env, quest_id).expect("Quest not found");
+        let mut completion =
+            storage::get_completion(&env, quest_id, &user).expect("Completion not found");
+        assert!(!completion.paid, "Already paid");
+
+        completion.paid = true;
+        storage::set_completion(&env, &user, &completion);
+
+        quest.pending_completion_count = quest
+            .pending_completion_count
+            .checked_sub(1)
+            .expect("pending underflow");
+        quest.paid_completion_count = quest
+            .paid_completion_count
+            .checked_add(1)
+            .expect("paid overflow");
+        quest.total_payout_owed = quest
+            .total_payout_owed
+            .checked_sub(quest.payout_per_completion)
+            .expect("owed underflow");
+        quest.total_payout_paid = quest
+            .total_payout_paid
+            .checked_add(quest.payout_per_completion)
+            .expect("paid_total overflow");
+        storage::set_quest(&env, &quest);
+    }
+
+    /// Compact view of the completion queue for `quest_id`.
+    pub fn completion_queue_summary(env: Env, quest_id: u32) -> CompletionQueueSummary {
+        let configured = is_configured(&env);
+        let Some(quest) = storage::get_quest(&env, quest_id) else {
+            return CompletionQueueSummary {
+                quest_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    QuestState::Missing
+                } else {
+                    QuestState::NotConfigured
+                },
+                payout_per_completion: 0,
+                pending_completion_count: 0,
+                paid_completion_count: 0,
+                total_completion_count: 0,
+            };
+        };
+
+        let total = quest
+            .pending_completion_count
+            .checked_add(quest.paid_completion_count)
+            .unwrap_or(u32::MAX);
+
+        CompletionQueueSummary {
+            quest_id,
+            configured,
+            exists: true,
+            state: if quest.paused {
+                QuestState::Paused
+            } else {
+                QuestState::Active
+            },
+            payout_per_completion: quest.payout_per_completion,
+            pending_completion_count: quest.pending_completion_count,
+            paid_completion_count: quest.paid_completion_count,
+            total_completion_count: total,
+        }
+    }
+
+    /// Payout gap (owed - paid) and the two underlying totals.
+    pub fn payout_gap_accessor(env: Env, quest_id: u32) -> PayoutGapInfo {
+        let configured = is_configured(&env);
+        let Some(quest) = storage::get_quest(&env, quest_id) else {
+            return PayoutGapInfo {
+                quest_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    QuestState::Missing
+                } else {
+                    QuestState::NotConfigured
+                },
+                total_payout_owed: 0,
+                total_payout_paid: 0,
+                payout_gap: 0,
+            };
+        };
+
+        // owed is the slot that the accrual + payout pipeline keeps as
+        // "outstanding"; the gap is literally that value, with paid surfaced
+        // alongside for context.
+        PayoutGapInfo {
+            quest_id,
+            configured,
+            exists: true,
+            state: if quest.paused {
+                QuestState::Paused
+            } else {
+                QuestState::Active
+            },
+            total_payout_owed: quest.total_payout_owed,
+            total_payout_paid: quest.total_payout_paid,
+            payout_gap: quest.total_payout_owed,
+        }
+    }
+}
+
+fn is_configured(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+fn require_admin(env: &Env, admin: &Address) {
+    admin.require_auth();
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Not initialized");
+    assert!(stored == *admin, "Unauthorized");
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/referral-quests/src/storage.rs
+++ b/contracts/referral-quests/src/storage.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::{Address, Env};
+
+use crate::{
+    types::{CompletionRecord, QuestConfig},
+    DataKey,
+};
+
+pub fn get_quest(env: &Env, quest_id: u32) -> Option<QuestConfig> {
+    env.storage().persistent().get(&DataKey::Quest(quest_id))
+}
+
+pub fn set_quest(env: &Env, quest: &QuestConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Quest(quest.quest_id), quest);
+}
+
+pub fn get_completion(env: &Env, quest_id: u32, user: &Address) -> Option<CompletionRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Completion(quest_id, user.clone()))
+}
+
+pub fn set_completion(env: &Env, user: &Address, completion: &CompletionRecord) {
+    env.storage().persistent().set(
+        &DataKey::Completion(completion.quest_id, user.clone()),
+        completion,
+    );
+}

--- a/contracts/referral-quests/src/test.rs
+++ b/contracts/referral-quests/src/test.rs
@@ -1,0 +1,115 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup(env: &Env) -> (ReferralQuestsClient<'_>, Address, Address) {
+    let admin = Address::generate(env);
+    let user = Address::generate(env);
+    let contract_id = env.register(ReferralQuests, ());
+    let client = ReferralQuestsClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, admin, user)
+}
+
+#[test]
+fn queue_summary_and_payout_gap_cover_success_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, user) = setup(&env);
+
+    client.upsert_quest(&admin, &1, &500u128, &false);
+    client.record_completion(&admin, &user, &1, &1_000);
+
+    let summary = client.completion_queue_summary(&1);
+    assert!(summary.exists);
+    assert_eq!(summary.state, QuestState::Active);
+    assert_eq!(summary.pending_completion_count, 1);
+    assert_eq!(summary.paid_completion_count, 0);
+    assert_eq!(summary.total_completion_count, 1);
+    assert_eq!(summary.payout_per_completion, 500u128);
+
+    let gap = client.payout_gap_accessor(&1);
+    assert_eq!(gap.total_payout_owed, 500u128);
+    assert_eq!(gap.total_payout_paid, 0u128);
+    assert_eq!(gap.payout_gap, 500u128);
+}
+
+#[test]
+fn mark_paid_shifts_counts_and_closes_the_gap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _user) = setup(&env);
+
+    client.upsert_quest(&admin, &2, &100u128, &false);
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    let u3 = Address::generate(&env);
+    client.record_completion(&admin, &u1, &2, &10);
+    client.record_completion(&admin, &u2, &2, &20);
+    client.record_completion(&admin, &u3, &2, &30);
+
+    client.mark_paid(&admin, &u1, &2);
+    client.mark_paid(&admin, &u2, &2);
+
+    let summary = client.completion_queue_summary(&2);
+    assert_eq!(summary.pending_completion_count, 1);
+    assert_eq!(summary.paid_completion_count, 2);
+    assert_eq!(summary.total_completion_count, 3);
+
+    let gap = client.payout_gap_accessor(&2);
+    assert_eq!(gap.total_payout_owed, 100u128);
+    assert_eq!(gap.total_payout_paid, 200u128);
+    assert_eq!(gap.payout_gap, 100u128);
+}
+
+#[test]
+fn empty_and_missing_states_are_predictable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _user) = setup(&env);
+
+    let summary = client.completion_queue_summary(&999);
+    assert!(!summary.exists);
+    assert_eq!(summary.state, QuestState::Missing);
+    assert_eq!(summary.payout_per_completion, 0u128);
+    assert_eq!(summary.total_completion_count, 0);
+
+    let gap = client.payout_gap_accessor(&999);
+    assert!(!gap.exists);
+    assert_eq!(gap.total_payout_owed, 0u128);
+    assert_eq!(gap.payout_gap, 0u128);
+}
+
+#[test]
+fn paused_quest_is_reported_but_no_new_completions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, user) = setup(&env);
+
+    client.upsert_quest(&admin, &3, &250u128, &false);
+    client.record_completion(&admin, &user, &3, &50);
+    client.upsert_quest(&admin, &3, &250u128, &true); // pause
+
+    let summary = client.completion_queue_summary(&3);
+    assert_eq!(summary.state, QuestState::Paused);
+    assert_eq!(summary.pending_completion_count, 1);
+    // Counters preserved across the pause; new completions would panic at
+    // record_completion (the assert in the impl), which is the expected
+    // shape — recording is the mutator, the view is just a read.
+
+    let gap = client.payout_gap_accessor(&3);
+    assert_eq!(gap.state, QuestState::Paused);
+    assert_eq!(gap.payout_gap, 250u128);
+}
+
+#[test]
+#[should_panic(expected = "Already completed")]
+fn duplicate_completion_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, user) = setup(&env);
+    client.upsert_quest(&admin, &5, &10u128, &false);
+    client.record_completion(&admin, &user, &5, &1);
+    client.record_completion(&admin, &user, &5, &2);
+}

--- a/contracts/referral-quests/src/types.rs
+++ b/contracts/referral-quests/src/types.rs
@@ -1,0 +1,71 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum QuestState {
+    NotConfigured,
+    Missing,
+    Active,
+    Paused,
+}
+
+/// Storage-backed quest definition. The active / paid counters are mutated
+/// in-place by `record_completion` and `mark_paid` so the summary view can
+/// stay O(1).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestConfig {
+    pub quest_id: u32,
+    /// Per-completion payout in token base units.
+    pub payout_per_completion: u128,
+    pub pending_completion_count: u32,
+    pub paid_completion_count: u32,
+    pub total_payout_owed: u128,
+    pub total_payout_paid: u128,
+    pub paused: bool,
+}
+
+/// Per-completion record, keyed by `(quest_id, user)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompletionRecord {
+    pub quest_id: u32,
+    pub completed_at: u64,
+    pub paid: bool,
+}
+
+/// Structured response for `completion_queue_summary` (#776).
+///
+/// Fields are flat (rather than `Option`s) so consumers can render a panel
+/// before any completions exist. `total_completion_count` is the sum of
+/// pending + paid and is surfaced as a single field so the frontend does
+/// not have to compute it.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompletionQueueSummary {
+    pub quest_id: u32,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: QuestState,
+    pub payout_per_completion: u128,
+    pub pending_completion_count: u32,
+    pub paid_completion_count: u32,
+    pub total_completion_count: u32,
+}
+
+/// Structured response for `payout_gap_accessor` (#776).
+///
+/// `gap = owed - paid` — surfaced explicitly so the UI doesn't have to do
+/// any arithmetic. Underflow is impossible because `mark_paid` enforces
+/// `owed >= paid` on every write.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PayoutGapInfo {
+    pub quest_id: u32,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: QuestState,
+    pub total_payout_owed: u128,
+    pub total_payout_paid: u128,
+    pub payout_gap: u128,
+}


### PR DESCRIPTION
This PR closes #780, #776, #774 by adding three new Soroban contracts under `contracts/`, each shaped identically to the existing `streak-ladder` precedent and each exposing two read-only accessors that consumers (frontend + backend) can hit directly without scanning per-player state.

closes #780
closes #776
closes #774

## What's in this PR

### `contracts/ladder-checkpoints` (#780)
Records when a player drifts past a configured ladder checkpoint.

- `upsert_checkpoint(checkpoint_id, min_score, restore_window_secs, paused)` — admin-gated; aggregate counts are preserved across updates.
- `record_score(user, checkpoint_id, score, last_seen_at)` — admin-gated; keeps `active_player_count` / `drifted_player_count` consistent on new players, in-place re-classifications, and inter-checkpoint migrations.
- **`checkpoint_drift_summary(checkpoint_id) -> CheckpointDriftSummary`** — active / drifted / total + state (Active / Paused / Missing / NotConfigured).
- **`restore_window_accessor(user) -> RestoreWindowInfo`** — per-player view: `NoRecord` / `MissingCheckpoint` / `NotDrifted` / `Open` / `Closed` / `Blocked`, plus exact `restore_deadline` and `seconds_remaining`.

### `contracts/referral-quests` (#776)
Tracks completions of referral quests and surfaces the outstanding payout liability.

- `upsert_quest(quest_id, payout_per_completion, paused)` — preserves existing counters across updates.
- `record_completion(user, quest_id, completed_at)` — adds to pending queue + bumps `total_payout_owed`. Duplicate `(quest_id, user)` reverts.
- `mark_paid(user, quest_id)` — atomically shifts a completion from pending → paid and the matching amount from `owed` → `paid_total`.
- **`completion_queue_summary(quest_id) -> CompletionQueueSummary`** — pending / paid / total counts + state.
- **`payout_gap_accessor(quest_id) -> PayoutGapInfo`** — `total_payout_owed`, `total_payout_paid`, `payout_gap`.

### `contracts/rank-rewards` (#774)
Bracket-based rank rewards with a per-bracket rollover cooldown.

- `upsert_bracket(bracket_id, min_rank, max_rank, reward_per_player, rollover_cooldown_secs, paused)` — preserves existing population / total_reward_owed across updates.
- `set_player_rank(user, bracket_id, rank, last_rollover_at)` — admin-gated; inter-bracket migration adjusts both brackets' aggregates atomically.
- **`bracket_reward_summary(bracket_id) -> BracketRewardSummary`** — player count, total reward owed, min/max rank, reward_per_player, cooldown.
- **`rollover_readiness_accessor(user) -> RolloverReadinessInfo`** — `NoRecord` / `MissingBracket` / `NotReady` / `Ready` / `BlockedByPause`, plus `next_rollover_at` and `seconds_until_ready`.

### Workspace
`contracts/Cargo.toml` adds the three crates to `workspace.members`. No exclusions, no existing crate touched.

## Design notes
- **Named response types over tuples**. Every accessor returns a `#[contracttype]` struct so consumers get stable field names in the contract spec instead of positional tuples.
- **Zero-state is explicit**. Each accessor's response includes `configured`, `exists`, and an enum `state` (or `readiness`) so callers can branch on the enum rather than inspecting sentinel zeros.
- **Aggregates are kept in storage**. `record_score` / `record_completion` / `set_player_rank` mutate the matching counter in the config blob, so the summary accessors are O(1) — no per-player scans.
- **Storage invariants preserved**. The existing crates were not modified; new contracts use their own `DataKey` enums to avoid namespace collisions.

## Tests

14 unit tests, all passing:

```
$ cd contracts && cargo test -p stellarcade-ladder-checkpoints -p stellarcade-referral-quests -p stellarcade-rank-rewards
test result: ok. 5 passed; 0 failed   # ladder-checkpoints
test result: ok. 4 passed; 0 failed   # rank-rewards
test result: ok. 5 passed; 0 failed   # referral-quests
```

- **ladder-checkpoints** (5): success path, open-then-closed restore window, empty / missing states, paused checkpoint, drift→active recovery.
- **referral-quests** (5): success path, mark-paid shifts counts + gap, empty / missing states, paused quest preserves totals, duplicate completion panics (`#[should_panic]`).
- **rank-rewards** (4): success path, ready-after-cooldown + BlockedByPause, empty / missing states, atomic bracket migration.

## Disclosures
- The contracts ship as new crates only; no cross-contract integration is included in this PR (the issue scope is the read interface, and there is no existing consumer to wire up). A follow-up could wire `record_*` calls from the order / quest pipelines that already track ladders elsewhere.
- `IMPLEMENTATION_SUMMARY.md` is left as-is — these contracts are new and don't appear in that document; updating it can happen in a docs-pass PR alongside the other recently-added accessor contracts.

## Summary by CodeRabbit

* **New Features**
  * Introduced three new smart contracts for enhanced game progression management: Ladder Checkpoints for tracking player progression across checkpoints with drift detection, Rank Rewards for managing reward brackets and player rank assignments, and Referral Quests for administering quest configurations and tracking player completions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
