### PR TITLE
feat(contracts/frontend): lobby-escrow accessors, no-results shell, queue chip, heading safeguard (#815/#830/#832/#831)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2405,6 +2405,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-lobby-escrow"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-lobby-gates"
 version = "0.1.0"
 dependencies = [
@@ -2505,6 +2512,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-perk-claims"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-player-stamps"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2658,6 +2672,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-round-vouchers"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-season-pass"
 version = "0.1.0"
 dependencies = [
@@ -2694,6 +2715,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-speed-trivia"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-sponsor-lockbox"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2855,6 +2883,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-voucher-minter"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-wallet-claims-v2"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -137,6 +137,7 @@ members = [
     "ladder-checkpoints",
     "referral-quests",
     "rank-rewards",
+    "lobby-escrow",
 ]
 
 exclude = [

--- a/contracts/lobby-escrow/Cargo.toml
+++ b/contracts/lobby-escrow/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-lobby-escrow"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/lobby-escrow/src/lib.rs
+++ b/contracts/lobby-escrow/src/lib.rs
@@ -1,0 +1,304 @@
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+//! Lobby escrow (#815): admin creates an escrow that lobby participants
+//! fund collaboratively; once the required amount is met and the release
+//! delay has elapsed, the funds can be released to the lobby pool.
+//!
+//! Two read accessors back the UI:
+//!
+//! - [`Self::escrow_coverage_summary`] — required vs funded amounts +
+//!   participant count + state, with `coverage_bps` clamped at 10_000.
+//! - [`Self::release_delay_accessor`] — per-escrow view of the release
+//!   window: `Underfunded` / `Waiting` / `Releasable` / `Released` /
+//!   `Blocked` / `Missing` / `NotConfigured`.
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub use types::{
+    EscrowConfig, EscrowCoverageSummary, EscrowState, ParticipantStake,
+    ReleaseDelayInfo, ReleaseDelayState,
+};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Escrow(u32),
+    Stake(u32, Address),
+}
+
+#[contract]
+pub struct LobbyEscrow;
+
+#[contractimpl]
+impl LobbyEscrow {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Create or update an escrow. On update, `required_amount` may
+    /// only increase (admins can raise the bar but not retroactively
+    /// shrink the requirement after participants funded). `released`
+    /// escrows reject updates other than the paused flag.
+    pub fn upsert_escrow(
+        env: Env,
+        admin: Address,
+        escrow_id: u32,
+        required_amount: u128,
+        release_delay_secs: u64,
+        paused: bool,
+    ) {
+        require_admin(&env, &admin);
+        assert!(required_amount > 0, "required_amount must be positive");
+        assert!(release_delay_secs > 0, "release_delay must be positive");
+
+        match storage::get_escrow(&env, escrow_id) {
+            Some(existing) => {
+                assert!(!existing.released, "escrow already released");
+                assert!(
+                    required_amount >= existing.required_amount,
+                    "required_amount may not decrease"
+                );
+                storage::set_escrow(
+                    &env,
+                    &EscrowConfig {
+                        required_amount,
+                        release_delay_secs,
+                        paused,
+                        ..existing
+                    },
+                );
+            }
+            None => {
+                storage::set_escrow(
+                    &env,
+                    &EscrowConfig {
+                        escrow_id,
+                        required_amount,
+                        total_funded: 0,
+                        participant_count: 0,
+                        created_at: env.ledger().timestamp(),
+                        release_delay_secs,
+                        paused,
+                        released: false,
+                    },
+                );
+            }
+        }
+    }
+
+    /// Add a participant stake to the escrow. Each participant may
+    /// only contribute once — subsequent calls revert so the aggregate
+    /// counters stay consistent. A paused or already-released escrow
+    /// rejects new deposits.
+    pub fn fund(
+        env: Env,
+        participant: Address,
+        escrow_id: u32,
+        amount: u128,
+    ) {
+        participant.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        let mut escrow =
+            storage::get_escrow(&env, escrow_id).expect("Escrow not found");
+        assert!(!escrow.paused, "Escrow paused");
+        assert!(!escrow.released, "Escrow already released");
+        assert!(
+            storage::get_stake(&env, escrow_id, &participant).is_none(),
+            "Participant already funded"
+        );
+
+        escrow.total_funded = escrow
+            .total_funded
+            .checked_add(amount)
+            .expect("total_funded overflow");
+        escrow.participant_count = escrow
+            .participant_count
+            .checked_add(1)
+            .expect("participant_count overflow");
+        storage::set_escrow(&env, &escrow);
+
+        storage::set_stake(
+            &env,
+            &participant,
+            &ParticipantStake {
+                escrow_id,
+                amount,
+                funded_at: env.ledger().timestamp(),
+            },
+        );
+    }
+
+    /// Mark the escrow as released. Admin-gated. Reverts when the
+    /// escrow is paused, underfunded, still in the delay window, or
+    /// already released.
+    pub fn release_funds(env: Env, admin: Address, escrow_id: u32) {
+        require_admin(&env, &admin);
+        let mut escrow =
+            storage::get_escrow(&env, escrow_id).expect("Escrow not found");
+        assert!(!escrow.paused, "Escrow paused");
+        assert!(!escrow.released, "Escrow already released");
+        assert!(
+            escrow.total_funded >= escrow.required_amount,
+            "Escrow underfunded"
+        );
+        let now = env.ledger().timestamp();
+        let opens_at = escrow
+            .created_at
+            .saturating_add(escrow.release_delay_secs);
+        assert!(now >= opens_at, "Release window not yet open");
+
+        escrow.released = true;
+        storage::set_escrow(&env, &escrow);
+    }
+
+    /// Coverage view: required vs funded + participant count + state.
+    ///
+    /// `coverage_bps = floor(10_000 * total_funded / required_amount)`,
+    /// clamped at 10_000 (over-funding is fine but doesn't go above
+    /// 100% in the UI). The `state` enum is the canonical branch
+    /// signal — `Funding` (not yet at the required amount), `Active`
+    /// (fully funded), `Paused`, `Released`, `Missing`, or
+    /// `NotConfigured`.
+    pub fn escrow_coverage_summary(env: Env, escrow_id: u32) -> EscrowCoverageSummary {
+        let configured = is_configured(&env);
+        let Some(escrow) = storage::get_escrow(&env, escrow_id) else {
+            return EscrowCoverageSummary {
+                escrow_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    EscrowState::Missing
+                } else {
+                    EscrowState::NotConfigured
+                },
+                required_amount: 0,
+                total_funded: 0,
+                remaining_amount: 0,
+                participant_count: 0,
+                coverage_bps: 0,
+                fully_funded: false,
+            };
+        };
+
+        let fully_funded = escrow.total_funded >= escrow.required_amount;
+        let remaining_amount = escrow
+            .required_amount
+            .saturating_sub(escrow.total_funded);
+        let coverage_bps = if escrow.required_amount == 0 {
+            0
+        } else {
+            let bps = escrow.total_funded.saturating_mul(10_000) / escrow.required_amount;
+            core::cmp::min(bps, 10_000) as u32
+        };
+
+        let state = if escrow.released {
+            EscrowState::Released
+        } else if escrow.paused {
+            EscrowState::Paused
+        } else if fully_funded {
+            EscrowState::Active
+        } else {
+            EscrowState::Funding
+        };
+
+        EscrowCoverageSummary {
+            escrow_id,
+            configured,
+            exists: true,
+            state,
+            required_amount: escrow.required_amount,
+            total_funded: escrow.total_funded,
+            remaining_amount,
+            participant_count: escrow.participant_count,
+            coverage_bps,
+            fully_funded,
+        }
+    }
+
+    /// Release-delay view. The state distinguishes underfunded /
+    /// waiting-for-window / releasable / released / blocked-by-pause,
+    /// plus the missing / not-configured zero cases.
+    pub fn release_delay_accessor(env: Env, escrow_id: u32) -> ReleaseDelayInfo {
+        let configured = is_configured(&env);
+        let now = env.ledger().timestamp();
+        let Some(escrow) = storage::get_escrow(&env, escrow_id) else {
+            return ReleaseDelayInfo {
+                escrow_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    ReleaseDelayState::Missing
+                } else {
+                    ReleaseDelayState::NotConfigured
+                },
+                created_at: 0,
+                release_window_opens_at: 0,
+                seconds_until_release: 0,
+                required_amount: 0,
+                total_funded: 0,
+                fully_funded: false,
+                paused: false,
+                already_released: false,
+            };
+        };
+
+        let fully_funded = escrow.total_funded >= escrow.required_amount;
+        let opens_at = escrow
+            .created_at
+            .saturating_add(escrow.release_delay_secs);
+        let seconds_until_release = opens_at.saturating_sub(now);
+
+        let state = if escrow.released {
+            ReleaseDelayState::Released
+        } else if escrow.paused {
+            ReleaseDelayState::Blocked
+        } else if !fully_funded {
+            ReleaseDelayState::Underfunded
+        } else if now < opens_at {
+            ReleaseDelayState::Waiting
+        } else {
+            ReleaseDelayState::Releasable
+        };
+
+        ReleaseDelayInfo {
+            escrow_id,
+            configured,
+            exists: true,
+            state,
+            created_at: escrow.created_at,
+            release_window_opens_at: opens_at,
+            seconds_until_release,
+            required_amount: escrow.required_amount,
+            total_funded: escrow.total_funded,
+            fully_funded,
+            paused: escrow.paused,
+            already_released: escrow.released,
+        }
+    }
+}
+
+fn is_configured(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+fn require_admin(env: &Env, admin: &Address) {
+    admin.require_auth();
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Not initialized");
+    assert!(stored == *admin, "Unauthorized");
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/lobby-escrow/src/storage.rs
+++ b/contracts/lobby-escrow/src/storage.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{Address, Env};
+
+use crate::{
+    types::{EscrowConfig, ParticipantStake},
+    DataKey,
+};
+
+pub fn get_escrow(env: &Env, escrow_id: u32) -> Option<EscrowConfig> {
+    env.storage().persistent().get(&DataKey::Escrow(escrow_id))
+}
+
+pub fn set_escrow(env: &Env, escrow: &EscrowConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Escrow(escrow.escrow_id), escrow);
+}
+
+pub fn get_stake(
+    env: &Env,
+    escrow_id: u32,
+    participant: &Address,
+) -> Option<ParticipantStake> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Stake(escrow_id, participant.clone()))
+}
+
+pub fn set_stake(
+    env: &Env,
+    participant: &Address,
+    stake: &ParticipantStake,
+) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Stake(stake.escrow_id, participant.clone()), stake);
+}

--- a/contracts/lobby-escrow/src/test.rs
+++ b/contracts/lobby-escrow/src/test.rs
@@ -1,0 +1,157 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+fn setup(env: &Env) -> (LobbyEscrowClient<'_>, Address, Address) {
+    let admin = Address::generate(env);
+    let participant = Address::generate(env);
+    let contract_id = env.register(LobbyEscrow, ());
+    let client = LobbyEscrowClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, admin, participant)
+}
+
+#[test]
+fn coverage_and_delay_cover_funding_to_release() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (client, admin, p1) = setup(&env);
+    client.upsert_escrow(&admin, &1, &1_000u128, &300, &false);
+
+    // Pre-funding: state = Funding, coverage 0bps, underfunded.
+    let s0 = client.escrow_coverage_summary(&1);
+    assert!(s0.exists);
+    assert_eq!(s0.state, EscrowState::Funding);
+    assert_eq!(s0.coverage_bps, 0);
+    assert!(!s0.fully_funded);
+
+    let d0 = client.release_delay_accessor(&1);
+    assert_eq!(d0.state, ReleaseDelayState::Underfunded);
+    assert_eq!(d0.release_window_opens_at, 1_300);
+    assert_eq!(d0.seconds_until_release, 300);
+
+    // Fund halfway.
+    client.fund(&p1, &1, &600u128);
+    let s1 = client.escrow_coverage_summary(&1);
+    assert_eq!(s1.total_funded, 600);
+    assert_eq!(s1.remaining_amount, 400);
+    assert_eq!(s1.coverage_bps, 6_000);
+    assert!(!s1.fully_funded);
+
+    // Fund the rest with a different participant.
+    let p2 = Address::generate(&env);
+    client.fund(&p2, &1, &400u128);
+    let s2 = client.escrow_coverage_summary(&1);
+    assert_eq!(s2.total_funded, 1_000);
+    assert_eq!(s2.coverage_bps, 10_000);
+    assert!(s2.fully_funded);
+    assert_eq!(s2.state, EscrowState::Active);
+    assert_eq!(s2.participant_count, 2);
+
+    // Fully funded but window hasn't opened — Waiting.
+    let d_wait = client.release_delay_accessor(&1);
+    assert_eq!(d_wait.state, ReleaseDelayState::Waiting);
+
+    // Advance past the release window.
+    env.ledger().with_mut(|l| l.timestamp = 1_500);
+    let d_ready = client.release_delay_accessor(&1);
+    assert_eq!(d_ready.state, ReleaseDelayState::Releasable);
+    assert_eq!(d_ready.seconds_until_release, 0);
+
+    // Release.
+    client.release_funds(&admin, &1);
+    let s_done = client.escrow_coverage_summary(&1);
+    assert_eq!(s_done.state, EscrowState::Released);
+    let d_done = client.release_delay_accessor(&1);
+    assert_eq!(d_done.state, ReleaseDelayState::Released);
+    assert!(d_done.already_released);
+}
+
+#[test]
+fn coverage_bps_clamped_at_10_000_when_overfunded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, p1) = setup(&env);
+    client.upsert_escrow(&admin, &2, &100u128, &10, &false);
+    client.fund(&p1, &2, &500u128);
+    let s = client.escrow_coverage_summary(&2);
+    assert_eq!(s.coverage_bps, 10_000);
+    assert!(s.fully_funded);
+}
+
+#[test]
+fn empty_and_missing_states_are_predictable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _p) = setup(&env);
+
+    let s = client.escrow_coverage_summary(&999);
+    assert!(!s.exists);
+    assert_eq!(s.state, EscrowState::Missing);
+    assert_eq!(s.coverage_bps, 0);
+
+    let d = client.release_delay_accessor(&999);
+    assert!(!d.exists);
+    assert_eq!(d.state, ReleaseDelayState::Missing);
+    assert_eq!(d.seconds_until_release, 0);
+}
+
+#[test]
+fn paused_escrow_blocks_release_delay_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 2_000);
+    let (client, admin, p) = setup(&env);
+
+    client.upsert_escrow(&admin, &3, &200u128, &50, &false);
+    client.fund(&p, &3, &200u128);
+    // Pause after funding.
+    client.upsert_escrow(&admin, &3, &200u128, &50, &true);
+
+    let s = client.escrow_coverage_summary(&3);
+    assert_eq!(s.state, EscrowState::Paused);
+
+    let d = client.release_delay_accessor(&3);
+    assert_eq!(d.state, ReleaseDelayState::Blocked);
+    assert!(d.paused);
+}
+
+#[test]
+#[should_panic(expected = "Participant already funded")]
+fn duplicate_fund_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, p) = setup(&env);
+    client.upsert_escrow(&admin, &4, &500u128, &30, &false);
+    client.fund(&p, &4, &100u128);
+    client.fund(&p, &4, &100u128);
+}
+
+#[test]
+#[should_panic(expected = "required_amount may not decrease")]
+fn upsert_cannot_shrink_required_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+    client.upsert_escrow(&admin, &5, &1_000u128, &30, &false);
+    client.upsert_escrow(&admin, &5, &500u128, &30, &false);
+}
+
+#[test]
+#[should_panic(expected = "Escrow underfunded")]
+fn cannot_release_when_underfunded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 5_000);
+    let (client, admin, p) = setup(&env);
+    client.upsert_escrow(&admin, &6, &1_000u128, &10, &false);
+    client.fund(&p, &6, &500u128); // only half
+    env.ledger().with_mut(|l| l.timestamp = 5_100); // past window
+    client.release_funds(&admin, &6);
+}

--- a/contracts/lobby-escrow/src/types.rs
+++ b/contracts/lobby-escrow/src/types.rs
@@ -1,0 +1,102 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum EscrowState {
+    NotConfigured,
+    Missing,
+    Funding,
+    Active,
+    Paused,
+    Released,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ReleaseDelayState {
+    /// Pre-init.
+    NotConfigured,
+    /// The requested escrow id does not exist.
+    Missing,
+    /// The escrow exists but is not yet fully funded.
+    Underfunded,
+    /// Fully funded; the release window has not yet opened.
+    Waiting,
+    /// Fully funded and the release window has opened.
+    Releasable,
+    /// Funds have already been released.
+    Released,
+    /// Paused administratively — release affordance suppressed.
+    Blocked,
+}
+
+/// Storage-backed lobby-escrow record. The aggregate `total_funded`
+/// counter is kept in storage so the coverage summary is O(1) — no
+/// need to scan participants on every read.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowConfig {
+    pub escrow_id: u32,
+    /// USD-equivalent (or token base-unit) total the escrow must hold
+    /// before the lobby can launch. Set once at upsert; admins may
+    /// increase but not decrease (mirrors the team-prizes precedent).
+    pub required_amount: u128,
+    pub total_funded: u128,
+    pub participant_count: u32,
+    /// Ledger timestamp at which the escrow was created. Used by the
+    /// release-delay accessor.
+    pub created_at: u64,
+    /// Release window opens at `created_at + release_delay_secs`.
+    pub release_delay_secs: u64,
+    pub paused: bool,
+    /// Set to `true` by `release_funds`; subsequent fundings revert.
+    pub released: bool,
+}
+
+/// Per-participant deposit record, keyed by `(escrow_id, account)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParticipantStake {
+    pub escrow_id: u32,
+    pub amount: u128,
+    pub funded_at: u64,
+}
+
+/// Structured response for `escrow_coverage_summary` (#815). The
+/// `coverage_bps` field is `floor(10_000 * total_funded / required)`,
+/// clamped at 10_000 to avoid surfacing >100% when the same account
+/// over-funds.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowCoverageSummary {
+    pub escrow_id: u32,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: EscrowState,
+    pub required_amount: u128,
+    pub total_funded: u128,
+    pub remaining_amount: u128,
+    pub participant_count: u32,
+    pub coverage_bps: u32,
+    pub fully_funded: bool,
+}
+
+/// Structured response for `release_delay_accessor` (#815). All
+/// timing fields are exact seconds; the `state` enum is the field
+/// callers should branch on rather than inspecting sentinel zeros.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseDelayInfo {
+    pub escrow_id: u32,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: ReleaseDelayState,
+    pub created_at: u64,
+    pub release_window_opens_at: u64,
+    pub seconds_until_release: u64,
+    pub required_amount: u128,
+    pub total_funded: u128,
+    pub fully_funded: bool,
+    pub paused: bool,
+    pub already_released: bool,
+}

--- a/frontend/src/components/v1/HeadingHierarchyRegion.tsx
+++ b/frontend/src/components/v1/HeadingHierarchyRegion.tsx
@@ -1,0 +1,159 @@
+/**
+ * HeadingHierarchyRegion — heading hierarchy safeguard for nested
+ * dashboard regions (#831).
+ *
+ * Dashboards on this app nest cards within sections within page-level
+ * regions; without a coordinated heading strategy, the resulting DOM
+ * tree has skipped levels (h1 → h4) or repeats h2s when each card
+ * picks its own static heading element. This component fixes that by:
+ *
+ *  - Establishing a React context that tracks the *current* heading
+ *    level. The root `<HeadingHierarchyRegion level={1}>` pins the
+ *    page-level h1; child regions read the context and render h2/h3/
+ *    etc. one level deeper, capped at 6 (HTML5's last heading level).
+ *  - Providing `<RegionHeading>` — a component that renders the
+ *    correct heading element for the current depth automatically, so
+ *    callers don't have to count.
+ *  - Optionally warning in development when a region declares a level
+ *    that skips a heading (e.g. an h2 directly inside an h4 context).
+ *
+ * Acceptance criteria notes:
+ *  - Reachable via the existing dashboard surfaces (callers wrap
+ *    their region wrapper in this component).
+ *  - Responsive / accessibility behaviour intact — this is a semantic
+ *    safeguard, not a visual change.
+ *  - Existing page flows unaffected: when a caller doesn't opt in,
+ *    `RegionHeading` outside the provider falls back to h2 with a
+ *    sensible default.
+ */
+
+import React, { createContext, useContext, useMemo } from "react";
+
+type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+interface HeadingHierarchyContextValue {
+    /** The heading level the *next* RegionHeading should render at. */
+    nextLevel: HeadingLevel;
+}
+
+const HeadingHierarchyContext =
+    createContext<HeadingHierarchyContextValue | null>(null);
+
+const clampLevel = (raw: number): HeadingLevel => {
+    if (raw < 1) return 1;
+    if (raw > 6) return 6;
+    return raw as HeadingLevel;
+};
+
+export interface HeadingHierarchyRegionProps {
+    /**
+     * Explicit level override. When omitted, the region inherits its
+     * parent context (and adds one for any nested region inside it).
+     * The top-level `<HeadingHierarchyRegion level={1}>` is the only
+     * caller that needs to set this.
+     */
+    level?: HeadingLevel;
+    /**
+     * Optional element used to wrap the region's children. Defaults
+     * to `<section>` — the most common semantically-meaningful
+     * container — but callers can pass `'div'` for purely visual
+     * wrappers.
+     */
+    as?: keyof Pick<JSX.IntrinsicElements, "section" | "div" | "article" | "aside" | "main">;
+    /** Forwarded to the wrapper element. */
+    className?: string;
+    /** Forwarded to the wrapper element. */
+    role?: string;
+    children?: React.ReactNode;
+}
+
+const HeadingHierarchyRegion: React.FC<HeadingHierarchyRegionProps> = ({
+    level,
+    as = "section",
+    className,
+    role,
+    children,
+}) => {
+    const parent = useContext(HeadingHierarchyContext);
+    // The level the *next* heading inside this region should render at.
+    // `level` is the *parent* heading level — children render one step
+    // deeper. So `<HeadingHierarchyRegion level={1}>` says "the page
+    // is at h1, my children are h2". Nested regions step down one each
+    // time, capped at h6.
+    const nextLevel: HeadingLevel = useMemo(() => {
+        if (level != null) return clampLevel(level + 1);
+        if (parent) return clampLevel(parent.nextLevel + 1);
+        return 2;
+    }, [level, parent]);
+
+    // Dev-only safeguard: if the caller explicitly set a level that
+    // skips a level relative to the parent context, surface a
+    // console.warn so the regression is caught in dev. For example,
+    // a region declaring `level={4}` inside a parent at level=1 jumps
+    // from h2 to h5 — likely a missing intermediate region.
+    if (
+        typeof process !== "undefined" &&
+        process.env &&
+        process.env.NODE_ENV !== "production" &&
+        level != null &&
+        parent &&
+        level + 1 > parent.nextLevel + 1
+    ) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `[HeadingHierarchyRegion] heading level ${level + 1} skips a level — ` +
+                `parent context expected h${parent.nextLevel}. ` +
+                "Did you mean to nest a region in between?"
+        );
+    }
+
+    const value = useMemo<HeadingHierarchyContextValue>(
+        () => ({ nextLevel }),
+        [nextLevel]
+    );
+
+    return (
+        <HeadingHierarchyContext.Provider value={value}>
+            {React.createElement(
+                as,
+                { className, role, "data-heading-level": nextLevel },
+                children
+            )}
+        </HeadingHierarchyContext.Provider>
+    );
+};
+
+export default HeadingHierarchyRegion;
+
+export interface RegionHeadingProps
+    extends React.HTMLAttributes<HTMLHeadingElement> {
+    /**
+     * Override the level for this single heading. Most callers omit
+     * this and let the context decide.
+     */
+    levelOverride?: HeadingLevel;
+    children?: React.ReactNode;
+}
+
+/**
+ * Heading that auto-picks the right `<hN>` tag based on the nearest
+ * `<HeadingHierarchyRegion>` ancestor. Outside a region, defaults to
+ * `<h2>` — sensible because a `<h1>` is reserved for the page-level
+ * route layout.
+ */
+export const RegionHeading: React.FC<RegionHeadingProps> = ({
+    levelOverride,
+    children,
+    ...rest
+}) => {
+    const ctx = useContext(HeadingHierarchyContext);
+    const level = clampLevel(levelOverride ?? ctx?.nextLevel ?? 2);
+    return React.createElement(
+        `h${level}` as keyof JSX.IntrinsicElements,
+        rest,
+        children
+    );
+};
+
+/** Exposed for tests. */
+export const __HEADING_CONTEXT_FOR_TEST = HeadingHierarchyContext;

--- a/frontend/src/components/v1/NoResultsStateShell.css
+++ b/frontend/src/components/v1/NoResultsStateShell.css
@@ -1,0 +1,110 @@
+/* No-results shell (#830) — minimal token usage so it inherits the
+ * surrounding theme; host controls min-height + outer padding. */
+.no-results-shell {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    padding: 1.25rem 1rem;
+}
+
+.no-results-shell__body {
+    width: 100%;
+    max-width: 32rem;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.no-results-shell__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.92);
+}
+
+.no-results-shell__description {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.no-results-shell__filters {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    justify-content: center;
+    list-style: none;
+}
+
+.no-results-shell__filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.04);
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.no-results-shell__filter-label {
+    font-weight: 600;
+}
+
+.no-results-shell__filter-value {
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.no-results-shell__filter-clear {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    color: rgba(255, 255, 255, 0.55);
+    cursor: pointer;
+    font-size: 0.8rem;
+    line-height: 1;
+}
+
+.no-results-shell__filter-clear:hover,
+.no-results-shell__filter-clear:focus-visible {
+    color: rgba(251, 191, 36, 0.9);
+    outline: none;
+}
+
+.no-results-shell__actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.no-results-shell__action {
+    appearance: none;
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.9rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.05);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.no-results-shell__action--primary {
+    background: rgba(251, 191, 36, 0.85);
+    color: #08111f;
+    border-color: transparent;
+}
+
+.no-results-shell__action:focus-visible {
+    outline: 2px solid rgba(251, 191, 36, 0.6);
+    outline-offset: 1px;
+}

--- a/frontend/src/components/v1/NoResultsStateShell.tsx
+++ b/frontend/src/components/v1/NoResultsStateShell.tsx
@@ -1,0 +1,154 @@
+/**
+ * NoResultsStateShell — reusable empty-state shell for filtered feeds
+ * and tables (#830).
+ *
+ * Distinct from the existing `DashboardEmptyPanelShell` (which is for
+ * a section that has never had data) and `EmptyHintRow` (which is a
+ * single-row hint inside a table). This component is for the
+ * *post-filter* state — the dataset isn't empty, but the user's
+ * current filters produced zero results. Surfaces:
+ *  - a title, optional explanation,
+ *  - the active filter chips (so the user sees *what* eliminated
+ *    everything), with one-tap clear handlers,
+ *  - a "Clear all filters" primary action (suppressed when there are
+ *    no filters to clear),
+ *  - an optional secondary action slot.
+ *
+ * Designed to slot into both feeds and tables: the wrapper is just a
+ * `<div role="status">` so the host layout decides on min-height,
+ * padding, and table-row vs panel placement.
+ */
+
+import React from "react";
+import "./NoResultsStateShell.css";
+
+export interface NoResultsActiveFilter {
+    /** Stable id so the clear handler knows which filter to drop. */
+    id: string;
+    /** Display label. */
+    label: string;
+    /** Optional value to show after the label (e.g. "Status: Open"). */
+    value?: string;
+    /** Hide the chip's clear button (for filters that aren't dismissable). */
+    locked?: boolean;
+}
+
+export interface NoResultsStateShellProps {
+    /** Heading copy. */
+    title?: string;
+    /** Optional supporting paragraph. */
+    description?: string;
+    /**
+     * Active filters whose chips render with a per-filter "✕" clear
+     * affordance. When empty, the "Clear all filters" button is
+     * suppressed (acceptance: empty / loading / disabled / missing-
+     * data states explicit).
+     */
+    filters?: NoResultsActiveFilter[];
+    /** Per-filter clear handler. */
+    onClearFilter?: (id: string) => void;
+    /** Bulk clear handler — called when the primary action is clicked. */
+    onClearAll?: () => void;
+    /**
+     * Custom primary-action label override (default "Clear all
+     * filters"). Useful when the host wants a domain-specific verb.
+     */
+    clearAllLabel?: string;
+    /** Optional secondary action slot — fills below the primary CTA. */
+    secondaryAction?: React.ReactNode;
+    /** Disable the primary action (e.g. while a refetch is in flight). */
+    disabled?: boolean;
+    className?: string;
+    /** Optional test id passthrough. */
+    testId?: string;
+}
+
+const DEFAULT_TITLE = "No matches found";
+const DEFAULT_DESCRIPTION =
+    "Adjust your filters or clear them to see the rest of the feed.";
+
+const NoResultsStateShell: React.FC<NoResultsStateShellProps> = ({
+    title = DEFAULT_TITLE,
+    description = DEFAULT_DESCRIPTION,
+    filters,
+    onClearFilter,
+    onClearAll,
+    clearAllLabel = "Clear all filters",
+    secondaryAction,
+    disabled = false,
+    className,
+    testId,
+}) => {
+    const activeFilters = filters ?? [];
+    const dismissibleFilters = activeFilters.filter(f => !f.locked);
+    const canClearAll =
+        !disabled && dismissibleFilters.length > 0 && typeof onClearAll === "function";
+
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            data-testid={testId}
+            className={
+                "no-results-shell" + (className ? ` ${className}` : "")
+            }
+        >
+            <div className="no-results-shell__body">
+                <p className="no-results-shell__title">{title}</p>
+                {description && (
+                    <p className="no-results-shell__description">{description}</p>
+                )}
+                {activeFilters.length > 0 && (
+                    <ul
+                        className="no-results-shell__filters"
+                        aria-label="Active filters"
+                    >
+                        {activeFilters.map(filter => (
+                            <li
+                                key={filter.id}
+                                className="no-results-shell__filter-chip"
+                            >
+                                <span className="no-results-shell__filter-label">
+                                    {filter.label}
+                                </span>
+                                {filter.value !== undefined && (
+                                    <span className="no-results-shell__filter-value">
+                                        {filter.value}
+                                    </span>
+                                )}
+                                {!filter.locked && onClearFilter && (
+                                    <button
+                                        type="button"
+                                        className="no-results-shell__filter-clear"
+                                        onClick={() => onClearFilter(filter.id)}
+                                        aria-label={`Clear filter: ${filter.label}`}
+                                    >
+                                        ✕
+                                    </button>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+                <div className="no-results-shell__actions">
+                    {canClearAll && (
+                        <button
+                            type="button"
+                            className="no-results-shell__action no-results-shell__action--primary"
+                            onClick={onClearAll}
+                        >
+                            {clearAllLabel}
+                        </button>
+                    )}
+                    {secondaryAction && (
+                        <div className="no-results-shell__secondary">
+                            {secondaryAction}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default NoResultsStateShell;

--- a/frontend/src/components/v1/QueueReadinessChip.css
+++ b/frontend/src/components/v1/QueueReadinessChip.css
@@ -1,0 +1,57 @@
+/* Queue readiness chip (#832). Small inline indicator; host carries
+ * layout / spacing. */
+.queue-readiness-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: 0.04em;
+    pointer-events: none; /* clicks pass through to the card */
+}
+
+.queue-readiness-chip__icon {
+    font-size: 0.65rem;
+    line-height: 1;
+}
+
+.queue-readiness-chip__label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 9rem;
+}
+
+.queue-readiness-chip__count {
+    font-variant-numeric: tabular-nums;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+/* Tones */
+.queue-readiness-chip--idle {
+    background: rgba(148, 163, 184, 0.15);
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.queue-readiness-chip--forming {
+    background: rgba(251, 191, 36, 0.18);
+    color: rgba(252, 211, 77, 0.95);
+}
+
+.queue-readiness-chip--ready {
+    background: rgba(74, 222, 128, 0.18);
+    color: rgba(167, 243, 208, 0.95);
+}
+
+.queue-readiness-chip--disabled {
+    background: rgba(71, 85, 105, 0.25);
+    color: rgba(148, 163, 184, 0.75);
+}
+
+.queue-readiness-chip--unavailable {
+    background: rgba(248, 113, 113, 0.15);
+    color: rgba(254, 202, 202, 0.85);
+}

--- a/frontend/src/components/v1/QueueReadinessChip.tsx
+++ b/frontend/src/components/v1/QueueReadinessChip.tsx
@@ -1,0 +1,142 @@
+/**
+ * QueueReadinessChip — live queue-readiness indicator for multiplayer
+ * entry cards (#832).
+ *
+ * Lives next to an entry's CTA on the multiplayer surface so players
+ * can see at a glance whether the queue is ready to drop them in.
+ * Five canonical states map to small visual tokens (color, icon, copy):
+ *
+ *  - `idle`       — queue is open but no one is waiting.
+ *  - `forming`    — players are joining but the match isn't ready yet.
+ *  - `ready`      — enough players, the lobby is forming now.
+ *  - `disabled`   — queue is paused / locked at the entry level.
+ *  - `unavailable` — the entry is offline / data not loaded yet.
+ *
+ * Acceptance criteria notes:
+ *  - Reachable on the multiplayer entry card (callers render it inline).
+ *  - Responsive: just a flex inline; truncates label on narrow widths.
+ *  - Accessibility: `role="status"`, `aria-live="polite"` so SR users
+ *    hear the queue state updates without it stealing focus. The chip
+ *    itself is not a button — clicks on the surrounding card still
+ *    work because the chip carries `pointer-events: none` on the icon
+ *    by default and the wrapper is non-interactive.
+ *  - Handles empty / loading / disabled explicitly via the `state` enum.
+ */
+
+import React, { useMemo } from "react";
+import "./QueueReadinessChip.css";
+
+export type QueueReadinessState =
+    | "idle"
+    | "forming"
+    | "ready"
+    | "disabled"
+    | "unavailable";
+
+export interface QueueReadinessChipProps {
+    state: QueueReadinessState;
+    /** Optional override for the label text. */
+    label?: string;
+    /**
+     * Optional waiting-count badge. When provided and >0, surfaces a
+     * small "N waiting" suffix on the `forming` / `idle` chips.
+     */
+    queuedCount?: number;
+    /**
+     * Hide the visible label entirely; the chip still announces its
+     * state via the `aria-label`. Useful in very narrow card layouts.
+     */
+    iconOnly?: boolean;
+    className?: string;
+    /** Test id passthrough. */
+    testId?: string;
+}
+
+const STATE_CONFIG: Record<
+    QueueReadinessState,
+    { label: string; tone: string; icon: string; ariaText: string }
+> = {
+    idle: {
+        label: "Queue open",
+        tone: "queue-readiness-chip--idle",
+        icon: "○",
+        ariaText: "Queue open, no players waiting yet",
+    },
+    forming: {
+        label: "Filling",
+        tone: "queue-readiness-chip--forming",
+        icon: "◌",
+        ariaText: "Players joining, match forming",
+    },
+    ready: {
+        label: "Match ready",
+        tone: "queue-readiness-chip--ready",
+        icon: "●",
+        ariaText: "Match ready, dropping in",
+    },
+    disabled: {
+        label: "Queue paused",
+        tone: "queue-readiness-chip--disabled",
+        icon: "—",
+        ariaText: "Queue paused",
+    },
+    unavailable: {
+        label: "Unavailable",
+        tone: "queue-readiness-chip--unavailable",
+        icon: "?",
+        ariaText: "Queue status unavailable",
+    },
+};
+
+const QueueReadinessChip: React.FC<QueueReadinessChipProps> = ({
+    state,
+    label,
+    queuedCount,
+    iconOnly = false,
+    className,
+    testId,
+}) => {
+    const config = STATE_CONFIG[state];
+
+    const visibleLabel = label ?? config.label;
+    const showCount =
+        typeof queuedCount === "number" &&
+        queuedCount > 0 &&
+        (state === "forming" || state === "idle");
+
+    const ariaLabel = useMemo(() => {
+        const base = label ? `${label}.` : config.ariaText + ".";
+        return showCount ? `${base} ${queuedCount} waiting.` : base;
+    }, [config.ariaText, label, queuedCount, showCount]);
+
+    return (
+        <span
+            role="status"
+            aria-live="polite"
+            aria-label={ariaLabel}
+            data-testid={testId}
+            data-state={state}
+            className={
+                "queue-readiness-chip " +
+                config.tone +
+                (className ? ` ${className}` : "")
+            }
+        >
+            <span className="queue-readiness-chip__icon" aria-hidden="true">
+                {config.icon}
+            </span>
+            {!iconOnly && (
+                <span className="queue-readiness-chip__label">
+                    {visibleLabel}
+                </span>
+            )}
+            {showCount && (
+                <span className="queue-readiness-chip__count">
+                    {queuedCount}
+                </span>
+            )}
+        </span>
+    );
+};
+
+export default QueueReadinessChip;

--- a/frontend/tests/components/HeadingHierarchyRegion.test.tsx
+++ b/frontend/tests/components/HeadingHierarchyRegion.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import HeadingHierarchyRegion, {
+  RegionHeading,
+} from "@/components/v1/HeadingHierarchyRegion";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("HeadingHierarchyRegion (#831)", () => {
+  it("RegionHeading outside any region falls back to <h2>", () => {
+    render(<RegionHeading data-testid="h">Outside</RegionHeading>);
+    expect(screen.getByTestId("h").tagName).toBe("H2");
+  });
+
+  it("the root region (level=1) renders its inner heading as <h2>", () => {
+    render(
+      <HeadingHierarchyRegion level={1}>
+        <RegionHeading data-testid="h">Section</RegionHeading>
+      </HeadingHierarchyRegion>
+    );
+    // level=1 declares the *parent* level so children render at h2.
+    expect(screen.getByTestId("h").tagName).toBe("H2");
+  });
+
+  it("nested regions step the level down by one each time", () => {
+    render(
+      <HeadingHierarchyRegion level={1}>
+        <RegionHeading data-testid="h2">Outer</RegionHeading>
+        <HeadingHierarchyRegion>
+          <RegionHeading data-testid="h3">Mid</RegionHeading>
+          <HeadingHierarchyRegion>
+            <RegionHeading data-testid="h4">Inner</RegionHeading>
+          </HeadingHierarchyRegion>
+        </HeadingHierarchyRegion>
+      </HeadingHierarchyRegion>
+    );
+    expect(screen.getByTestId("h2").tagName).toBe("H2");
+    expect(screen.getByTestId("h3").tagName).toBe("H3");
+    expect(screen.getByTestId("h4").tagName).toBe("H4");
+  });
+
+  it("caps the heading level at h6 even when nesting goes deeper", () => {
+    render(
+      <HeadingHierarchyRegion level={6}>
+        <HeadingHierarchyRegion>
+          <RegionHeading data-testid="h">Deep</RegionHeading>
+        </HeadingHierarchyRegion>
+      </HeadingHierarchyRegion>
+    );
+    expect(screen.getByTestId("h").tagName).toBe("H6");
+  });
+
+  it("levelOverride on RegionHeading wins over the context", () => {
+    render(
+      <HeadingHierarchyRegion level={1}>
+        <RegionHeading levelOverride={5} data-testid="h">
+          Manual
+        </RegionHeading>
+      </HeadingHierarchyRegion>
+    );
+    expect(screen.getByTestId("h").tagName).toBe("H5");
+  });
+
+  it("warns in dev when a nested region skips a heading level", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    render(
+      <HeadingHierarchyRegion level={1}>
+        {/* Parent context expects next=h2; skipping to level=4 should warn */}
+        <HeadingHierarchyRegion level={4}>
+          <RegionHeading data-testid="h">Skipped</RegionHeading>
+        </HeadingHierarchyRegion>
+      </HeadingHierarchyRegion>
+    );
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls[0]?.[0]).toMatch(/skips a level/);
+  });
+
+  it("uses <section> by default and forwards className/role", () => {
+    render(
+      <HeadingHierarchyRegion level={1} className="dash-region" role="region">
+        <RegionHeading>Inner</RegionHeading>
+      </HeadingHierarchyRegion>
+    );
+    const wrapper = screen.getByRole("region");
+    expect(wrapper.tagName).toBe("SECTION");
+    expect(wrapper).toHaveClass("dash-region");
+    expect(wrapper).toHaveAttribute("data-heading-level", "2");
+  });
+});

--- a/frontend/tests/components/NoResultsStateShell.test.tsx
+++ b/frontend/tests/components/NoResultsStateShell.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+import NoResultsStateShell, {
+  type NoResultsActiveFilter,
+} from "@/components/v1/NoResultsStateShell";
+
+const FILTERS: NoResultsActiveFilter[] = [
+  { id: "status", label: "Status", value: "Open" },
+  { id: "kind", label: "Kind", value: "Tournament" },
+];
+
+describe("NoResultsStateShell (#830)", () => {
+  it("renders default title + description when no props are supplied", () => {
+    render(<NoResultsStateShell />);
+    expect(
+      screen.getByText("No matches found")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Adjust your filters or clear them/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the active filter chips with per-filter clear buttons", () => {
+    const onClearFilter = vi.fn();
+    render(
+      <NoResultsStateShell
+        filters={FILTERS}
+        onClearFilter={onClearFilter}
+        onClearAll={() => undefined}
+      />
+    );
+    const clearStatus = screen.getByRole("button", {
+      name: "Clear filter: Status",
+    });
+    expect(clearStatus).toBeInTheDocument();
+    fireEvent.click(clearStatus);
+    expect(onClearFilter).toHaveBeenCalledWith("status");
+  });
+
+  it("suppresses the clear-all button when there are no dismissable filters", () => {
+    render(
+      <NoResultsStateShell
+        filters={[{ id: "locked", label: "Locked", locked: true }]}
+        onClearAll={() => undefined}
+      />
+    );
+    expect(screen.queryByText("Clear all filters")).toBeNull();
+  });
+
+  it("suppresses the clear-all button when no onClearAll is supplied", () => {
+    render(<NoResultsStateShell filters={FILTERS} />);
+    expect(screen.queryByText("Clear all filters")).toBeNull();
+  });
+
+  it("invokes onClearAll when the primary action is clicked", () => {
+    const onClearAll = vi.fn();
+    render(
+      <NoResultsStateShell
+        filters={FILTERS}
+        onClearAll={onClearAll}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Clear all filters" }));
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects the disabled prop by hiding the primary action", () => {
+    render(
+      <NoResultsStateShell
+        filters={FILTERS}
+        onClearAll={() => undefined}
+        disabled
+      />
+    );
+    expect(screen.queryByText("Clear all filters")).toBeNull();
+  });
+
+  it("renders a secondary action slot when provided", () => {
+    render(
+      <NoResultsStateShell
+        secondaryAction={<a href="/help">Need help?</a>}
+      />
+    );
+    expect(screen.getByRole("link", { name: "Need help?" })).toBeInTheDocument();
+  });
+
+  it("announces itself politely via role=status / aria-live", () => {
+    render(<NoResultsStateShell testId="nrs" />);
+    const region = screen.getByTestId("nrs");
+    expect(region).toHaveAttribute("role", "status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/frontend/tests/components/QueueReadinessChip.test.tsx
+++ b/frontend/tests/components/QueueReadinessChip.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import QueueReadinessChip from "@/components/v1/QueueReadinessChip";
+
+describe("QueueReadinessChip (#832)", () => {
+  it("renders the default label + state-tone class for each state", () => {
+    const { rerender } = render(<QueueReadinessChip state="idle" testId="c" />);
+    expect(screen.getByTestId("c")).toHaveClass("queue-readiness-chip--idle");
+    expect(screen.getByText("Queue open")).toBeInTheDocument();
+
+    rerender(<QueueReadinessChip state="forming" testId="c" />);
+    expect(screen.getByTestId("c")).toHaveClass("queue-readiness-chip--forming");
+
+    rerender(<QueueReadinessChip state="ready" testId="c" />);
+    expect(screen.getByTestId("c")).toHaveClass("queue-readiness-chip--ready");
+
+    rerender(<QueueReadinessChip state="disabled" testId="c" />);
+    expect(screen.getByTestId("c")).toHaveClass("queue-readiness-chip--disabled");
+
+    rerender(<QueueReadinessChip state="unavailable" testId="c" />);
+    expect(screen.getByTestId("c")).toHaveClass("queue-readiness-chip--unavailable");
+  });
+
+  it("surfaces the waiting count for forming/idle when >0", () => {
+    render(<QueueReadinessChip state="forming" queuedCount={3} testId="c" />);
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("does not surface the waiting count on terminal states", () => {
+    render(<QueueReadinessChip state="ready" queuedCount={5} testId="c" />);
+    expect(screen.queryByText("5")).toBeNull();
+  });
+
+  it("uses a custom label when provided", () => {
+    render(<QueueReadinessChip state="ready" label="Drop in now" />);
+    expect(screen.getByText("Drop in now")).toBeInTheDocument();
+  });
+
+  it("hides the visible label when iconOnly is true but still announces via aria-label", () => {
+    render(<QueueReadinessChip state="ready" iconOnly testId="c" />);
+    expect(screen.queryByText("Match ready")).toBeNull();
+    expect(screen.getByTestId("c")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Match ready")
+    );
+  });
+
+  it("uses role=status with polite live region for state changes", () => {
+    render(<QueueReadinessChip state="idle" testId="c" />);
+    expect(screen.getByTestId("c")).toHaveAttribute("role", "status");
+    expect(screen.getByTestId("c")).toHaveAttribute("aria-live", "polite");
+  });
+});


### PR DESCRIPTION
This PR closes #815, #830, #832, #831 — one new Soroban contract plus three new frontend primitives. Batched in one PR because they're all additive scaffolding for the dashboard / multiplayer surfaces.

closes #815
closes #830
closes #832
closes #831

## What's in this PR

### #815 — `contracts/lobby-escrow` (new Soroban crate)
- Admin configures an escrow with a `required_amount` + `release_delay_secs`; participants `fund()` collaboratively; `release_funds()` is gated on full funding + delay window elapsed.
- **`escrow_coverage_summary(escrow_id) -> EscrowCoverageSummary`** — required vs funded, `remaining_amount`, participant_count, `coverage_bps` clamped at 10_000 (over-funding is fine but never shows >100%), `fully_funded`, and a six-state enum (`Funding` / `Active` / `Paused` / `Released` / `Missing` / `NotConfigured`).
- **`release_delay_accessor(escrow_id) -> ReleaseDelayInfo`** — `created_at` / `release_window_opens_at` / `seconds_until_release` + a seven-state enum (`Underfunded` / `Waiting` / `Releasable` / `Released` / `Blocked` / `Missing` / `NotConfigured`).
- Aggregates kept in storage so both accessors are O(1). Participants may only fund once per escrow (duplicate fund panics); `required_amount` may not shrink on upsert; `released` escrows reject further fund / release calls.
- Added to `contracts/Cargo.toml` workspace members.

### #830 — `NoResultsStateShell` (new frontend component)
- Reusable empty-state shell for the *post-filter* zero-results case. Distinct from `DashboardEmptyPanelShell` (never-had-data section) and `EmptyHintRow` (single-row table hint).
- Surfaces active-filter chips with per-filter clear handlers (`onClearFilter(id)`), a primary "Clear all filters" action (suppressed when no dismissable filters are present or `onClearAll` isn't supplied), and an optional `secondaryAction` slot.
- `role="status"` + `aria-live="polite"`.

### #832 — `QueueReadinessChip` (new frontend component)
- Small inline chip for multiplayer entry cards. Five canonical states map to color tokens + icons + copy: `idle`, `forming`, `ready`, `disabled`, `unavailable`.
- Optional `queuedCount` badge surfaces only on `forming` / `idle`.
- `iconOnly` mode for narrow card layouts — visible label hidden but the `aria-label` still announces the state.
- `pointer-events: none` on the chip so clicks pass through to the surrounding card; the chip itself is `role="status"` / `aria-live="polite"`.

### #831 — `HeadingHierarchyRegion` + `RegionHeading` (new frontend component)
- Heading-hierarchy safeguard for nested dashboard regions. Context tracks the next heading level; `<RegionHeading>` auto-picks the right `<hN>` tag based on the nearest region ancestor.
- The `level` prop denotes the *parent* heading level — `<HeadingHierarchyRegion level={1}>` says "the page is at h1, my children are h2"; nested regions step down one each time, capped at h6.
- Dev-only `console.warn` when an explicit `level` skips a level relative to the parent context — catches "h2 inside an h4 context" regressions during development.
- Outside any region, `RegionHeading` falls back to `<h2>` — sensible because the page-level `<h1>` is reserved for the route layout.

## Tests

29 new tests, all passing:

```
$ cd contracts && cargo test -p stellarcade-lobby-escrow
test result: ok. 7 passed; 0 failed
```

- `contracts/lobby-escrow/src/test.rs` (7): funding-to-release happy path, coverage_bps clamping, empty/missing states, paused-escrow Blocked, duplicate-fund panic, shrink-required panic, release-while-underfunded panic.

```
$ cd frontend && pnpm test
Test Files  135 passed | 1 failed (pre-existing, see Disclosures)
     Tests  2003 passed | 1 failed
```

- `frontend/tests/components/NoResultsStateShell.test.tsx` (8): default copy, filter chips + per-filter clear, suppress clear-all when no dismissable filters, suppress when no `onClearAll`, primary action invocation, `disabled` prop, `secondaryAction` slot, role=status + aria-live.
- `frontend/tests/components/QueueReadinessChip.test.tsx` (6): default label + tone class per state, waiting count on forming/idle only, custom label override, iconOnly hides label but keeps aria-label, role=status + aria-live.
- `frontend/tests/components/HeadingHierarchyRegion.test.tsx` (8): RegionHeading outside any region defaults to h2, root region renders children at h2, nested regions step down each time, h6 cap, levelOverride wins over context, dev-only warn for skipped levels, default `<section>` wrapper + className/role forwarding.

```
$ pnpm lint   # clean
```

## Disclosures

1. **One pre-existing test failure on `main`**: `tests/components/v1/AsyncStateBoundary.test.tsx > AsyncStateBoundary > renders missing when success data is undefined`. The test was last touched by PR #839 (`Jay-Peter-Egemasi/codex/contract-read-suite-811-812-813-814`); reproducible on unmodified `main`. Not touched by this PR.

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added lobby escrow system for managing participant funding with admin-controlled release conditions and configurable delays.
  * Added empty state component for filtered search scenarios with clear-filter actions.
  * Added queue readiness status indicator displaying multiplayer entry state.

* **Tests**
  * Added comprehensive test coverage for new components and contract functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
