### PR TITLE
Add backlog accessors for payout, perks, tickets, and quests

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2511,6 +2511,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-player-stamps"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-price-prediction"
 version = "0.1.0"
 dependencies = [
@@ -2658,6 +2665,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellarcade-round-vouchers"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
 name = "stellarcade-season-pass"
 version = "0.1.0"
 dependencies = [
@@ -2694,6 +2708,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-speed-trivia"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-sponsor-lockbox"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",
@@ -2855,6 +2876,13 @@ dependencies = [
 
 [[package]]
 name = "stellarcade-voucher-minter"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.1",
+]
+
+[[package]]
+name = "stellarcade-wallet-claims-v2"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk 25.3.1",

--- a/contracts/attendance-pass/src/lib.rs
+++ b/contracts/attendance-pass/src/lib.rs
@@ -6,8 +6,8 @@ mod types;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 pub use types::{
-    CheckInCoverageSummary, ExpiryBand, HolderCoverageSummary, PassRecord, PassStatus,
-    ResaleLockStatus,
+    CheckInCoverageSummary, ExpiryBand, HolderCoverageSummary, PassRecord,
+    PassStatus, RedemptionReadinessSnapshot, ResaleLockStatus,
 };
 
 #[contracttype]
@@ -120,6 +120,62 @@ impl AttendancePass {
             configured,
             exists: true,
             status,
+            issued_at: record.issued_at,
+            expires_at: record.expires_at,
+            now,
+        }
+    }
+
+    /// Returns a readiness snapshot for redeeming a pass.
+    ///
+    /// Empty/missing behavior:
+    /// - Unknown `pass_id` returns `exists = false` and zero-value fields.
+    /// - Not-yet-configured contracts return `configured = false` and `status = NotConfigured`.
+    pub fn redemption_readiness_snapshot(
+        env: Env,
+        pass_id: u64,
+    ) -> RedemptionReadinessSnapshot {
+        let now = env.ledger().timestamp();
+        let configured = env.storage().instance().has(&DataKey::Admin);
+
+        let Some(record) = storage::get_pass(&env, pass_id) else {
+            return RedemptionReadinessSnapshot {
+                pass_id,
+                configured,
+                exists: false,
+                status: if configured {
+                    PassStatus::Active
+                } else {
+                    PassStatus::NotConfigured
+                },
+                active: false,
+                checked_in: false,
+                resale_locked: false,
+                ready_to_redeem: false,
+                issued_at: 0,
+                expires_at: 0,
+                now,
+            };
+        };
+
+        let status = if !record.active || now >= record.expires_at {
+            PassStatus::Expired
+        } else {
+            PassStatus::Active
+        };
+        let checked_in = storage::is_checked_in(&env, pass_id);
+        let resale_locked = storage::is_resale_locked(&env, pass_id);
+        let ready_to_redeem = configured && status == PassStatus::Active && !checked_in && !resale_locked;
+
+        RedemptionReadinessSnapshot {
+            pass_id,
+            configured,
+            exists: true,
+            status,
+            active: record.active,
+            checked_in,
+            resale_locked,
+            ready_to_redeem,
             issued_at: record.issued_at,
             expires_at: record.expires_at,
             now,

--- a/contracts/attendance-pass/src/types.rs
+++ b/contracts/attendance-pass/src/types.rs
@@ -42,6 +42,22 @@ pub struct ExpiryBand {
 
 #[contracttype]
 #[derive(Clone, Debug)]
+pub struct RedemptionReadinessSnapshot {
+    pub pass_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub status: PassStatus,
+    pub active: bool,
+    pub checked_in: bool,
+    pub resale_locked: bool,
+    pub ready_to_redeem: bool,
+    pub issued_at: u64,
+    pub expires_at: u64,
+    pub now: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
 pub struct CheckInCoverageSummary {
     pub configured: bool,
     pub total_issued: u64,

--- a/contracts/contract-doc-generator/src/lib.rs
+++ b/contracts/contract-doc-generator/src/lib.rs
@@ -142,6 +142,8 @@ impl DocGenerator {
             types: Vec::new(),
             events: Vec::new(),
         };
+        let fn_name_regex = Regex::new(r"fn\s+([a-zA-Z0-9_]+)").unwrap();
+        let struct_name_regex = Regex::new(r"struct\s+([a-zA-Z0-9_]+)").unwrap();
 
         let mut lines = content.lines().peekable();
         let mut current_docs = Vec::new();
@@ -153,8 +155,8 @@ impl DocGenerator {
                 continue;
             }
 
-            if trimmed.starts_with("///") {
-                current_docs.push(trimmed[3..].trim().to_string());
+            if let Some(doc_line) = trimmed.strip_prefix("///") {
+                current_docs.push(doc_line.trim().to_string());
                 continue;
             }
 
@@ -170,7 +172,6 @@ impl DocGenerator {
 
             // Detect Methods
             if trimmed.contains("pub fn") {
-                let name_regex = Regex::new(r"fn\s+([a-zA-Z0-9_]+)").unwrap();
                 // Capture multi-line signatures (common in contract methods).
                 let mut signature = trimmed.to_string();
                 while !signature.contains('{') {
@@ -196,7 +197,7 @@ impl DocGenerator {
                     .replace(", )", ")")
                     .replace(" )", ")");
 
-                if let Some(cap) = name_regex.captures(&normalized_signature) {
+                if let Some(cap) = fn_name_regex.captures(&normalized_signature) {
                     let (parameters, return_type) = self.extract_params_and_return(&normalized_signature);
                     doc.methods.push(MethodDoc {
                         name: cap[1].to_string(),
@@ -211,25 +212,22 @@ impl DocGenerator {
             // Detect Events (marked with #[contractevent])
             // Since we skipped #[ earlier, we need to check if the NEXT line is an event struct
             // Actually, let's look back or handle decorators specifically
-            if trimmed.contains("struct") {
-                 if !current_docs.is_empty() {
-                    let name_regex = Regex::new(r"struct\s+([a-zA-Z0-9_]+)").unwrap();
-                    if let Some(cap) = name_regex.captures(trimmed) {
-                        let struct_name = cap[1].to_string();
-                        if struct_name.contains("Event") || struct_name.contains("Claimed") {
-                            doc.events.push(EventDoc {
-                                name: struct_name,
-                                description: Some(current_docs.join(" ")),
-                            });
-                        } else {
-                            doc.types.push(TypeDoc {
-                                name: struct_name,
-                                description: Some(current_docs.join(" ")),
-                                fields: Vec::new(),
-                            });
-                        }
+            if trimmed.contains("struct") && !current_docs.is_empty() {
+                if let Some(cap) = struct_name_regex.captures(trimmed) {
+                    let struct_name = cap[1].to_string();
+                    if struct_name.contains("Event") || struct_name.contains("Claimed") {
+                        doc.events.push(EventDoc {
+                            name: struct_name,
+                            description: Some(current_docs.join(" ")),
+                        });
+                    } else {
+                        doc.types.push(TypeDoc {
+                            name: struct_name,
+                            description: Some(current_docs.join(" ")),
+                            fields: Vec::new(),
+                        });
                     }
-                 }
+                }
             }
 
             current_docs.clear();
@@ -303,7 +301,7 @@ impl DocGenerator {
                         for p in &m.parameters {
                             content.push_str(&format!("| `{}` | `{}` |\n", p.name, p.type_name));
                         }
-                        content.push_str("\n");
+                        content.push('\n');
                     }
 
                     if let Some(rt) = &m.return_type {
@@ -318,7 +316,7 @@ impl DocGenerator {
                 for e in &doc.events {
                     content.push_str(&format!("- **{}**: {}\n", e.name, e.description.as_deref().unwrap_or("No description")));
                 }
-                content.push_str("\n");
+                content.push('\n');
             }
 
             fs::write(file_path, content).map_err(|e| e.to_string())?;

--- a/contracts/fanout-distributor/src/lib.rs
+++ b/contracts/fanout-distributor/src/lib.rs
@@ -120,6 +120,11 @@ impl FanoutDistributor {
         }
     }
 
+    /// Backwards-compatible alias for the payout sweep backlog summary.
+    pub fn sweep_backlog_summary(env: Env) -> BatchProgressSummary {
+        Self::batch_progress_summary(env)
+    }
+
     pub fn retryable_failure(env: Env, batch_id: u64) -> RetryableFailure {
         let now = env.ledger().timestamp();
         let configured = env.storage().instance().has(&DataKey::Admin);
@@ -264,6 +269,11 @@ impl FanoutDistributor {
             current_ledger,
             can_retry: record.failed && !record.completed,
         }
+    }
+
+    /// Backwards-compatible alias for the batch retry window accessor.
+    pub fn retry_window_accessor(env: Env, batch_id: u64) -> RetryGap {
+        Self::retry_gap(env, batch_id)
     }
 }
 

--- a/contracts/profile-perks/src/lib.rs
+++ b/contracts/profile-perks/src/lib.rs
@@ -94,6 +94,11 @@ impl ProfilePerks {
         }
     }
 
+    /// Backwards-compatible alias for the active perk snapshot accessor.
+    pub fn active_perk_snapshot(env: Env, user: Address) -> ActivePerkSummary {
+        Self::active_perk_summary(env, user)
+    }
+
     /// Returns unlock-gap info for the next perk in the active catalog.
     ///
     /// Zero-value conventions:
@@ -132,5 +137,10 @@ impl ProfilePerks {
             points_to_unlock,
             all_perks_unlocked,
         }
+    }
+
+    /// Backwards-compatible alias for the next-perk gap accessor.
+    pub fn expiration_gap(env: Env, user: Address) -> UnlockGapSnapshot {
+        Self::unlock_gap(env, user)
     }
 }

--- a/contracts/quest-redeemer/src/lib.rs
+++ b/contracts/quest-redeemer/src/lib.rs
@@ -7,7 +7,7 @@ mod storage;
 mod test;
 
 use soroban_sdk::{contract, contractimpl, contractevent, Address, Env, contracterror};
-use crate::types::{RedeemerConfig, RedemptionStatus, RedemptionSnapshot};
+use crate::types::{RedeemerConfig, RedemptionStatus, RedemptionSnapshot, RewardGap};
 use crate::storage::{get_config, set_config, has_redeemed, record_redemption};
 
 #[contracterror]
@@ -79,7 +79,12 @@ impl QuestRedeemer {
         
         record_redemption(&env, &user, quest_id);
 
-        env.events().publish(("quest", "redeemed"), QuestRedeemed { user, quest_id, reward_amount: 0 });
+        QuestRedeemed {
+            user,
+            quest_id,
+            reward_amount: 0,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -112,6 +117,43 @@ impl QuestRedeemer {
             user,
             quest_id,
             timestamp: env.ledger().timestamp(),
+        }
+    }
+
+    /// Backwards-compatible alias for the turn-in queue summary accessor.
+    pub fn turn_in_queue_summary(env: Env, user: Address, quest_id: u32) -> RedemptionSnapshot {
+        Self::get_redemption_snapshot(env, user, quest_id)
+    }
+
+    /// Returns how far a quest turn-in is from being claimable.
+    ///
+    /// Zero-state behavior:
+    /// - Uninitialized or paused contracts return `reward_gap = 1`.
+    /// - Redeemed quests return `reward_gap = 0`.
+    pub fn reward_gap(env: Env, user: Address, quest_id: u32) -> RewardGap {
+        let RedemptionSnapshot {
+            config,
+            status,
+            user,
+            quest_id,
+            timestamp,
+        } = Self::get_redemption_snapshot(env, user, quest_id);
+
+        let ready_to_turn_in = matches!(&status, RedemptionStatus::Eligible);
+        let reward_gap = if ready_to_turn_in || matches!(&status, RedemptionStatus::Redeemed) {
+            0
+        } else {
+            1
+        };
+
+        RewardGap {
+            config,
+            status,
+            user,
+            quest_id,
+            reward_gap,
+            ready_to_turn_in,
+            timestamp,
         }
     }
 

--- a/contracts/quest-redeemer/src/types.rs
+++ b/contracts/quest-redeemer/src/types.rs
@@ -28,3 +28,15 @@ pub struct RedemptionSnapshot {
     pub quest_id: u32,
     pub timestamp: u64,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RewardGap {
+    pub config: Option<RedeemerConfig>,
+    pub status: RedemptionStatus,
+    pub user: Address,
+    pub quest_id: u32,
+    pub reward_gap: u32,
+    pub ready_to_turn_in: bool,
+    pub timestamp: u64,
+}


### PR DESCRIPTION
Adds the issue-specific read accessors and readiness snapshots across the matching contracts.

Closes #850
Closes #847
Closes #807
Closes #817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added redemption readiness status queries for attendance passes
  * Added quest turn-in queue and reward gap query methods
  * Introduced backwards-compatible query accessors for fanout distributor and profile perks
  * Enhanced event tracking for quest redemptions with improved data structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->