### PR TITLE
feat: add read models for roster, stream, vault, and settlement contracts

### DIFF
--- a/contracts/bonus-vault/src/lib.rs
+++ b/contracts/bonus-vault/src/lib.rs
@@ -37,12 +37,7 @@ impl BonusVaultContract {
         set_config(&env, &cfg);
     }
 
-    pub fn set_state(
-        env: Env,
-        admin: Address,
-        pending_accrual: i128,
-        release_threshold: i128,
-    ) {
+    pub fn set_state(env: Env, admin: Address, pending_accrual: i128, release_threshold: i128) {
         let cfg = get_config(&env).unwrap_or_else(|| panic!("not configured"));
         admin.require_auth();
         if admin != cfg.admin {
@@ -91,7 +86,8 @@ impl BonusVaultContract {
             pending_accrual: state.pending_accrual,
             release_threshold: state.release_threshold,
             pressure_bps,
-            over_threshold: state.release_threshold > 0 && state.pending_accrual >= state.release_threshold,
+            over_threshold: state.release_threshold > 0
+                && state.pending_accrual >= state.release_threshold,
         }
     }
 
@@ -111,12 +107,12 @@ impl BonusVaultContract {
         });
 
         let threshold_configured = state.release_threshold > 0;
-        let remaining_until_release = if !threshold_configured || state.pending_accrual >= state.release_threshold
-        {
-            0
-        } else {
-            state.release_threshold - state.pending_accrual
-        };
+        let remaining_until_release =
+            if !threshold_configured || state.pending_accrual >= state.release_threshold {
+                0
+            } else {
+                state.release_threshold - state.pending_accrual
+            };
 
         ReleaseThresholdAccessor {
             status: if cfg.paused {
@@ -127,6 +123,50 @@ impl BonusVaultContract {
             threshold_configured,
             release_threshold: state.release_threshold,
             remaining_until_release,
+        }
+    }
+
+    /// Backwards-compatible accessor for the release-threshold read model.
+    pub fn release_threshold_accessor(env: Env) -> ReleaseThresholdAccessor {
+        Self::get_release_threshold_accessor(env)
+    }
+
+    /// Return the pending outflow pressure summary.
+    ///
+    /// Zero-state returns `Unconfigured` with zeroed numeric fields.
+    pub fn pending_outflow_summary(env: Env) -> PendingOutflowSummary {
+        let Some(cfg) = get_config(&env) else {
+            return PendingOutflowSummary {
+                status: BonusVaultStatus::Unconfigured,
+                pending_outflow: 0,
+                release_threshold: 0,
+                pressure_bps: 0,
+                over_threshold: false,
+            };
+        };
+
+        let state = get_state(&env).unwrap_or(BonusVaultState {
+            pending_accrual: 0,
+            release_threshold: 0,
+        });
+
+        let pressure_bps = if state.release_threshold <= 0 {
+            0
+        } else {
+            ((state.pending_accrual as u128 * 10_000u128) / state.release_threshold as u128) as u32
+        };
+
+        PendingOutflowSummary {
+            status: if cfg.paused {
+                BonusVaultStatus::Paused
+            } else {
+                BonusVaultStatus::Active
+            },
+            pending_outflow: state.pending_accrual,
+            release_threshold: state.release_threshold,
+            pressure_bps,
+            over_threshold: state.release_threshold > 0
+                && state.pending_accrual >= state.release_threshold,
         }
     }
 }

--- a/contracts/bonus-vault/src/types.rs
+++ b/contracts/bonus-vault/src/types.rs
@@ -43,6 +43,20 @@ pub struct ReleaseThresholdAccessor {
     pub remaining_until_release: i128,
 }
 
+/// Summary of pending outflow pressure for the vault.
+///
+/// Zero-state: `status` is `Unconfigured` and all numeric fields are zero when
+/// the contract has not been initialized.
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingOutflowSummary {
+    pub status: BonusVaultStatus,
+    pub pending_outflow: i128,
+    pub release_threshold: i128,
+    pub pressure_bps: u32,
+    pub over_threshold: bool,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {

--- a/contracts/prize-streamer/src/lib.rs
+++ b/contracts/prize-streamer/src/lib.rs
@@ -21,7 +21,9 @@ mod types;
 
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
 
-pub use types::{FundingGap, StreamOutflowSummary, StreamRecord};
+pub use types::{
+    FundingGap, SettlementReadiness, StreamBacklogSnapshot, StreamOutflowSummary, StreamRecord,
+};
 
 pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
 
@@ -153,6 +155,78 @@ impl PrizeStreamer {
             },
         }
     }
+
+    /// Return a backlog snapshot for `stream_id`.
+    ///
+    /// Unknown stream ids return `exists = false` with zeroed numeric fields.
+    pub fn stream_backlog_snapshot(env: Env, stream_id: u32) -> StreamBacklogSnapshot {
+        match storage::get_stream(&env, stream_id) {
+            Some(record) => {
+                let current_balance = (record.total_funding - record.total_streamed).max(0);
+                let backlog_bps = backlog_bps(record.funding_target, current_balance);
+
+                StreamBacklogSnapshot {
+                    stream_id,
+                    exists: true,
+                    total_streamed: record.total_streamed,
+                    current_backlog: current_balance,
+                    funding_target: record.funding_target,
+                    backlog_bps,
+                    is_draining: record.is_draining,
+                }
+            }
+            None => StreamBacklogSnapshot {
+                stream_id,
+                exists: false,
+                total_streamed: 0,
+                current_backlog: 0,
+                funding_target: 0,
+                backlog_bps: 0,
+                is_draining: false,
+            },
+        }
+    }
+
+    /// Return whether a stream is ready to settle.
+    ///
+    /// Unknown stream ids return `exists = false` with zeroed numeric fields.
+    pub fn settlement_readiness(env: Env, stream_id: u32) -> SettlementReadiness {
+        match storage::get_stream(&env, stream_id) {
+            Some(record) => {
+                let current_balance = (record.total_funding - record.total_streamed).max(0);
+                let remaining_gap = (record.funding_target - current_balance).max(0);
+                let is_ready = !record.is_draining && remaining_gap == 0;
+                let blocked_reason_code = if record.is_draining {
+                    1
+                } else if remaining_gap > 0 {
+                    2
+                } else {
+                    0
+                };
+
+                SettlementReadiness {
+                    stream_id,
+                    exists: true,
+                    is_ready,
+                    current_balance,
+                    funding_target: record.funding_target,
+                    remaining_gap,
+                    is_draining: record.is_draining,
+                    blocked_reason_code,
+                }
+            }
+            None => SettlementReadiness {
+                stream_id,
+                exists: false,
+                is_ready: false,
+                current_balance: 0,
+                funding_target: 0,
+                remaining_gap: 0,
+                is_draining: false,
+                blocked_reason_code: 3,
+            },
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -170,6 +244,15 @@ fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
         return Err(Error::NotAuthorized);
     }
     Ok(())
+}
+
+fn backlog_bps(funding_target: i128, current_balance: i128) -> u32 {
+    if funding_target <= 0 {
+        return 0;
+    }
+
+    let gap = (funding_target - current_balance).max(0);
+    ((gap * 10_000) / funding_target) as u32
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/prize-streamer/src/types.rs
+++ b/contracts/prize-streamer/src/types.rs
@@ -40,6 +40,44 @@ pub struct FundingGap {
     pub is_underfunded: bool,
 }
 
+/// Backlog snapshot for a prize stream.
+///
+/// Zero-state: `exists` is false and all numeric fields are zero when the
+/// requested stream has not been configured.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamBacklogSnapshot {
+    pub stream_id: u32,
+    pub exists: bool,
+    /// Total tokens ever streamed out.
+    pub total_streamed: i128,
+    /// Tokens currently remaining against the configured target.
+    pub current_backlog: i128,
+    /// The configured funding target.
+    pub funding_target: i128,
+    /// Backlog pressure in basis points, floored.
+    pub backlog_bps: u32,
+    /// `true` when the stream is actively draining.
+    pub is_draining: bool,
+}
+
+/// Settlement readiness view for a prize stream.
+///
+/// Zero-state: `exists` is false and all numeric fields are zero when the
+/// requested stream has not been configured.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SettlementReadiness {
+    pub stream_id: u32,
+    pub exists: bool,
+    pub is_ready: bool,
+    pub current_balance: i128,
+    pub funding_target: i128,
+    pub remaining_gap: i128,
+    pub is_draining: bool,
+    pub blocked_reason_code: u32,
+}
+
 /// Persistent stream record written by admin mutations.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/reward-stream/src/lib.rs
+++ b/contracts/reward-stream/src/lib.rs
@@ -3,12 +3,13 @@
 use soroban_sdk::{contract, contractimpl, Address, Env};
 
 mod storage;
-mod types;
 #[cfg(test)]
 mod test;
+mod types;
 
 pub use types::{
-    DepletionBand, StreamData, StreamHealthSummary, StreamPressureSnapshot, WithdrawalReadiness,
+    DepletionBand, DripPressureSummary, PauseRecoveryAccessor, StreamData, StreamHealthSummary,
+    StreamPressureSnapshot, WithdrawalReadiness,
 };
 
 #[contract]
@@ -135,12 +136,83 @@ impl RewardStream {
         }
     }
 
+    /// Return a drip-pressure summary for the configured stream.
+    ///
+    /// Missing, empty, or non-positive allocations return a zero pressure and
+    /// `is_configured = false` so callers can render a predictable zero state.
+    pub fn drip_pressure_summary(env: Env) -> DripPressureSummary {
+        if let Some(s) = storage::get_stream(&env) {
+            let remaining = (s.total_allocated - s.total_withdrawn).max(0);
+            let pressure_bps = pressure_bps(s.total_allocated, s.total_withdrawn);
+
+            DripPressureSummary {
+                is_configured: s.total_allocated > 0,
+                stream_id: s.stream_id,
+                total_allocated: s.total_allocated,
+                total_withdrawn: s.total_withdrawn,
+                remaining,
+                pressure_bps,
+                paused: s.paused,
+            }
+        } else {
+            DripPressureSummary {
+                is_configured: false,
+                stream_id: 0,
+                total_allocated: 0,
+                total_withdrawn: 0,
+                remaining: 0,
+                pressure_bps: 0,
+                paused: false,
+            }
+        }
+    }
+
     /// Return only the depletion band from `stream_pressure_snapshot`.
     ///
     /// This accessor is intentionally narrow for UI badge reads. Missing or
     /// not-yet-configured state returns `DepletionBand::NotConfigured`.
     pub fn depletion_band(env: Env) -> DepletionBand {
         Self::stream_pressure_snapshot(env).depletion_band
+    }
+
+    /// Return a pause-recovery view for the configured stream.
+    ///
+    /// Missing, empty, or non-positive allocations return a zero state with
+    /// `is_configured = false`.
+    pub fn pause_recovery_accessor(env: Env, now: u64) -> PauseRecoveryAccessor {
+        if let Some(s) = storage::get_stream(&env) {
+            let remaining = (s.total_allocated - s.total_withdrawn).max(0);
+            let recovery_ready = !s.paused && now >= s.unlock_time && remaining > 0;
+            let blocked_reason_code = if s.paused {
+                1
+            } else if now < s.unlock_time {
+                2
+            } else if remaining == 0 {
+                3
+            } else {
+                0
+            };
+
+            PauseRecoveryAccessor {
+                is_configured: s.total_allocated > 0,
+                stream_id: s.stream_id,
+                paused: s.paused,
+                unlock_time: s.unlock_time,
+                remaining,
+                recovery_ready,
+                blocked_reason_code,
+            }
+        } else {
+            PauseRecoveryAccessor {
+                is_configured: false,
+                stream_id: 0,
+                paused: false,
+                unlock_time: 0,
+                remaining: 0,
+                recovery_ready: false,
+                blocked_reason_code: 4,
+            }
+        }
     }
 }
 

--- a/contracts/reward-stream/src/types.rs
+++ b/contracts/reward-stream/src/types.rs
@@ -55,3 +55,35 @@ pub struct StreamPressureSnapshot {
     pub depletion_band: DepletionBand,
     pub paused: bool,
 }
+
+/// Drip-pressure snapshot returned by `drip_pressure_summary`.
+///
+/// Zero-state: all numeric fields are zero and `is_configured` is false when
+/// no stream has been configured.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DripPressureSummary {
+    pub is_configured: bool,
+    pub stream_id: u64,
+    pub total_allocated: i128,
+    pub total_withdrawn: i128,
+    pub remaining: i128,
+    pub pressure_bps: u32,
+    pub paused: bool,
+}
+
+/// Pause-recovery view returned by `pause_recovery_accessor`.
+///
+/// Zero-state: all numeric fields are zero and `is_configured` is false when
+/// no stream has been configured.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseRecoveryAccessor {
+    pub is_configured: bool,
+    pub stream_id: u64,
+    pub paused: bool,
+    pub unlock_time: u64,
+    pub remaining: i128,
+    pub recovery_ready: bool,
+    pub blocked_reason_code: u32,
+}

--- a/contracts/squad-roster/src/lib.rs
+++ b/contracts/squad-roster/src/lib.rs
@@ -9,12 +9,10 @@
 mod storage;
 mod types;
 
-pub use types::*;
 use storage::{DataKey, PERSISTENT_BUMP};
+pub use types::*;
 
-use soroban_sdk::{
-    contract, contracterror, contractimpl, Address, Env, Symbol, Vec,
-};
+use soroban_sdk::{contract, contracterror, contractimpl, Address, Env, Symbol, Vec};
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -25,12 +23,12 @@ use soroban_sdk::{
 #[repr(u32)]
 pub enum Error {
     AlreadyInitialized = 1,
-    NotInitialized     = 2,
-    NotAuthorized      = 3,
-    SlotNotFound       = 4,
-    SlotLocked         = 5,
-    ContractPaused     = 6,
-    DuplicateRole      = 7,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+    SlotNotFound = 4,
+    SlotLocked = 5,
+    ContractPaused = 6,
+    DuplicateRole = 7,
 }
 
 // ---------------------------------------------------------------------------
@@ -225,6 +223,55 @@ impl SquadRosterContract {
         }
     }
 
+    /// Return a coverage snapshot for roster participation.
+    ///
+    /// Zero-state (no slots registered): all counts 0, `ready` false.
+    /// `coverage_bps` is floored basis-point coverage of filled slots over
+    /// registered slots.
+    pub fn participation_coverage_snapshot(env: Env) -> ParticipationCoverageSnapshot {
+        let roles: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Roles)
+            .unwrap_or(Vec::new(&env));
+
+        let total_slots = roles.len();
+        let mut filled_slots: u32 = 0;
+        let mut locked_slots: u32 = 0;
+
+        for role in roles.iter() {
+            if let Some(slot) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, RosterSlot>(&DataKey::Slot(role))
+            {
+                if slot.player.is_some() {
+                    filled_slots += 1;
+                }
+                if slot.locked {
+                    locked_slots += 1;
+                }
+            }
+        }
+
+        let coverage_bps = if total_slots > 0 {
+            ((filled_slots as u128 * 10_000) / (total_slots as u128)) as u32
+        } else {
+            0
+        };
+        let paused = Self::is_paused(&env);
+        let ready = total_slots > 0 && filled_slots == total_slots && locked_slots == 0 && !paused;
+
+        ParticipationCoverageSnapshot {
+            total_slots,
+            filled_slots,
+            locked_slots,
+            coverage_bps,
+            ready,
+            paused,
+        }
+    }
+
     /// Return vacancy information for a specific role.
     ///
     /// Zero-state: `exists` false when the role has no registered slot.
@@ -242,6 +289,35 @@ impl SquadRosterContract {
             Some(slot) => RoleVacancy {
                 exists: true,
                 vacant: slot.player.is_none(),
+                player: slot.player,
+            },
+        }
+    }
+
+    /// Return the current lock-window state for a specific role.
+    ///
+    /// Zero-state: `exists` false when the role has no registered slot.
+    pub fn lock_window_accessor(env: Env, role: Symbol) -> LockWindowAccessor {
+        let paused = Self::is_paused(&env);
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, RosterSlot>(&DataKey::Slot(role.clone()))
+        {
+            None => LockWindowAccessor {
+                exists: false,
+                role,
+                locked: false,
+                paused,
+                can_modify: false,
+                player: None,
+            },
+            Some(slot) => LockWindowAccessor {
+                exists: true,
+                role,
+                locked: slot.locked,
+                paused,
+                can_modify: !slot.locked && !paused,
                 player: slot.player,
             },
         }
@@ -283,6 +359,15 @@ fn assert_not_paused(env: &Env) -> Result<(), Error> {
         return Err(Error::ContractPaused);
     }
     Ok(())
+}
+
+impl SquadRosterContract {
+    fn is_paused(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
 }
 
 #[cfg(test)]

--- a/contracts/squad-roster/src/types.rs
+++ b/contracts/squad-roster/src/types.rs
@@ -43,3 +43,44 @@ pub struct RoleVacancy {
     /// The current occupant, if any.
     pub player: Option<Address>,
 }
+
+/// Snapshot of roster participation coverage.
+///
+/// Zero-state: all numeric fields are zero and `ready` is false when no
+/// slots are registered.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParticipationCoverageSnapshot {
+    /// Total number of registered slots.
+    pub total_slots: u32,
+    /// Slots that currently have a player assigned.
+    pub filled_slots: u32,
+    /// Slots that are currently locked.
+    pub locked_slots: u32,
+    /// Coverage rate in basis points, floored.
+    pub coverage_bps: u32,
+    /// True when every registered slot is filled and none are locked.
+    pub ready: bool,
+    /// True when the roster is paused.
+    pub paused: bool,
+}
+
+/// Lock-state view for a single role slot.
+///
+/// Zero-state: `exists` false when the role has no registered slot.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LockWindowAccessor {
+    /// Whether a slot for this role exists in the roster.
+    pub exists: bool,
+    /// The queried role name.
+    pub role: Symbol,
+    /// Whether the slot is locked.
+    pub locked: bool,
+    /// Whether contract-level pause blocks edits.
+    pub paused: bool,
+    /// True when the slot can currently be modified.
+    pub can_modify: bool,
+    /// The current occupant, if any.
+    pub player: Option<Address>,
+}


### PR DESCRIPTION
Closes #809
Closes #810
Closes #816
Closes #808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bonus Vault: Added read-only accessors for release threshold values and pending outflow summary data including pressure metrics
  * Prize Streamer: Added stream backlog snapshot computation and settlement readiness status reporting with funding gap details
  * Reward Stream: Added drip pressure summary accessors and pause recovery status information
  * Squad Roster: Added participation coverage snapshot metrics and per-role lock window state accessors for role modifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->