### PR TITLE
feat(frontend): payout health chips, detail facts block, recovery banner, focus-return hook

### DIFF
--- a/frontend/src/components/AbandonedFlowRecoveryBanner.tsx
+++ b/frontend/src/components/AbandonedFlowRecoveryBanner.tsx
@@ -1,0 +1,113 @@
+import type { CSSProperties } from "react";
+
+export interface StagedSubmission {
+  /** Human label for the staged flow, e.g. "deposit" or "game entry". */
+  label?: string;
+  /** When the draft was last saved. */
+  savedAt?: Date | string | number;
+}
+
+export interface AbandonedFlowRecoveryBannerProps {
+  /** The staged submission to recover; when null/undefined nothing renders. */
+  staged?: StagedSubmission | null;
+  onResume: () => void;
+  onDismiss: () => void;
+  className?: string;
+}
+
+function formatSavedAt(savedAt?: Date | string | number): string | null {
+  if (savedAt === undefined || savedAt === null) return null;
+  const date = savedAt instanceof Date ? savedAt : new Date(savedAt);
+  if (Number.isNaN(date.getTime())) return null;
+  const diffMs = Date.now() - date.getTime();
+  const mins = Math.round(diffMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins} minute${mins === 1 ? "" : "s"} ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+/**
+ * Banner that offers to resume a staged-but-unsubmitted flow. Renders nothing
+ * when there is no staged submission, so callers can mount it unconditionally.
+ */
+export function AbandonedFlowRecoveryBanner({
+  staged,
+  onResume,
+  onDismiss,
+  className = "",
+}: AbandonedFlowRecoveryBannerProps) {
+  if (!staged) return null;
+
+  const what = staged.label?.trim() ? staged.label.trim() : "submission";
+  const when = formatSavedAt(staged.savedAt);
+
+  return (
+    <div
+      className={`abandoned-flow-recovery ${className}`}
+      style={styles.banner}
+      role="region"
+      aria-label="Recover unfinished submission"
+    >
+      <div style={styles.text}>
+        <strong style={styles.title}>You have an unfinished {what}</strong>
+        <span style={styles.subtitle}>
+          {when ? `Saved ${when}.` : "Pick up where you left off."}
+        </span>
+      </div>
+      <div style={styles.actions}>
+        <button type="button" onClick={onResume} style={styles.resume}>
+          Resume
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          style={styles.dismiss}
+          aria-label="Dismiss recovery banner"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  banner: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "1rem",
+    flexWrap: "wrap" as const,
+    padding: "0.75rem 1rem",
+    borderRadius: "0.5rem",
+    border: "1px solid #fde68a",
+    backgroundColor: "#fffbeb",
+  } as CSSProperties,
+  text: { display: "flex", flexDirection: "column" as const, gap: "0.125rem", minWidth: 0 },
+  title: { fontSize: "0.875rem", color: "#92400e" },
+  subtitle: { fontSize: "0.75rem", color: "#b45309" },
+  actions: { display: "flex", gap: "0.5rem", flexShrink: 0 },
+  resume: {
+    padding: "0.375rem 0.875rem",
+    borderRadius: "0.375rem",
+    border: "none",
+    backgroundColor: "#f59e0b",
+    color: "#1c1917",
+    fontWeight: 600,
+    fontSize: "0.8125rem",
+    cursor: "pointer",
+  },
+  dismiss: {
+    padding: "0.375rem 0.875rem",
+    borderRadius: "0.375rem",
+    border: "1px solid #fcd34d",
+    backgroundColor: "transparent",
+    color: "#92400e",
+    fontWeight: 600,
+    fontSize: "0.8125rem",
+    cursor: "pointer",
+  },
+} as const;

--- a/frontend/src/components/DetailFactsBlock.tsx
+++ b/frontend/src/components/DetailFactsBlock.tsx
@@ -1,0 +1,88 @@
+import type { CSSProperties, ReactNode } from "react";
+
+export interface DetailFact {
+  /** Term shown in the first column. */
+  label: string;
+  /** Value shown in the second column. */
+  value: ReactNode;
+  /** Let a long value span both columns. */
+  full?: boolean;
+}
+
+export interface DetailFactsBlockProps {
+  facts: DetailFact[];
+  /** Message rendered when there are no facts to show. */
+  emptyLabel?: string;
+  /** Accessible label for the underlying definition list. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Shared two-column label/value block for dense side panels. Renders a semantic
+ * <dl> so each fact is a proper term/description pair, and explicitly handles
+ * the empty case rather than collapsing to nothing.
+ */
+export function DetailFactsBlock({
+  facts,
+  emptyLabel = "No details available",
+  ariaLabel = "Details",
+  className = "",
+}: DetailFactsBlockProps) {
+  if (facts.length === 0) {
+    return (
+      <p className={`detail-facts-empty ${className}`} style={styles.empty} role="note">
+        {emptyLabel}
+      </p>
+    );
+  }
+
+  return (
+    <dl className={`detail-facts ${className}`} style={styles.list} aria-label={ariaLabel}>
+      {facts.map((fact, index) => (
+        <div
+          key={`${fact.label}-${index}`}
+          style={{ ...styles.row, ...(fact.full ? styles.rowFull : null) }}
+        >
+          <dt style={styles.term}>{fact.label}</dt>
+          <dd style={styles.value}>{fact.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+const styles = {
+  list: {
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gap: "0.5rem 1rem",
+    margin: 0,
+  } as CSSProperties,
+  row: {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: "0.125rem",
+    minWidth: 0,
+  },
+  rowFull: { gridColumn: "1 / -1" },
+  term: {
+    fontSize: "0.6875rem",
+    fontWeight: 600,
+    letterSpacing: "0.04em",
+    textTransform: "uppercase" as const,
+    color: "#64748b",
+  },
+  value: {
+    margin: 0,
+    fontSize: "0.875rem",
+    color: "#1e293b",
+    wordBreak: "break-word" as const,
+  },
+  empty: {
+    margin: 0,
+    fontSize: "0.8125rem",
+    color: "#94a3b8",
+    fontStyle: "italic" as const,
+  },
+} as const;

--- a/frontend/src/components/PayoutHealthChip.tsx
+++ b/frontend/src/components/PayoutHealthChip.tsx
@@ -1,0 +1,88 @@
+import type { CSSProperties } from "react";
+
+export type PayoutHealthStatus =
+  | "healthy"
+  | "delayed"
+  | "at_risk"
+  | "failed"
+  | "unknown";
+
+export interface PayoutHealthChipProps {
+  /** Health status; missing/unrecognised values render as "Unknown". */
+  status?: PayoutHealthStatus | null;
+  /** Optional label override; defaults to the humanised status. */
+  label?: string;
+  /** Compact summary chip ("sm") vs. slightly larger detail chip ("md"). */
+  size?: "sm" | "md";
+  className?: string;
+}
+
+const STATUS_META: Record<
+  PayoutHealthStatus,
+  { label: string; fg: string; bg: string; border: string; dot: string }
+> = {
+  healthy: { label: "Healthy", fg: "#047857", bg: "#ecfdf5", border: "#a7f3d0", dot: "#10b981" },
+  delayed: { label: "Delayed", fg: "#b45309", bg: "#fffbeb", border: "#fde68a", dot: "#f59e0b" },
+  at_risk: { label: "At risk", fg: "#c2410c", bg: "#fff7ed", border: "#fed7aa", dot: "#f97316" },
+  failed: { label: "Failed", fg: "#b91c1c", bg: "#fef2f2", border: "#fecaca", dot: "#ef4444" },
+  unknown: { label: "Unknown", fg: "#475569", bg: "#f8fafc", border: "#e2e8f0", dot: "#94a3b8" },
+};
+
+/**
+ * Compact, color-coded chip summarising payout health. Designed to read the
+ * same in a dense summary row ("sm") and in a detail panel ("md"); an absent or
+ * unrecognised status degrades gracefully to a neutral "Unknown" chip.
+ */
+export function PayoutHealthChip({
+  status,
+  label,
+  size = "sm",
+  className = "",
+}: PayoutHealthChipProps) {
+  const resolved: PayoutHealthStatus =
+    status && status in STATUS_META ? status : "unknown";
+  const meta = STATUS_META[resolved];
+  const text = label ?? meta.label;
+
+  const chipStyle: CSSProperties = {
+    ...styles.chip,
+    ...(size === "md" ? styles.md : styles.sm),
+    color: meta.fg,
+    backgroundColor: meta.bg,
+    borderColor: meta.border,
+  };
+
+  return (
+    <span
+      className={`payout-health-chip ${className}`}
+      style={chipStyle}
+      role="status"
+      data-status={resolved}
+      aria-label={`Payout health: ${text}`}
+    >
+      <span aria-hidden="true" style={{ ...styles.dot, backgroundColor: meta.dot }} />
+      {text}
+    </span>
+  );
+}
+
+const styles = {
+  chip: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.375rem",
+    borderRadius: "9999px",
+    border: "1px solid",
+    fontWeight: 600,
+    lineHeight: 1.2,
+    whiteSpace: "nowrap" as const,
+  },
+  sm: { padding: "0.125rem 0.5rem", fontSize: "0.6875rem" },
+  md: { padding: "0.25rem 0.75rem", fontSize: "0.8125rem" },
+  dot: {
+    width: "0.5rem",
+    height: "0.5rem",
+    borderRadius: "9999px",
+    flexShrink: 0,
+  },
+} as const;

--- a/frontend/src/hooks/useFocusReturn.ts
+++ b/frontend/src/hooks/useFocusReturn.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface UseFocusReturnOptions {
+  /** Focused when the original trigger is no longer in the document on close. */
+  fallbackRef?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Deterministically returns focus when a transient surface (e.g. a warning
+ * drawer) closes. On open it records the element that had focus; on close it
+ * restores focus to that element, or to `fallbackRef` if the original trigger
+ * has since been removed from the DOM. This keeps keyboard users anchored
+ * instead of dropping focus back to <body>.
+ */
+export function useFocusReturn(
+  isOpen: boolean,
+  options: UseFocusReturnOptions = {},
+): void {
+  const { fallbackRef } = options;
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    if (isOpen && !wasOpen.current) {
+      // Rising edge: capture whatever had focus before the drawer opened.
+      triggerRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    } else if (!isOpen && wasOpen.current) {
+      // Falling edge: restore focus deterministically.
+      const trigger = triggerRef.current;
+      const target =
+        trigger && document.contains(trigger)
+          ? trigger
+          : fallbackRef?.current ?? null;
+      target?.focus();
+      triggerRef.current = null;
+    }
+
+    wasOpen.current = isOpen;
+  }, [isOpen, fallbackRef]);
+}

--- a/frontend/tests/components/AbandonedFlowRecoveryBanner.test.tsx
+++ b/frontend/tests/components/AbandonedFlowRecoveryBanner.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+import { AbandonedFlowRecoveryBanner } from "@/components/AbandonedFlowRecoveryBanner";
+
+describe("AbandonedFlowRecoveryBanner", () => {
+  it("renders nothing when there is no staged submission", () => {
+    const { container } = render(
+      <AbandonedFlowRecoveryBanner staged={null} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the staged flow and wires up resume/dismiss", () => {
+    const onResume = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <AbandonedFlowRecoveryBanner
+        staged={{ label: "deposit", savedAt: Date.now() }}
+        onResume={onResume}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByRole("region", { name: /recover unfinished submission/i })).toBeInTheDocument();
+    expect(screen.getByText(/unfinished deposit/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(onResume).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/components/DetailFactsBlock.test.tsx
+++ b/frontend/tests/components/DetailFactsBlock.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import { DetailFactsBlock } from "@/components/DetailFactsBlock";
+
+describe("DetailFactsBlock", () => {
+  it("renders each fact as a term/value pair", () => {
+    render(
+      <DetailFactsBlock
+        facts={[
+          { label: "Network", value: "Testnet" },
+          { label: "Asset", value: "XLM" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Network")).toBeInTheDocument();
+    expect(screen.getByText("Testnet")).toBeInTheDocument();
+    expect(screen.getByText("Asset")).toBeInTheDocument();
+    expect(screen.getByText("XLM")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no facts", () => {
+    render(<DetailFactsBlock facts={[]} emptyLabel="Nothing to show" />);
+    expect(screen.getByText("Nothing to show")).toBeInTheDocument();
+    expect(screen.queryByRole("definition")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/PayoutHealthChip.test.tsx
+++ b/frontend/tests/components/PayoutHealthChip.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import { PayoutHealthChip } from "@/components/PayoutHealthChip";
+
+describe("PayoutHealthChip", () => {
+  it("renders the humanised label and exposes the status", () => {
+    render(<PayoutHealthChip status="healthy" />);
+    const chip = screen.getByRole("status");
+    expect(chip).toHaveTextContent("Healthy");
+    expect(chip).toHaveAttribute("data-status", "healthy");
+    expect(chip).toHaveAttribute("aria-label", "Payout health: Healthy");
+  });
+
+  it("supports a label override and the md size", () => {
+    render(<PayoutHealthChip status="delayed" label="Pending review" size="md" />);
+    expect(screen.getByRole("status")).toHaveTextContent("Pending review");
+  });
+
+  it("falls back to Unknown for a missing or unrecognised status", () => {
+    const { rerender } = render(<PayoutHealthChip status={null} />);
+    expect(screen.getByRole("status")).toHaveAttribute("data-status", "unknown");
+
+    // @ts-expect-error — exercising the runtime guard against bad input.
+    rerender(<PayoutHealthChip status="not-a-real-status" />);
+    expect(screen.getByRole("status")).toHaveTextContent("Unknown");
+  });
+});

--- a/frontend/tests/unit/useFocusReturn.test.tsx
+++ b/frontend/tests/unit/useFocusReturn.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { useRef, useState } from "react";
+import { describe, expect, it } from "vitest";
+import { useFocusReturn } from "@/hooks/useFocusReturn";
+
+function Harness({ removeTriggerOnClose = false }: { removeTriggerOnClose?: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [triggerGone, setTriggerGone] = useState(false);
+  const fallbackRef = useRef<HTMLButtonElement>(null);
+  useFocusReturn(open, { fallbackRef });
+
+  return (
+    <div>
+      <button ref={fallbackRef} type="button" data-testid="fallback">
+        Fallback
+      </button>
+      {!triggerGone && (
+        <button type="button" data-testid="trigger" onClick={() => setOpen(true)}>
+          Open drawer
+        </button>
+      )}
+      {open && (
+        <div role="dialog">
+          <button
+            type="button"
+            data-testid="close"
+            onClick={() => {
+              if (removeTriggerOnClose) setTriggerGone(true);
+              setOpen(false);
+            }}
+          >
+            Close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+describe("useFocusReturn", () => {
+  it("returns focus to the trigger when the drawer closes", () => {
+    render(<Harness />);
+    const trigger = screen.getByTestId("trigger");
+    act(() => trigger.focus());
+    expect(trigger).toHaveFocus();
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByTestId("close"));
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it("falls back to fallbackRef when the trigger was removed", () => {
+    render(<Harness removeTriggerOnClose />);
+    const trigger = screen.getByTestId("trigger");
+    act(() => trigger.focus());
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByTestId("close"));
+
+    expect(screen.getByTestId("fallback")).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Summary

Adds four small, self-contained frontend primitives (each with vitest coverage), bundled into one PR. They live in `frontend/` (the repo's actual web app; the issue templates reference an `apps/web/` path that does not exist here).

- **#822 — `PayoutHealthChip`** (`src/components/PayoutHealthChip.tsx`): compact, colour-coded chip summarising payout health, with `sm` (summary row) and `md` (detail panel) sizes. An absent or unrecognised status degrades gracefully to a neutral "Unknown" chip. Exposes `role="status"` + `aria-label` + `data-status`.
- **#823 — `DetailFactsBlock`** (`src/components/DetailFactsBlock.tsx`): shared two-column label/value block for dense side panels, rendered as a semantic `<dl>`. Handles the empty case explicitly and supports full-width facts.
- **#824 — `AbandonedFlowRecoveryBanner`** (`src/components/AbandonedFlowRecoveryBanner.tsx`): resume/dismiss banner for a staged-but-unsubmitted flow, with a relative "saved N ago" timestamp. Renders nothing when there is no staged submission, so it can be mounted unconditionally.
- **#825 — `useFocusReturn`** (`src/hooks/useFocusReturn.ts`): deterministically returns focus to the element that opened a transient warning drawer when it closes, falling back to a supplied ref if that trigger was removed from the DOM.

## Test plan

- [x] `vitest run` for the four new specs — **9 tests pass** (`tests/components/*`, `tests/unit/useFocusReturn.test.tsx`), covering success paths plus empty/unknown/fallback edge cases
- [x] `tsc --noEmit` — no type errors in the new files
- [x] Components follow the repo's inline-style + accessibility conventions (semantic roles, aria labels, keyboard-safe)

These are shared primitives intended for reuse in summary/detail panels and drawer surfaces; they are exported for import by path and kept free of page-local coupling.

Closes #822
Closes #823
Closes #824
Closes #825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recovery prompt to help users resume unfinished form submissions
  * Added a detailed information display component for better data presentation
  * Added visual status indicators for payout health monitoring
  * Improved accessibility with automatic focus restoration when closing dialogs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theblockcade/stellarcade/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->