### PR TITLE
feat(dice-roll): rolling history snapshot and cooldown-window accessor (#874)

### DIFF
--- a/contracts/dice-roll/src/lib.rs
+++ b/contracts/dice-roll/src/lib.rs
@@ -23,7 +23,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, token::TokenClient,
-    Address, Env,
+    Address, Env, Vec,
 };
 
 use stellarcade_random_generator::RandomGeneratorClient;
@@ -42,6 +42,10 @@ pub const MAX_FACE: u32 = 6;
 pub const DIE_SIDES: u64 = 6;
 /// Payout multiplier (before house edge deduction).
 const PAYOUT_MULTIPLIER: i128 = 6;
+/// Default per-player cooldown between rolls, in seconds (30s).
+pub const DEFAULT_COOLDOWN_SECS: u64 = 30;
+/// Max entries kept in the rolling history snapshot.
+const HISTORY_MAX: u32 = 20;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -80,6 +84,29 @@ pub enum DataKey {
     MaxWager,
     HouseEdgeBps,
     Game(u64),
+    /// Ordered list of resolved game_ids (most-recent last).
+    ResolvedHistory,
+    /// Ledger timestamp of last roll per player, for cooldown tracking.
+    LastRollAt(Address),
+}
+
+/// Snapshot of recent rolling history.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RollingHistorySnapshot {
+    pub total_resolved: u32,
+    pub recent_game_ids: Vec<u64>,
+}
+
+/// Cooldown window state for a player.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CooldownWindow {
+    pub player_has_rolled: bool,
+    pub last_roll_at: u64,
+    pub cooldown_secs: u64,
+    pub seconds_remaining: u64,
+    pub in_cooldown: bool,
 }
 
 #[contracttype]
@@ -230,6 +257,17 @@ impl DiceRoll {
             PERSISTENT_BUMP_LEDGERS,
         );
 
+        // Record last roll timestamp for cooldown tracking
+        let now = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&DataKey::LastRollAt(player.clone()), &now);
+        env.storage().persistent().extend_ttl(
+            &DataKey::LastRollAt(player.clone()),
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
+
         RollPlaced {
             game_id,
             player,
@@ -324,6 +362,25 @@ impl DiceRoll {
             );
         }
 
+        // Append to rolling history (capped at HISTORY_MAX)
+        let mut history: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ResolvedHistory)
+            .unwrap_or_else(|| Vec::new(&env));
+        history.push_back(game_id);
+        if history.len() > HISTORY_MAX {
+            history.remove(0);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::ResolvedHistory, &history);
+        env.storage().persistent().extend_ttl(
+            &DataKey::ResolvedHistory,
+            PERSISTENT_BUMP_LEDGERS,
+            PERSISTENT_BUMP_LEDGERS,
+        );
+
         RollResolved {
             game_id,
             player: roll.player,
@@ -368,6 +425,57 @@ impl DiceRoll {
             min_wager: env.storage().instance().get(&DataKey::MinWager).unwrap(),
             max_wager: env.storage().instance().get(&DataKey::MaxWager).unwrap(),
         })
+    }
+
+    /// Snapshot of resolved roll history (up to last 20 game IDs).
+    /// Returns empty list and zero total when no rolls have been resolved yet.
+    pub fn rolling_history_snapshot(env: Env) -> RollingHistorySnapshot {
+        let recent_game_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ResolvedHistory)
+            .unwrap_or_else(|| Vec::new(&env));
+        let total_resolved = recent_game_ids.len();
+        RollingHistorySnapshot {
+            total_resolved,
+            recent_game_ids,
+        }
+    }
+
+    /// Per-player cooldown window accessor.
+    /// Returns whether the player is currently in a cooldown period after their last roll.
+    /// `cooldown_secs` is the configured cooldown window (DEFAULT_COOLDOWN_SECS = 30s).
+    pub fn cooldown_window(env: Env, player: Address) -> CooldownWindow {
+        let now = env.ledger().timestamp();
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, u64>(&DataKey::LastRollAt(player))
+        {
+            Some(last_roll_at) => {
+                let elapsed = now.saturating_sub(last_roll_at);
+                let in_cooldown = elapsed < DEFAULT_COOLDOWN_SECS;
+                let seconds_remaining = if in_cooldown {
+                    DEFAULT_COOLDOWN_SECS - elapsed
+                } else {
+                    0
+                };
+                CooldownWindow {
+                    player_has_rolled: true,
+                    last_roll_at,
+                    cooldown_secs: DEFAULT_COOLDOWN_SECS,
+                    seconds_remaining,
+                    in_cooldown,
+                }
+            }
+            None => CooldownWindow {
+                player_has_rolled: false,
+                last_roll_at: 0,
+                cooldown_secs: DEFAULT_COOLDOWN_SECS,
+                seconds_remaining: 0,
+                in_cooldown: false,
+            },
+        }
     }
 }
 

--- a/contracts/dice-roll/src/test.rs
+++ b/contracts/dice-roll/src/test.rs
@@ -729,3 +729,82 @@ fn test_loss_stores_actual_result() {
     assert_eq!(roll.result, target_face);
     assert_eq!(roll.payout, 0);
 }
+
+// -------------------------------------------------------------------
+// 19. Rolling history snapshot — empty state
+// -------------------------------------------------------------------
+
+#[test]
+fn test_rolling_history_snapshot_empty() {
+    let env = Env::default();
+    let s = setup(&env);
+
+    let snap = s.dice_client.rolling_history_snapshot();
+    assert_eq!(snap.total_resolved, 0);
+    assert_eq!(snap.recent_game_ids.len(), 0);
+}
+
+// -------------------------------------------------------------------
+// 20. Rolling history snapshot — after resolved roll
+// -------------------------------------------------------------------
+
+#[test]
+fn test_rolling_history_snapshot_after_resolve() {
+    let env = Env::default();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let player = Address::generate(&env);
+    s.token_sac.mint(&player, &500);
+
+    let game_id = 1u64;
+    let prediction = 3u32;
+    s.dice_client.roll(&player, &prediction, &100, &game_id);
+    let win_seed = find_seed_for_face(&env, game_id, prediction);
+    s.rng_client.fulfill_random(&s.oracle, &game_id, &win_seed);
+    s.dice_client.resolve_roll(&game_id);
+
+    let snap = s.dice_client.rolling_history_snapshot();
+    assert_eq!(snap.total_resolved, 1);
+    assert_eq!(snap.recent_game_ids.get(0).unwrap(), game_id);
+}
+
+// -------------------------------------------------------------------
+// 21. Cooldown window — player has never rolled
+// -------------------------------------------------------------------
+
+#[test]
+fn test_cooldown_window_never_rolled() {
+    let env = Env::default();
+    let s = setup(&env);
+
+    let player = Address::generate(&env);
+    let cw = s.dice_client.cooldown_window(&player);
+    assert!(!cw.player_has_rolled);
+    assert!(!cw.in_cooldown);
+    assert_eq!(cw.seconds_remaining, 0);
+    assert_eq!(cw.last_roll_at, 0);
+}
+
+// -------------------------------------------------------------------
+// 22. Cooldown window — player is in cooldown immediately after roll
+// -------------------------------------------------------------------
+
+#[test]
+fn test_cooldown_window_after_roll() {
+    let env = Env::default();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    let player = Address::generate(&env);
+    s.token_sac.mint(&player, &500);
+
+    // Place a roll — ledger timestamp is 0 in test env, cooldown = 30s
+    s.dice_client.roll(&player, &2u32, &100, &1u64);
+
+    let cw = s.dice_client.cooldown_window(&player);
+    assert!(cw.player_has_rolled);
+    assert!(cw.in_cooldown);
+    assert_eq!(cw.seconds_remaining, 30);
+    assert_eq!(cw.cooldown_secs, 30);
+}


### PR DESCRIPTION
## Summary

Adds two read-only accessor methods to the `dice-roll` contract:

- **`rolling_history_snapshot()`** — returns the total count of resolved rolls and the most recent game IDs (capped at 20 entries). A new `DataKey::ResolvedHistory` persistent entry is appended in `resolve_roll()` after each settlement.
- **`cooldown_window(player)`** — returns whether a player is currently within the 30-second cooldown window after their last roll, and how many seconds remain. A `DataKey::LastRollAt(player)` persistent entry is written in `roll()` on each bet placement.

Both methods return explicit zero/false states when no data is present (player never rolled, no rolls resolved yet), so callers never need to handle missing-key errors.

4 new tests added: empty history, post-resolve history, never-rolled cooldown, and in-cooldown state.

closes #874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cooldown status query so players can check whether they must wait before rolling again, including time remaining.
  * Added a rolling history snapshot that shows how many games have been resolved and lists recent resolved game IDs.

* **Bug Fixes**
  * Improved tracking of recent game activity and player roll timing to keep read results up to date.

* **Tests**
  * Added coverage for empty and populated history snapshots, plus cooldown behavior before and after a roll.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->