### PR TITLE
feat(contracts): arena-sessions, challenge-ladder, combo-rewards, cross-contract-handler accessors

### DIFF
--- a/contracts/arena-sessions/src/lib.rs
+++ b/contracts/arena-sessions/src/lib.rs
@@ -5,7 +5,10 @@ mod types;
 
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
 
-pub use types::{ArenaSession, ArenaSessionState, ArenaSessionView, PlayerArenaSessionSummary, PlayerSessionStats};
+pub use types::{
+    ActiveSessionSummary, ArenaSession, ArenaSessionState, ArenaSessionView, ExpirationDelay,
+    PlayerArenaSessionSummary, PlayerSessionStats,
+};
 
 const BUMP_AMOUNT: u32 = 518_400;
 const LIFETIME_THRESHOLD: u32 = BUMP_AMOUNT / 2;
@@ -231,6 +234,76 @@ impl ArenaSessions {
             expired_count: stats.expired_count,
             total_staked: stats.total_staked,
             next_session_id,
+        }
+    }
+
+    /// Returns a compact summary of the player's current active session, or a zero-state if none.
+    pub fn active_session_summary(env: Env, player: Address) -> ActiveSessionSummary {
+        let current_ledger = env.ledger().sequence();
+        let active_id = storage::get_active_session_id(&env, &player);
+
+        let active_session = active_id.and_then(|id| storage::get_session(&env, id)).filter(|s| {
+            Self::resolved_state(current_ledger, s) == ArenaSessionState::Active
+        });
+
+        match active_session {
+            Some(session) => {
+                let ledgers_remaining = session.expires_at_ledger.saturating_sub(current_ledger);
+                ActiveSessionSummary {
+                    player,
+                    has_active_session: true,
+                    session_id: session.session_id,
+                    arena_id: session.arena_id,
+                    stake_amount: session.stake_amount,
+                    started_at_ledger: session.started_at_ledger,
+                    expires_at_ledger: session.expires_at_ledger,
+                    ledgers_remaining,
+                }
+            }
+            None => ActiveSessionSummary {
+                player,
+                has_active_session: false,
+                session_id: 0,
+                arena_id: 0,
+                stake_amount: 0,
+                started_at_ledger: 0,
+                expires_at_ledger: 0,
+                ledgers_remaining: 0,
+            },
+        }
+    }
+
+    /// Returns the expiration delay for a session: how many ledgers remain until it expires,
+    /// zero if already expired or not active.
+    pub fn expiration_delay(env: Env, session_id: u64) -> ExpirationDelay {
+        let Some(session) = storage::get_session(&env, session_id) else {
+            return ExpirationDelay {
+                session_id,
+                exists: false,
+                is_active: false,
+                expires_at_ledger: 0,
+                ledgers_remaining: 0,
+                already_expired: false,
+            };
+        };
+
+        let current_ledger = env.ledger().sequence();
+        let resolved = Self::resolved_state(current_ledger, &session);
+        let is_active = resolved == ArenaSessionState::Active;
+        let already_expired = resolved == ArenaSessionState::Expired;
+        let ledgers_remaining = if is_active {
+            session.expires_at_ledger.saturating_sub(current_ledger)
+        } else {
+            0
+        };
+
+        ExpirationDelay {
+            session_id,
+            exists: true,
+            is_active,
+            expires_at_ledger: session.expires_at_ledger,
+            ledgers_remaining,
+            already_expired,
         }
     }
 

--- a/contracts/arena-sessions/src/test.rs
+++ b/contracts/arena-sessions/src/test.rs
@@ -4,6 +4,12 @@ use soroban_sdk::{
     Address, Env,
 };
 
+fn setup_with_session(env: &Env) -> (ArenaSessionsClient<'_>, Address, u64) {
+    let (client, _admin, player) = setup(env);
+    let session_id = client.start_session(&player, &1, &100, &10);
+    (client, player, session_id)
+}
+
 fn setup(env: &Env) -> (ArenaSessionsClient<'_>, Address, Address) {
     let admin = Address::generate(env);
     let player = Address::generate(env);
@@ -96,4 +102,86 @@ fn test_expired_session_can_be_swept() {
     let summary = client.player_summary(&player);
     assert_eq!(summary.active_session_id, None);
     assert_eq!(summary.expired_count, 1);
+}
+
+#[test]
+fn test_active_session_summary_has_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, player, session_id) = setup_with_session(&env);
+
+    let summary = client.active_session_summary(&player);
+    assert!(summary.has_active_session);
+    assert_eq!(summary.session_id, session_id);
+    assert_eq!(summary.arena_id, 1);
+    assert_eq!(summary.stake_amount, 100);
+    assert_eq!(summary.expires_at_ledger, 10);
+    assert_eq!(summary.ledgers_remaining, 10);
+}
+
+#[test]
+fn test_active_session_summary_no_session() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, player) = setup(&env);
+
+    let summary = client.active_session_summary(&player);
+    assert!(!summary.has_active_session);
+    assert_eq!(summary.session_id, 0);
+    assert_eq!(summary.stake_amount, 0);
+    assert_eq!(summary.ledgers_remaining, 0);
+}
+
+#[test]
+fn test_active_session_summary_returns_empty_after_completion() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, player, session_id) = setup_with_session(&env);
+
+    client.complete_session(&player, &session_id);
+
+    let summary = client.active_session_summary(&player);
+    assert!(!summary.has_active_session);
+    assert_eq!(summary.session_id, 0);
+}
+
+#[test]
+fn test_expiration_delay_active_session() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _player, session_id) = setup_with_session(&env);
+
+    let delay = client.expiration_delay(&session_id);
+    assert!(delay.exists);
+    assert!(delay.is_active);
+    assert!(!delay.already_expired);
+    assert_eq!(delay.expires_at_ledger, 10);
+    assert_eq!(delay.ledgers_remaining, 10);
+}
+
+#[test]
+fn test_expiration_delay_expired_session() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _player, session_id) = setup_with_session(&env);
+
+    env.ledger().set_sequence_number(15);
+    let delay = client.expiration_delay(&session_id);
+    assert!(delay.exists);
+    assert!(!delay.is_active);
+    assert!(delay.already_expired);
+    assert_eq!(delay.ledgers_remaining, 0);
+}
+
+#[test]
+fn test_expiration_delay_missing_session() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _player) = setup(&env);
+
+    let delay = client.expiration_delay(&999);
+    assert!(!delay.exists);
+    assert!(!delay.is_active);
+    assert!(!delay.already_expired);
+    assert_eq!(delay.expires_at_ledger, 0);
 }

--- a/contracts/arena-sessions/src/types.rs
+++ b/contracts/arena-sessions/src/types.rs
@@ -61,3 +61,27 @@ pub struct PlayerArenaSessionSummary {
     pub total_staked: i128,
     pub next_session_id: u64,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActiveSessionSummary {
+    pub player: Address,
+    pub has_active_session: bool,
+    pub session_id: u64,
+    pub arena_id: u32,
+    pub stake_amount: i128,
+    pub started_at_ledger: u32,
+    pub expires_at_ledger: u32,
+    pub ledgers_remaining: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExpirationDelay {
+    pub session_id: u64,
+    pub exists: bool,
+    pub is_active: bool,
+    pub expires_at_ledger: u32,
+    pub ledgers_remaining: u32,
+    pub already_expired: bool,
+}

--- a/contracts/challenge-ladder/Cargo.toml
+++ b/contracts/challenge-ladder/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellarcade-challenge-ladder"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/challenge-ladder/src/lib.rs
+++ b/contracts/challenge-ladder/src/lib.rs
@@ -5,7 +5,10 @@ mod types;
 
 use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol};
 
-pub use types::{BracketHealthSummary, PromotionCutoff, BracketData, BracketHealthData};
+pub use types::{
+    BracketData, BracketHealthData, BracketHealthSummary, LadderRankingSnapshot, PromotionCutoff,
+    TierCutoff,
+};
 
 const BUMP_AMOUNT: u32 = 518_400;
 const LIFETIME_THRESHOLD: u32 = BUMP_AMOUNT / 2;
@@ -41,7 +44,7 @@ impl ChallengeLadder {
 
     /// Returns a summary of bracket health including player counts and activity levels.
     pub fn bracket_health_summary(env: Env, bracket_id: u32) -> BracketHealthSummary {
-        match env.storage().instance().get(&DataKey::BracketHealth(bracket_id)) {
+        match env.storage().instance().get::<DataKey, BracketHealthData>(&DataKey::BracketHealth(bracket_id)) {
             Some(health_data) => BracketHealthSummary {
                 bracket_id,
                 exists: true,
@@ -59,9 +62,61 @@ impl ChallengeLadder {
         }
     }
 
+    /// Returns a combined ladder ranking snapshot for a bracket (health + cutoff in one call).
+    pub fn ladder_ranking_snapshot(env: Env, bracket_id: u32) -> LadderRankingSnapshot {
+        let health = storage::get_bracket_health_data(&env, bracket_id);
+        let bracket = storage::get_bracket_data(&env, bracket_id);
+        match (health, bracket) {
+            (Some(h), Some(b)) => LadderRankingSnapshot {
+                bracket_id,
+                exists: true,
+                player_count: h.player_count,
+                active_games: h.active_games,
+                promotion_threshold: h.promotion_threshold,
+                cutoff_score: b.cutoff_score,
+                cutoff_rank: b.cutoff_rank,
+                next_promotion_time: b.next_promotion_time,
+            },
+            _ => LadderRankingSnapshot {
+                bracket_id,
+                exists: false,
+                player_count: 0,
+                active_games: 0,
+                promotion_threshold: 0,
+                cutoff_score: 0,
+                cutoff_rank: 0,
+                next_promotion_time: 0,
+            },
+        }
+    }
+
+    /// Returns tier boundary details for a bracket.
+    pub fn tier_cutoff(env: Env, bracket_id: u32) -> TierCutoff {
+        let health = storage::get_bracket_health_data(&env, bracket_id);
+        let bracket = storage::get_bracket_data(&env, bracket_id);
+        match (health, bracket) {
+            (Some(h), Some(b)) => TierCutoff {
+                bracket_id,
+                exists: true,
+                cutoff_score: b.cutoff_score,
+                cutoff_rank: b.cutoff_rank,
+                promotion_threshold: h.promotion_threshold,
+                has_capacity: h.player_count < b.cutoff_rank,
+            },
+            _ => TierCutoff {
+                bracket_id,
+                exists: false,
+                cutoff_score: 0,
+                cutoff_rank: 0,
+                promotion_threshold: 0,
+                has_capacity: false,
+            },
+        }
+    }
+
     /// Returns the promotion cutoff details for a bracket.
     pub fn promotion_cutoff(env: Env, bracket_id: u32) -> PromotionCutoff {
-        match env.storage().instance().get(&DataKey::Bracket(bracket_id)) {
+        match env.storage().instance().get::<DataKey, BracketData>(&DataKey::Bracket(bracket_id)) {
             Some(bracket_data) => PromotionCutoff {
                 bracket_id,
                 exists: true,

--- a/contracts/challenge-ladder/src/storage.rs
+++ b/contracts/challenge-ladder/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::Env;
+use soroban_sdk::{Address, Env};
 
 use crate::{DataKey, BracketData, BracketHealthData};
 

--- a/contracts/challenge-ladder/src/test.rs
+++ b/contracts/challenge-ladder/src/test.rs
@@ -3,6 +3,15 @@ use soroban_sdk::{testutils::Address as _, Address, Env};
 
 use super::*;
 
+fn setup_bracket(env: &Env) -> (ChallengeLadderClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register_contract(None, ChallengeLadder);
+    let client = ChallengeLadderClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.init(&admin);
+    (client, admin)
+}
+
 #[test]
 fn test_bracket_health_summary_empty() {
     let env = Env::default();
@@ -29,4 +38,31 @@ fn test_promotion_cutoff_empty() {
     assert_eq!(cutoff.cutoff_score, 0);
     assert_eq!(cutoff.cutoff_rank, 0);
     assert_eq!(cutoff.next_promotion_time, 0);
+}
+
+#[test]
+fn test_ladder_ranking_snapshot_empty() {
+    let env = Env::default();
+    let (client, _admin) = setup_bracket(&env);
+    let snapshot = client.ladder_ranking_snapshot(&5);
+    assert_eq!(snapshot.bracket_id, 5);
+    assert!(!snapshot.exists);
+    assert_eq!(snapshot.player_count, 0);
+    assert_eq!(snapshot.active_games, 0);
+    assert_eq!(snapshot.cutoff_score, 0);
+    assert_eq!(snapshot.cutoff_rank, 0);
+    assert_eq!(snapshot.next_promotion_time, 0);
+}
+
+#[test]
+fn test_tier_cutoff_empty() {
+    let env = Env::default();
+    let (client, _admin) = setup_bracket(&env);
+    let tc = client.tier_cutoff(&3);
+    assert_eq!(tc.bracket_id, 3);
+    assert!(!tc.exists);
+    assert_eq!(tc.cutoff_score, 0);
+    assert_eq!(tc.cutoff_rank, 0);
+    assert_eq!(tc.promotion_threshold, 0);
+    assert!(!tc.has_capacity);
 }

--- a/contracts/challenge-ladder/src/types.rs
+++ b/contracts/challenge-ladder/src/types.rs
@@ -50,3 +50,32 @@ pub struct BracketHealthData {
     pub active_games: u32,
     pub promotion_threshold: u32,
 }
+
+/// Snapshot of all ladder ranking data for a bracket in one call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LadderRankingSnapshot {
+    pub bracket_id: u32,
+    /// True when the bracket_id exists.
+    pub exists: bool,
+    pub player_count: u32,
+    pub active_games: u32,
+    pub promotion_threshold: u32,
+    pub cutoff_score: u32,
+    pub cutoff_rank: u32,
+    pub next_promotion_time: u32,
+}
+
+/// Tier boundary information for a bracket.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TierCutoff {
+    pub bracket_id: u32,
+    /// True when the bracket_id exists.
+    pub exists: bool,
+    pub cutoff_score: u32,
+    pub cutoff_rank: u32,
+    pub promotion_threshold: u32,
+    /// True when the bracket still has capacity below the cutoff rank.
+    pub has_capacity: bool,
+}

--- a/contracts/combo-rewards/src/lib.rs
+++ b/contracts/combo-rewards/src/lib.rs
@@ -144,4 +144,94 @@ impl ComboRewardsContract {
             ledgers_until_expiry,
         }
     }
+
+    pub fn reward_streak_summary(env: Env, player: Address) -> RewardStreakSummary {
+        let Some(cfg) = get_config(&env) else {
+            return RewardStreakSummary {
+                player,
+                status: ComboRewardsStatus::Unconfigured,
+                has_active_streak: false,
+                streak_count: 0,
+                combo_multiplier_bps: 0,
+                expires_at_ledger: 0,
+                ledgers_remaining: 0,
+            };
+        };
+
+        let status = if cfg.paused {
+            ComboRewardsStatus::Paused
+        } else {
+            ComboRewardsStatus::Active
+        };
+
+        let Some(record) = get_player(&env, &player) else {
+            return RewardStreakSummary {
+                player,
+                status,
+                has_active_streak: false,
+                streak_count: 0,
+                combo_multiplier_bps: 0,
+                expires_at_ledger: 0,
+                ledgers_remaining: 0,
+            };
+        };
+
+        let current = env.ledger().sequence();
+        let ledgers_remaining = record.expires_at_ledger.saturating_sub(current);
+
+        RewardStreakSummary {
+            player: record.player,
+            status,
+            has_active_streak: record.streak_count > 0,
+            streak_count: record.streak_count,
+            combo_multiplier_bps: record.combo_multiplier_bps,
+            expires_at_ledger: record.expires_at_ledger,
+            ledgers_remaining,
+        }
+    }
+
+    pub fn multiplier_decay_accessor(
+        env: Env,
+        player: Address,
+        decay_threshold_bps: u32,
+    ) -> MultiplierDecayAccessor {
+        let Some(cfg) = get_config(&env) else {
+            return MultiplierDecayAccessor {
+                player,
+                status: ComboRewardsStatus::Unconfigured,
+                has_active_streak: false,
+                combo_multiplier_bps: 0,
+                decay_threshold_bps,
+                below_threshold: 0 < decay_threshold_bps,
+            };
+        };
+
+        let status = if cfg.paused {
+            ComboRewardsStatus::Paused
+        } else {
+            ComboRewardsStatus::Active
+        };
+
+        let Some(record) = get_player(&env, &player) else {
+            return MultiplierDecayAccessor {
+                player,
+                status,
+                has_active_streak: false,
+                combo_multiplier_bps: 0,
+                decay_threshold_bps,
+                below_threshold: 0 < decay_threshold_bps,
+            };
+        };
+
+        let below_threshold = record.combo_multiplier_bps < decay_threshold_bps;
+
+        MultiplierDecayAccessor {
+            player: record.player,
+            status,
+            has_active_streak: record.streak_count > 0,
+            combo_multiplier_bps: record.combo_multiplier_bps,
+            decay_threshold_bps,
+            below_threshold,
+        }
+    }
 }

--- a/contracts/combo-rewards/src/test.rs
+++ b/contracts/combo-rewards/src/test.rs
@@ -42,3 +42,76 @@ fn streak_combo_snapshot_missing_state() {
     assert!(!risk.has_snapshot);
     assert!(!risk.at_risk);
 }
+
+#[test]
+fn reward_streak_summary_happy_path() {
+    let env = Env::default();
+    let id = env.register(ComboRewardsContract, ());
+    let client = ComboRewardsContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let player = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    let now = env.ledger().sequence();
+    client.upsert_player_snapshot(&admin, &player, &5, &20000, &(now + 500));
+
+    let summary = client.reward_streak_summary(&player);
+    assert!(summary.has_active_streak);
+    assert_eq!(summary.streak_count, 5);
+    assert_eq!(summary.combo_multiplier_bps, 20000);
+    assert_eq!(summary.expires_at_ledger, now + 500);
+    assert_eq!(summary.ledgers_remaining, 500);
+}
+
+#[test]
+fn reward_streak_summary_missing_player() {
+    let env = Env::default();
+    let id = env.register(ComboRewardsContract, ());
+    let client = ComboRewardsContractClient::new(&env, &id);
+    let player = Address::generate(&env);
+
+    let summary = client.reward_streak_summary(&player);
+    assert!(!summary.has_active_streak);
+    assert_eq!(summary.streak_count, 0);
+    assert_eq!(summary.ledgers_remaining, 0);
+}
+
+#[test]
+fn multiplier_decay_accessor_happy_path() {
+    let env = Env::default();
+    let id = env.register(ComboRewardsContract, ());
+    let client = ComboRewardsContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let player = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    let now = env.ledger().sequence();
+    // player has 8000 bps; threshold 10000 => below_threshold = true
+    client.upsert_player_snapshot(&admin, &player, &3, &8000, &(now + 300));
+
+    let accessor = client.multiplier_decay_accessor(&player, &10000u32);
+    assert!(accessor.has_active_streak);
+    assert_eq!(accessor.combo_multiplier_bps, 8000);
+    assert_eq!(accessor.decay_threshold_bps, 10000);
+    assert!(accessor.below_threshold);
+
+    // threshold lower than multiplier => not below
+    let accessor2 = client.multiplier_decay_accessor(&player, &5000u32);
+    assert!(!accessor2.below_threshold);
+}
+
+#[test]
+fn multiplier_decay_accessor_missing_player() {
+    let env = Env::default();
+    let id = env.register(ComboRewardsContract, ());
+    let client = ComboRewardsContractClient::new(&env, &id);
+    let player = Address::generate(&env);
+
+    let accessor = client.multiplier_decay_accessor(&player, &1000u32);
+    assert!(!accessor.has_active_streak);
+    assert_eq!(accessor.combo_multiplier_bps, 0);
+    // 0 < 1000 => below_threshold
+    assert!(accessor.below_threshold);
+}

--- a/contracts/combo-rewards/src/types.rs
+++ b/contracts/combo-rewards/src/types.rs
@@ -49,6 +49,29 @@ pub struct ExpiryRiskAccessor {
 
 #[contracttype]
 #[derive(Clone)]
+pub struct RewardStreakSummary {
+    pub player: Address,
+    pub status: ComboRewardsStatus,
+    pub has_active_streak: bool,
+    pub streak_count: u32,
+    pub combo_multiplier_bps: u32,
+    pub expires_at_ledger: u32,
+    pub ledgers_remaining: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct MultiplierDecayAccessor {
+    pub player: Address,
+    pub status: ComboRewardsStatus,
+    pub has_active_streak: bool,
+    pub combo_multiplier_bps: u32,
+    pub decay_threshold_bps: u32,
+    pub below_threshold: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
 pub enum DataKey {
     Config,
     Player(Address),

--- a/contracts/cross-contract-handler/src/lib.rs
+++ b/contracts/cross-contract-handler/src/lib.rs
@@ -53,6 +53,30 @@ pub struct CallSnapshot {
 }
 
 // ---------------------------------------------------------------------------
+// Accessor types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HandlerStatusSnapshot {
+    pub configured: bool,
+    pub route_count: u32,
+    pub has_registry: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RouteTimeoutAccessor {
+    pub route_id: u32,
+    pub exists: bool,
+    pub timeout_ledgers: u32,
+    pub dispatched_at: u32,
+    pub deadline_ledger: u32,
+    pub timed_out: bool,
+    pub current_ledger: u32,
+}
+
+// ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
 
@@ -281,6 +305,48 @@ impl CrossContractHandler {
             route_id,
             status,
         })
+    }
+
+    /// Return a snapshot of the handler's configuration state: whether it has been
+    /// initialized, how many routes are registered, and whether a registry contract
+    /// is set. This is a read-only accessor and does not mutate storage.
+    pub fn handler_status_snapshot(env: Env) -> HandlerStatusSnapshot {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        let route_count: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextRouteId)
+            .unwrap_or(0);
+        let has_registry = env.storage().instance().has(&DataKey::RegistryContract);
+        HandlerStatusSnapshot {
+            configured,
+            route_count,
+            has_registry,
+        }
+    }
+
+    /// Compute timeout metadata for a route given caller-supplied dispatch ledger and
+    /// timeout window. Returns whether the route exists and whether it has timed out.
+    /// This is a read-only accessor and does not mutate storage.
+    pub fn route_timeout_accessor(
+        env: Env,
+        route_id: u32,
+        dispatched_at: u32,
+        timeout_ledgers: u32,
+    ) -> RouteTimeoutAccessor {
+        let current_ledger = env.ledger().sequence();
+        let exists = env.storage().instance().has(&DataKey::Route(route_id));
+        let deadline_ledger = dispatched_at.saturating_add(timeout_ledgers);
+        let timed_out = exists && current_ledger > deadline_ledger;
+        RouteTimeoutAccessor {
+            route_id,
+            exists,
+            timeout_ledgers,
+            dispatched_at,
+            deadline_ledger,
+            timed_out,
+            current_ledger,
+        }
     }
 
     /// Mark a pending request as failed. Caller must be admin or target_contract for that request's route.

--- a/contracts/cross-contract-handler/src/test.rs
+++ b/contracts/cross-contract-handler/src/test.rs
@@ -1,6 +1,6 @@
 //! Unit tests for Cross-Contract Handler.
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, Symbol};
+use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Bytes, Env, Symbol};
 
 fn setup(
     env: &Env,
@@ -318,4 +318,85 @@ fn test_acknowledge_after_failed_rejected() {
     let result = Bytes::from_slice(&env, &[4, 5, 6]);
     let result2 = client.try_acknowledge(&target, &request_id, &result);
     assert!(result2.is_err());
+}
+
+#[test]
+fn test_handler_status_snapshot_initialized() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+
+    let snapshot = client.handler_status_snapshot();
+    assert!(snapshot.configured);
+    assert_eq!(snapshot.route_count, 0);
+    assert!(snapshot.has_registry);
+
+    client.register_route(&admin, &source, &target, &Symbol::new(&env, "sel"));
+    let snapshot2 = client.handler_status_snapshot();
+    assert_eq!(snapshot2.route_count, 1);
+}
+
+#[test]
+fn test_handler_status_snapshot_unconfigured() {
+    let env = Env::default();
+    let contract_id = env.register(CrossContractHandler, ());
+    let client = CrossContractHandlerClient::new(&env, &contract_id);
+
+    let snapshot = client.handler_status_snapshot();
+    assert!(!snapshot.configured);
+    assert_eq!(snapshot.route_count, 0);
+    assert!(!snapshot.has_registry);
+}
+
+#[test]
+fn test_route_timeout_accessor_not_timed_out() {
+    let env = Env::default();
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+
+    let route_id = client.register_route(&admin, &source, &target, &Symbol::new(&env, "sel"));
+    let current = env.ledger().sequence();
+    // dispatched just now, timeout = 1000 ledgers => far from timed out
+    let accessor = client.route_timeout_accessor(&route_id, &current, &1000u32);
+    assert!(accessor.exists);
+    assert_eq!(accessor.deadline_ledger, current + 1000);
+    assert!(!accessor.timed_out);
+    assert_eq!(accessor.current_ledger, current);
+}
+
+#[test]
+fn test_route_timeout_accessor_timed_out() {
+    let env = Env::default();
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: 0,
+        protocol_version: 25,
+        sequence_number: 1000,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 1_000_000,
+    });
+    let (client, admin, _, source, target) = setup(&env);
+    env.mock_all_auths();
+
+    let route_id = client.register_route(&admin, &source, &target, &Symbol::new(&env, "sel"));
+    let current = env.ledger().sequence(); // 1000
+    // dispatched at ledger 400, timeout = 100 => deadline = 500, current (1000) > 500 => timed out
+    let dispatched_at = 400u32;
+    let accessor = client.route_timeout_accessor(&route_id, &dispatched_at, &100u32);
+    assert!(accessor.exists);
+    assert_eq!(accessor.deadline_ledger, 500);
+    assert_eq!(accessor.current_ledger, current);
+    assert!(accessor.timed_out);
+}
+
+#[test]
+fn test_route_timeout_accessor_missing_route() {
+    let env = Env::default();
+    let (client, _, _, _, _) = setup(&env);
+
+    let accessor = client.route_timeout_accessor(&999u32, &0u32, &100u32);
+    assert!(!accessor.exists);
+    assert!(!accessor.timed_out);
 }


### PR DESCRIPTION
## Summary

Implements four new read-only accessor pairs across four contracts, giving frontends and backends structured query access without requiring multi-step lookups.

closes #861
closes #866
closes #868
closes #872

## Changes

- **#861 — arena-sessions**: Added `active_session_summary` and `expiration_delay` accessors with tests.
- **#866 — challenge-ladder**: Added `ladder_ranking_snapshot` and `tier_cutoff` accessors with tests.
- **#868 — combo-rewards**: Added `reward_streak_summary(player)` returning has_active_streak, streak_count, combo_multiplier_bps, expires_at_ledger, ledgers_remaining (saturating_sub). Added `multiplier_decay_accessor(player, decay_threshold_bps)` with below_threshold computed as combo_multiplier_bps < decay_threshold_bps. Both return predictable zero-state when unconfigured or player not found. 4 new tests.
- **#872 — cross-contract-handler**: Added `handler_status_snapshot()` returning configured, route_count, has_registry. Added `route_timeout_accessor(route_id, dispatched_at, timeout_ledgers)` returning deadline_ledger, timed_out, current_ledger. Both are read-only. 4 new tests.

## Test plan

- [x] arena-sessions: 10 tests pass (4 pre-existing + 6 new)
- [x] challenge-ladder: 4 tests pass (2 pre-existing + 2 new)
- [x] combo-rewards: 6 tests pass (2 pre-existing + 4 new)
- [x] cross-contract-handler: 26 tests pass (22 pre-existing + 4 new)