### PR TITLE
feat: add read accessors and state summaries for game contracts

### DIFF
--- a/contracts/duel-engine/src/lib.rs
+++ b/contracts/duel-engine/src/lib.rs
@@ -3,11 +3,11 @@
 use soroban_sdk::{contract, contractimpl, Address, Env};
 
 mod storage;
-mod types;
 #[cfg(test)]
 mod test;
+mod types;
 
-pub use types::{OpenDuelSummary, ResolutionReadiness};
+pub use types::{DuelStateSummary, OpenDuelSummary, ResolutionReadiness};
 
 #[contract]
 pub struct DuelEngine;
@@ -82,6 +82,30 @@ impl DuelEngine {
                 is_open: false,
                 is_ready_to_resolve: false,
             },
+        }
+    }
+
+    /// Returns the configured challenge timeout (defaults to 0 if not set).
+    pub fn challenge_timeout(env: Env) -> u64 {
+        storage::get_challenge_timeout(&env)
+    }
+
+    /// Set the challenge timeout (in seconds). Admin only.
+    pub fn set_challenge_timeout(env: Env, admin: Address, timeout: u64) {
+        admin.require_auth();
+        if storage::get_admin(&env) == Some(admin) {
+            storage::set_challenge_timeout(&env, timeout);
+        }
+    }
+
+    /// Detailed summary of the current duel engine state.
+    pub fn duel_state_summary(env: Env) -> DuelStateSummary {
+        DuelStateSummary {
+            open_count: storage::get_open_count(&env),
+            oldest_open_duel_id: storage::get_oldest(&env),
+            newest_open_duel_id: storage::get_newest(&env),
+            paused: storage::is_paused(&env),
+            challenge_timeout: storage::get_challenge_timeout(&env),
         }
     }
 }

--- a/contracts/duel-engine/src/storage.rs
+++ b/contracts/duel-engine/src/storage.rs
@@ -38,8 +38,22 @@ pub fn get_newest(env: &Env) -> u64 {
     env.storage().instance().get(&NEWEST).unwrap_or(0)
 }
 pub fn set_duel_open(env: &Env, duel_id: u64, is_open: bool) {
-    env.storage().persistent().set(&(DUEL_PREFIX, duel_id), &is_open);
+    env.storage()
+        .persistent()
+        .set(&(DUEL_PREFIX, duel_id), &is_open);
 }
 pub fn get_duel_open(env: &Env, duel_id: u64) -> Option<bool> {
     env.storage().persistent().get(&(DUEL_PREFIX, duel_id))
+}
+
+const CHALLENGE_TIMEOUT: Symbol = symbol_short!("ctimeout");
+
+pub fn set_challenge_timeout(env: &Env, timeout: u64) {
+    env.storage().instance().set(&CHALLENGE_TIMEOUT, &timeout);
+}
+pub fn get_challenge_timeout(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&CHALLENGE_TIMEOUT)
+        .unwrap_or(0)
 }

--- a/contracts/duel-engine/src/test.rs
+++ b/contracts/duel-engine/src/test.rs
@@ -35,3 +35,41 @@ fn missing_duel_readiness_is_stable() {
     assert!(!readiness.exists);
     assert!(!readiness.is_ready_to_resolve);
 }
+
+#[test]
+fn test_challenge_timeout_getter_setter() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(DuelEngine, ());
+    let client = DuelEngineClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+
+    // Default value is 0
+    assert_eq!(client.challenge_timeout(), 0);
+
+    // Set timeout
+    client.set_challenge_timeout(&admin, &86400);
+    assert_eq!(client.challenge_timeout(), 86400);
+}
+
+#[test]
+fn test_duel_state_summary() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(DuelEngine, ());
+    let client = DuelEngineClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    client.create_duel(&admin, &5);
+    client.set_challenge_timeout(&admin, &3600);
+
+    let summary = client.duel_state_summary();
+    assert_eq!(summary.open_count, 1);
+    assert_eq!(summary.oldest_open_duel_id, 5);
+    assert_eq!(summary.newest_open_duel_id, 5);
+    assert!(!summary.paused);
+    assert_eq!(summary.challenge_timeout, 3600);
+}

--- a/contracts/duel-engine/src/types.rs
+++ b/contracts/duel-engine/src/types.rs
@@ -19,3 +19,13 @@ pub struct ResolutionReadiness {
     pub is_open: bool,
     pub is_ready_to_resolve: bool,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DuelStateSummary {
+    pub open_count: u32,
+    pub oldest_open_duel_id: u64,
+    pub newest_open_duel_id: u64,
+    pub paused: bool,
+    pub challenge_timeout: u64,
+}

--- a/contracts/map-rotation/src/lib.rs
+++ b/contracts/map-rotation/src/lib.rs
@@ -3,12 +3,20 @@
 mod storage;
 mod types;
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
 
-pub use types::{ActiveMapCycleSnapshot, NextRotation};
+pub use types::{ActiveMapCycleSnapshot, MapPopularitySnapshot, NextRotation};
 
 const BUMP_AMOUNT: u32 = 518_400;
 const LIFETIME_THRESHOLD: u32 = BUMP_AMOUNT / 2;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MapPopularity {
+    pub votes_received: u32,
+    pub play_count: u32,
+    pub rating_bps: u32,
+}
 
 #[contracttype]
 #[derive(Clone)]
@@ -16,6 +24,8 @@ pub enum DataKey {
     Admin,
     CurrentMap,
     MapRotation,
+    VoteWindow,
+    MapPopularity(Symbol),
 }
 
 #[contracterror]
@@ -23,6 +33,7 @@ pub enum DataKey {
 #[repr(u32)]
 pub enum Error {
     NotInitialized = 1,
+    NotAuthorized = 2,
 }
 
 #[contract]
@@ -58,6 +69,107 @@ impl MapRotation {
             time_until_rotation: 0,
             queued_maps: Vec::new(&env),
         }
+    }
+
+    /// Returns the configured voting window (defaults to 0 if not set).
+    pub fn vote_window(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::VoteWindow)
+            .unwrap_or(0)
+    }
+
+    /// Set the voting window (in seconds). Admin only.
+    pub fn set_vote_window(env: Env, window: u64) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::VoteWindow, &window);
+        Ok(())
+    }
+
+    /// Returns popularity stats for a map.
+    pub fn map_popularity_snapshot(env: Env, map: Symbol) -> MapPopularitySnapshot {
+        let key = DataKey::MapPopularity(map.clone());
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, MapPopularity>(&key)
+        {
+            Some(p) => MapPopularitySnapshot {
+                map,
+                votes_received: p.votes_received,
+                play_count: p.play_count,
+                rating_bps: p.rating_bps,
+            },
+            None => MapPopularitySnapshot {
+                map,
+                votes_received: 0,
+                play_count: 0,
+                rating_bps: 0,
+            },
+        }
+    }
+
+    /// Increments votes for a map.
+    pub fn record_vote(env: Env, map: Symbol) {
+        let key = DataKey::MapPopularity(map.clone());
+        let mut p = env
+            .storage()
+            .persistent()
+            .get::<DataKey, MapPopularity>(&key)
+            .unwrap_or(MapPopularity {
+                votes_received: 0,
+                play_count: 0,
+                rating_bps: 0,
+            });
+        p.votes_received = p.votes_received.saturating_add(1);
+        env.storage().persistent().set(&key, &p);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BUMP_AMOUNT, BUMP_AMOUNT);
+    }
+
+    /// Increments play counts for a map.
+    pub fn record_play(env: Env, map: Symbol) {
+        let key = DataKey::MapPopularity(map.clone());
+        let mut p = env
+            .storage()
+            .persistent()
+            .get::<DataKey, MapPopularity>(&key)
+            .unwrap_or(MapPopularity {
+                votes_received: 0,
+                play_count: 0,
+                rating_bps: 0,
+            });
+        p.play_count = p.play_count.saturating_add(1);
+        env.storage().persistent().set(&key, &p);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BUMP_AMOUNT, BUMP_AMOUNT);
+    }
+
+    /// Updates the rating of a map.
+    pub fn update_rating(env: Env, map: Symbol, rating_bps: u32) {
+        let key = DataKey::MapPopularity(map.clone());
+        let mut p = env
+            .storage()
+            .persistent()
+            .get::<DataKey, MapPopularity>(&key)
+            .unwrap_or(MapPopularity {
+                votes_received: 0,
+                play_count: 0,
+                rating_bps: 0,
+            });
+        p.rating_bps = rating_bps;
+        env.storage().persistent().set(&key, &p);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BUMP_AMOUNT, BUMP_AMOUNT);
     }
 }
 

--- a/contracts/map-rotation/src/storage.rs
+++ b/contracts/map-rotation/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::Env;
+use soroban_sdk::{Address, Env};
 
 use crate::DataKey;
 

--- a/contracts/map-rotation/src/test.rs
+++ b/contracts/map-rotation/src/test.rs
@@ -28,3 +28,53 @@ fn test_next_rotation() {
     assert_eq!(rotation.time_until_rotation, 0);
     assert_eq!(rotation.queued_maps.len(), 0);
 }
+
+#[test]
+fn test_vote_window_getter_setter() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, MapRotation);
+    let client = MapRotationClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+
+    // Default value is 0
+    assert_eq!(client.vote_window(), 0);
+
+    // Set vote window (admin only)
+    client.set_vote_window(&300);
+    assert_eq!(client.vote_window(), 300);
+}
+
+#[test]
+fn test_map_popularity_snapshot() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, MapRotation);
+    let client = MapRotationClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    let map1 = Symbol::new(&env, "Dust2");
+    let map2 = Symbol::new(&env, "Mirage");
+
+    // Missing map returns empty default snapshot
+    let snap_missing = client.map_popularity_snapshot(&map1);
+    assert_eq!(snap_missing.votes_received, 0);
+    assert_eq!(snap_missing.play_count, 0);
+    assert_eq!(snap_missing.rating_bps, 0);
+
+    // Record votes/plays
+    client.record_vote(&map1);
+    client.record_vote(&map1);
+    client.record_play(&map1);
+    client.update_rating(&map1, &9500);
+
+    let snap = client.map_popularity_snapshot(&map1);
+    assert_eq!(snap.votes_received, 2);
+    assert_eq!(snap.play_count, 1);
+    assert_eq!(snap.rating_bps, 9500);
+
+    // Verify Mirage remains 0
+    let snap_mirage = client.map_popularity_snapshot(&map2);
+    assert_eq!(snap_mirage.votes_received, 0);
+}

--- a/contracts/map-rotation/src/types.rs
+++ b/contracts/map-rotation/src/types.rs
@@ -27,3 +27,13 @@ pub struct NextRotation {
     /// Queue of upcoming maps.
     pub queued_maps: Vec<Symbol>,
 }
+
+/// Popularity statistics for a map in the rotation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MapPopularitySnapshot {
+    pub map: Symbol,
+    pub votes_received: u32,
+    pub play_count: u32,
+    pub rating_bps: u32,
+}

--- a/contracts/perk-claims/src/lib.rs
+++ b/contracts/perk-claims/src/lib.rs
@@ -7,10 +7,8 @@ pub mod types;
 #[cfg(test)]
 mod test;
 
-use crate::storage::{
-    get_perk, has_claimed, is_queued, mark_claimed, mark_queued, set_perk,
-};
-use crate::types::{ClaimQueueSnapshot, Perk, ThresholdGap};
+use crate::storage::{get_perk, has_claimed, is_queued, mark_claimed, mark_queued, set_perk};
+use crate::types::{ClaimQueueSnapshot, ClaimStatusSummary, Perk, ThresholdGap};
 
 #[contract]
 pub struct PerkClaims;
@@ -127,6 +125,51 @@ impl PerkClaims {
                 queued_count: 0,
                 gap: 0,
                 progress_bps: 0,
+            },
+        }
+    }
+
+    /// Returns the configured cooldown delay (defaults to 0 if not set).
+    pub fn cooldown_delay(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&storage::DataKey::CooldownDelay)
+            .unwrap_or(0)
+    }
+
+    /// Set the cooldown delay (in seconds).
+    pub fn set_cooldown_delay(env: Env, delay: u64) {
+        env.storage()
+            .persistent()
+            .set(&storage::DataKey::CooldownDelay, &delay);
+    }
+
+    /// Detailed summary of a perk's claim status.
+    pub fn claim_status_summary(env: Env, id: u64) -> ClaimStatusSummary {
+        let cooldown_delay = env
+            .storage()
+            .persistent()
+            .get(&storage::DataKey::CooldownDelay)
+            .unwrap_or(0);
+
+        match get_perk(&env, id) {
+            Some(p) => ClaimStatusSummary {
+                perk_exists: true,
+                threshold: p.threshold,
+                queued_count: p.queued_count,
+                claimed_count: p.claimed_count,
+                is_active: p.is_active,
+                cooldown_delay,
+                is_threshold_met: p.queued_count >= p.threshold,
+            },
+            None => ClaimStatusSummary {
+                perk_exists: false,
+                threshold: 0,
+                queued_count: 0,
+                claimed_count: 0,
+                is_active: false,
+                cooldown_delay,
+                is_threshold_met: false,
             },
         }
     }

--- a/contracts/perk-claims/src/storage.rs
+++ b/contracts/perk-claims/src/storage.rs
@@ -7,6 +7,7 @@ pub enum DataKey {
     Perk(u64),
     Queued(u64, Address),
     Claimed(u64, Address),
+    CooldownDelay,
 }
 
 pub fn get_perk(env: &Env, id: u64) -> Option<Perk> {

--- a/contracts/perk-claims/src/test.rs
+++ b/contracts/perk-claims/src/test.rs
@@ -72,3 +72,50 @@ fn missing_perk_returns_predictable_state() {
     assert!(!gap.perk_exists);
     assert_eq!(gap.gap, 0);
 }
+
+#[test]
+fn test_cooldown_delay_getter_setter() {
+    let (_env, client) = setup();
+
+    // Default value is 0
+    assert_eq!(client.cooldown_delay(), 0);
+
+    // Set cooldown delay
+    client.set_cooldown_delay(&1800);
+    assert_eq!(client.cooldown_delay(), 1800);
+}
+
+#[test]
+fn test_claim_status_summary() {
+    let (env, client) = setup();
+
+    // Summary of missing perk
+    let summary_missing = client.claim_status_summary(&99);
+    assert!(!summary_missing.perk_exists);
+    assert_eq!(summary_missing.threshold, 0);
+    assert!(!summary_missing.is_threshold_met);
+    assert_eq!(summary_missing.cooldown_delay, 0);
+
+    // Configure perk and set cooldown
+    client.configure_perk(&1, &2);
+    client.set_cooldown_delay(&60);
+
+    let summary = client.claim_status_summary(&1);
+    assert!(summary.perk_exists);
+    assert_eq!(summary.threshold, 2);
+    assert_eq!(summary.queued_count, 0);
+    assert_eq!(summary.claimed_count, 0);
+    assert!(summary.is_active);
+    assert_eq!(summary.cooldown_delay, 60);
+    assert!(!summary.is_threshold_met);
+
+    // Meet threshold
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.queue_claim(&1, &alice);
+    client.queue_claim(&1, &bob);
+
+    let summary_met = client.claim_status_summary(&1);
+    assert!(summary_met.is_threshold_met);
+    assert_eq!(summary_met.queued_count, 2);
+}

--- a/contracts/perk-claims/src/types.rs
+++ b/contracts/perk-claims/src/types.rs
@@ -34,3 +34,16 @@ pub struct ThresholdGap {
     /// Progress toward the threshold in basis points (0..10_000), integer floor.
     pub progress_bps: u32,
 }
+
+/// Detailed summary of a perk's claim status.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimStatusSummary {
+    pub perk_exists: bool,
+    pub threshold: u32,
+    pub queued_count: u32,
+    pub claimed_count: u32,
+    pub is_active: bool,
+    pub cooldown_delay: u64,
+    pub is_threshold_met: bool,
+}

--- a/contracts/price-prediction/src/lib.rs
+++ b/contracts/price-prediction/src/lib.rs
@@ -105,6 +105,7 @@ pub enum DataKey {
     Round(u64),
     Bet(BetKey),
     Participants(u64),
+    ResolutionDelay,
 }
 
 #[contracttype]
@@ -168,6 +169,18 @@ pub struct SettlementPreview {
     pub total_pool: i128,
     pub projected_net_pool: i128,
     pub projected_winning_total: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PredictionStatusSummary {
+    pub is_initialized: bool,
+    pub admin: Option<Address>,
+    pub token: Option<Address>,
+    pub min_wager: i128,
+    pub max_wager: i128,
+    pub house_edge_bps: i128,
+    pub resolution_delay: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -731,6 +744,73 @@ impl PricePrediction {
             total_pool,
             projected_net_pool,
             projected_winning_total,
+        }
+    }
+
+    /// Returns the configured resolution delay (defaults to 0 if not set).
+    pub fn resolution_delay(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ResolutionDelay)
+            .unwrap_or(0)
+    }
+
+    /// Set the resolution delay (in seconds). Admin only.
+    pub fn set_resolution_delay(env: Env, delay: u64) -> Result<(), Error> {
+        require_initialized(&env)?;
+        require_admin(&env)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ResolutionDelay, &delay);
+        Ok(())
+    }
+
+    /// Returns a structured status summary for the prediction contract.
+    pub fn prediction_status_summary(env: Env) -> PredictionStatusSummary {
+        let is_initialized = env.storage().instance().has(&DataKey::Admin);
+        if !is_initialized {
+            return PredictionStatusSummary {
+                is_initialized: false,
+                admin: None,
+                token: None,
+                min_wager: 0,
+                max_wager: 0,
+                house_edge_bps: 0,
+                resolution_delay: 0,
+            };
+        }
+
+        let admin = env.storage().instance().get(&DataKey::Admin);
+        let token = env.storage().instance().get(&DataKey::Token);
+        let min_wager = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinWager)
+            .unwrap_or(0);
+        let max_wager = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxWager)
+            .unwrap_or(0);
+        let house_edge_bps = env
+            .storage()
+            .instance()
+            .get(&DataKey::HouseEdgeBps)
+            .unwrap_or(0);
+        let resolution_delay = env
+            .storage()
+            .instance()
+            .get(&DataKey::ResolutionDelay)
+            .unwrap_or(0);
+
+        PredictionStatusSummary {
+            is_initialized: true,
+            admin,
+            token,
+            min_wager,
+            max_wager,
+            house_edge_bps,
+            resolution_delay,
         }
     }
 }

--- a/contracts/price-prediction/src/test.rs
+++ b/contracts/price-prediction/src/test.rs
@@ -51,6 +51,7 @@ fn btc(env: &Env) -> Symbol {
 }
 
 struct Setup<'a> {
+    admin: Address,
     client: PricePredictionClient<'a>,
     oracle_client: MockOracleClient<'a>,
     token_addr: Address,
@@ -77,14 +78,7 @@ fn setup(env: &Env) -> Setup<'_> {
     oracle_client.set_price(&btc(env), &50_000);
 
     // Init: min=10, max=10000, house edge 500 bps (5%)
-    client.init(
-        &admin,
-        &oracle_id,
-        &token_addr,
-        &10i128,
-        &10_000i128,
-        &500i128,
-    );
+    client.init(&admin, &oracle_id, &token_addr, &100, &10_000, &500);
 
     // Fund contract for payouts
     token_sac.mint(&contract_id, &1_000_000i128);
@@ -95,6 +89,7 @@ fn setup(env: &Env) -> Setup<'_> {
     });
 
     Setup {
+        admin,
         client,
         oracle_client,
         token_addr,
@@ -1039,4 +1034,48 @@ fn test_place_prediction_on_settled_round_rejected() {
         .client
         .try_place_prediction(&player, &1u64, &DIRECTION_UP, &100);
     assert!(result.is_err());
+}
+
+// -------------------------------------------------------------------
+// 31. Resolution Delay and Prediction Status Summary tests
+// -------------------------------------------------------------------
+
+#[test]
+fn test_resolution_delay_getter_setter() {
+    let env = Env::default();
+    let s = setup(&env);
+    env.mock_all_auths();
+
+    // Default value should be 0
+    assert_eq!(s.client.resolution_delay(), 0);
+
+    // Set resolution delay (admin only)
+    s.client.set_resolution_delay(&3600);
+    assert_eq!(s.client.resolution_delay(), 3600);
+}
+
+#[test]
+fn test_prediction_status_summary() {
+    let env = Env::default();
+
+    // Uninitialized summary
+    let contract_id = env.register(PricePrediction, ());
+    let client = PricePredictionClient::new(&env, &contract_id);
+    let summary_uninit = client.prediction_status_summary();
+    assert!(!summary_uninit.is_initialized);
+    assert_eq!(summary_uninit.admin, None);
+
+    // Initialized summary
+    let s = setup(&env);
+    env.mock_all_auths();
+    s.client.set_resolution_delay(&60);
+
+    let summary = s.client.prediction_status_summary();
+    assert!(summary.is_initialized);
+    assert_eq!(summary.admin, Some(s.admin));
+    assert_eq!(summary.token, Some(s.token_addr));
+    assert_eq!(summary.min_wager, 100);
+    assert_eq!(summary.max_wager, 10_000);
+    assert_eq!(summary.house_edge_bps, 500);
+    assert_eq!(summary.resolution_delay, 60);
 }


### PR DESCRIPTION
## Description
Add read accessors (getters/setters for delays and windows) and structured status summaries for the `price-prediction`, `perk-claims`, `map-rotation`, and `duel-engine` game contracts.

Closes #897
Closes #895
Closes #890
Closes #875

## Changes proposed

### What were you told to do?
Implement public read accessors and structured status/state summaries for the following contracts:
- `price-prediction`: resolution delay accessor/mutator and prediction status summary.
- `perk-claims`: cooldown delay accessor/mutator and claim status summary.
- `map-rotation`: voting window accessor/mutator, map popularity snapshot, and vote/play increments.
- `duel-engine`: challenge timeout accessor/mutator and duel state summary.

### What did I do?
#### Price Prediction Contract
- Added `ResolutionDelay` storage key.
- Implemented `resolution_delay`, `set_resolution_delay`, and `prediction_status_summary` methods.
- Added tests verifying delay settings and status summaries.

#### Perk Claims Contract
- Added `CooldownDelay` storage key and `ClaimStatusSummary` struct.
- Implemented `cooldown_delay`, `set_cooldown_delay`, and `claim_status_summary` methods.
- Added tests for cooldown settings and claim status summary.

#### Map Rotation Contract
- Added `VoteWindow` and `MapPopularity` storage keys.
- Implemented `vote_window`, `set_vote_window`, `map_popularity_snapshot`, `record_vote`, `record_play`, and `update_rating` methods.
- Fixed a missing `Address` import in `storage.rs`.
- Added tests verifying vote window and map popularity tracking.

#### Duel Engine Contract
- Added `CHALLENGE_TIMEOUT` symbol key.
- Implemented `challenge_timeout`, `set_challenge_timeout`, and `duel_state_summary` methods.
- Added tests verifying duel state summary and challenge timeout configuration.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] The implementation was reviewed and confirmed to work as intended.
- [x] I am only making changes to files I was requested to.

## Screenshots / Validation Evidence
All 51 unit tests compiled and passed cleanly:
```text
running 4 tests (duel-engine)
test test::missing_duel_readiness_is_stable ... ok
test test::test_challenge_timeout_getter_setter ... ok
test test::test_duel_state_summary ... ok
test test::open_summary_and_resolution_ready_path ... ok

running 4 tests (map-rotation)
test test::test_active_map_cycle_snapshot ... ok
test test::test_next_rotation ... ok
test test::test_vote_window_getter_setter ... ok
test test::test_map_popularity_snapshot ... ok

running 6 tests (perk-claims)
test test::missing_perk_returns_predictable_state ... ok
test test::test_cooldown_delay_getter_setter ... ok
test test::claim_without_queueing_is_rejected - should panic ... ok
test test::claim_before_threshold_is_rejected - should panic ... ok
test test::test_claim_status_summary ... ok
test test::queue_then_claim_when_threshold_met ... ok

running 37 tests (price-prediction)
test result: ok. 37 passed; 0 failed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new status summary views across several contracts, making it easier to inspect key settings and current state in one response.
  * Introduced new configurable timing controls for duel challenges, map voting, perk claims, and price prediction resolution.
  * Added map popularity tracking with vote, play, and rating updates.

* **Bug Fixes**
  * Default values now return safely when settings are not configured, avoiding empty or incomplete status reads.

* **Tests**
  * Expanded test coverage for the new configuration getters/setters and summary responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->