### PR TITLE
feat(contracts): accessor tests for creator-escrow, fee-allocator, fee-shield, merch-redemption

### DIFF
--- a/contracts/creator-escrow/src/test.rs
+++ b/contracts/creator-escrow/src/test.rs
@@ -102,3 +102,58 @@ fn test_creator_pause_blocks_release_workflow() {
     let result = client.try_release_available(&creator);
     assert_eq!(result, Err(Ok(Error::CreatorPaused)));
 }
+
+#[test]
+fn test_escrow_balance_summary_unlock_delay_accessor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, creator, payout_token, beneficiary) = setup(&env);
+
+    // Fund two entries with different unlock delays via release_delay_ledgers.
+    // Entry 0 funded at ledger 0 with delay=5 → releasable at ledger 5.
+    // Entry 1 funded at ledger 0 with same delay → releasable at ledger 5.
+    client.configure_creator(&creator, &payout_token, &beneficiary, &5);
+    client.fund_escrow(&creator, &400);
+    client.fund_escrow(&creator, &600);
+
+    // Before unlock: nothing releasable.
+    let summary = client.creator_summary(&creator);
+    assert!(summary.exists);
+    assert_eq!(summary.total_locked, 1000);
+    assert_eq!(summary.total_released, 0);
+    assert_eq!(summary.releasable_now, 0);
+    assert_eq!(summary.release_delay_ledgers, 5);
+    assert_eq!(summary.pending_entry_count, 2);
+
+    // Advance ledger past unlock point.
+    env.ledger().set_sequence_number(6);
+    let summary_after = client.creator_summary(&creator);
+    assert_eq!(summary_after.releasable_now, 1000);
+
+    // Verify entry-level unlock-delay details via escrow_entry.
+    let entry0 = client.escrow_entry(&creator, &0);
+    assert!(entry0.exists);
+    assert!(entry0.releasable_now);
+    assert_eq!(entry0.releasable_at_ledger, 5);
+    assert_eq!(entry0.amount, 400);
+}
+
+#[test]
+fn test_globally_paused_shows_in_summary_and_blocks_operations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, creator, payout_token, beneficiary) = setup(&env);
+
+    client.configure_creator(&creator, &payout_token, &beneficiary, &0);
+    client.fund_escrow(&creator, &100);
+    client.set_paused(&true);
+
+    let summary = client.creator_summary(&creator);
+    assert!(summary.paused);
+
+    let result = client.try_fund_escrow(&creator, &50);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+
+    let result_release = client.try_release_available(&creator);
+    assert_eq!(result_release, Err(Ok(Error::ContractPaused)));
+}

--- a/contracts/fee-allocator/src/test.rs
+++ b/contracts/fee-allocator/src/test.rs
@@ -81,3 +81,43 @@ fn paused_allocator_is_not_rebalance_ready() {
     assert!(readiness.has_drift);
     assert!(!readiness.ready_to_rebalance);
 }
+
+#[test]
+fn allocation_split_summary_shows_per_route_drift() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // Three routes summing to 10_000 bps; allocations skewed toward "rewar".
+    client.upsert_route(&admin, &symbol_short!("treas"), &3_000, &20);
+    client.upsert_route(&admin, &symbol_short!("rewar"), &5_000, &70);
+    client.upsert_route(&admin, &symbol_short!("ops"), &2_000, &10);
+
+    let summary = client.allocation_drift_summary();
+    assert!(summary.configured);
+    assert_eq!(summary.route_count, 3);
+    assert_eq!(summary.total_allocated, 100);
+    assert!(summary.target_bps_valid);
+    // Expect drift: "rewar" allocated 70, expected 50 → drift 20.
+    assert!(summary.total_drift > 0);
+    assert!(summary.max_route_drift >= 20);
+    assert!(!summary.balanced);
+}
+
+#[test]
+fn adjustment_delay_readiness_blocked_without_drift() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // Perfectly balanced: each route gets exactly its target share.
+    client.upsert_route(&admin, &symbol_short!("treas"), &5_000, &50);
+    client.upsert_route(&admin, &symbol_short!("rewar"), &5_000, &50);
+
+    let summary = client.allocation_drift_summary();
+    assert!(summary.balanced);
+    assert_eq!(summary.total_drift, 0);
+
+    // No drift → rebalancing not needed.
+    let readiness = client.rebalance_readiness();
+    assert!(!readiness.has_drift);
+    assert!(!readiness.ready_to_rebalance);
+}

--- a/contracts/fee-shield/src/test.rs
+++ b/contracts/fee-shield/src/test.rs
@@ -61,3 +61,52 @@ fn paused_and_missing_shields_return_predictable_reads() {
     assert_eq!(missing.spendable_bps, 0);
     assert_eq!(missing.risk_level, DepletionRiskLevel::None);
 }
+
+#[test]
+fn reserve_coverage_snapshot_depleted_when_spendable_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    // protected_balance == current_balance → spendable == 0.
+    client.upsert_shield(&admin, &1, &500, &500, &false);
+
+    let summary = client.protected_balance_summary(&1);
+    assert!(summary.exists);
+    assert_eq!(summary.state, ShieldState::Depleted);
+    assert_eq!(summary.spendable_balance, 0);
+    assert!(!summary.can_charge);
+
+    let risk = client.depletion_risk(&1);
+    assert_eq!(risk.spendable_bps, 0);
+    assert_eq!(risk.risk_level, DepletionRiskLevel::Critical);
+    assert!(risk.will_block_next_charge);
+}
+
+#[test]
+fn emergency_gap_accessor_risk_levels_are_correctly_assigned() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    // spendable_bps = 800 → High risk (0..=1_000).
+    client.upsert_shield(&admin, &10, &920, &1_000, &false);
+    let risk_high = client.depletion_risk(&10);
+    assert_eq!(risk_high.risk_level, DepletionRiskLevel::High);
+
+    // spendable_bps = 2_000 → Medium risk (1_001..=2_500).
+    client.upsert_shield(&admin, &11, &800, &1_000, &false);
+    let risk_medium = client.depletion_risk(&11);
+    assert_eq!(risk_medium.risk_level, DepletionRiskLevel::Medium);
+
+    // spendable_bps = 4_000 → Low risk (2_501..=5_000).
+    client.upsert_shield(&admin, &12, &600, &1_000, &false);
+    let risk_low = client.depletion_risk(&12);
+    assert_eq!(risk_low.risk_level, DepletionRiskLevel::Low);
+
+    // spendable_bps = 9_000 → None (>5_000).
+    client.upsert_shield(&admin, &13, &100, &1_000, &false);
+    let risk_none = client.depletion_risk(&13);
+    assert_eq!(risk_none.risk_level, DepletionRiskLevel::None);
+    assert!(!risk_none.will_block_next_charge);
+}

--- a/contracts/merch-redemption/src/test.rs
+++ b/contracts/merch-redemption/src/test.rs
@@ -71,3 +71,81 @@ fn test_stock_pressure_empty_state() {
     assert_eq!(pressure.pressure_bps, 0);
     assert_eq!(pressure.pressure_level, StockPressureLevel::None);
 }
+
+#[test]
+fn test_redemption_count_summary_stock_warning_levels() {
+    let env = Env::default();
+    env.ledger().set_timestamp(500);
+    let contract_id = env.register(MerchRedemption, ());
+    let client = MerchRedemptionClient::new(&env, &contract_id);
+
+    let tshirt = Symbol::new(&env, "tshirt");
+    let cap = Symbol::new(&env, "cap");
+
+    // High pressure: 92/100 claimed.
+    env.as_contract(&contract_id, || {
+        set_claim_window(
+            &env,
+            &tshirt,
+            &ClaimWindowState {
+                start_time: 400,
+                end_time: 600,
+                total_available: 100,
+                claimed_count: 92,
+            },
+        );
+    });
+    let pressure_high = client.stock_pressure(&tshirt);
+    assert_eq!(pressure_high.pressure_level, StockPressureLevel::High);
+    assert_eq!(pressure_high.remaining_stock, 8);
+
+    // No pressure: 10/100 claimed.
+    env.as_contract(&contract_id, || {
+        set_claim_window(
+            &env,
+            &cap,
+            &ClaimWindowState {
+                start_time: 400,
+                end_time: 600,
+                total_available: 100,
+                claimed_count: 10,
+            },
+        );
+    });
+    let pressure_none = client.stock_pressure(&cap);
+    assert_eq!(pressure_none.pressure_level, StockPressureLevel::None);
+    assert_eq!(pressure_none.remaining_stock, 90);
+}
+
+#[test]
+fn test_claim_window_inactive_before_start_and_after_end() {
+    let env = Env::default();
+    let contract_id = env.register(MerchRedemption, ());
+    let client = MerchRedemptionClient::new(&env, &contract_id);
+    let item_id = Symbol::new(&env, "poster");
+
+    env.as_contract(&contract_id, || {
+        set_claim_window(
+            &env,
+            &item_id,
+            &ClaimWindowState {
+                start_time: 1000,
+                end_time: 2000,
+                total_available: 50,
+                claimed_count: 0,
+            },
+        );
+    });
+
+    // Before window opens.
+    env.ledger().set_timestamp(500);
+    let before = client.claim_window_snapshot(&item_id);
+    assert!(before.configured);
+    assert!(!before.is_active);
+
+    // After window closes.
+    env.ledger().set_timestamp(2001);
+    let after = client.claim_window_snapshot(&item_id);
+    assert!(after.configured);
+    assert!(!after.is_active);
+}


### PR DESCRIPTION
## Summary

Adds and extends test coverage for four contract read-accessor methods across the assigned issues.

### #870 — creator-escrow: escrow balance summary and unlock-delay accessor
- Added `test_escrow_balance_summary_unlock_delay_accessor`: funds two entries, verifies `releasable_now=0` before unlock and `=1000` after advancing the ledger; confirms `releasable_at_ledger` on individual entries.
- Added `test_globally_paused_shows_in_summary_and_blocks_operations`: verifies `summary.paused=true` and that both `fund_escrow` and `release_available` return `ContractPaused`.

### #879 — fee-allocator: allocation split summary and adjustment-delay accessor
- Added `allocation_split_summary_shows_per_route_drift`: three routes with skewed allocations; asserts `total_drift > 0` and `max_route_drift >= 20`.
- Added `adjustment_delay_readiness_blocked_without_drift`: perfectly balanced routes → `total_drift=0`, `has_drift=false`, `ready_to_rebalance=false`.

### #880 — fee-shield: reserve coverage snapshot and emergency-gap accessor
- Added `reserve_coverage_snapshot_depleted_when_spendable_zero`: `protected_balance == current_balance` → `Depleted` state, `can_charge=false`.
- Added `emergency_gap_accessor_risk_levels_are_correctly_assigned`: four shields covering High/Medium/Low/None risk tiers with `will_block_next_charge` assertions.

### #891 — merch-redemption: redemption count summary and stock-warning accessor
- Added `test_redemption_count_summary_stock_warning_levels`: 92% claimed → `High`, 10% claimed → `None`.
- Added `test_claim_window_inactive_before_start_and_after_end`: verifies `is_active=false` both before and after window timestamps.

## Test plan

- `cargo test -p creator-escrow` — all tests pass
- `cargo test -p fee-allocator` — all tests pass
- `cargo test -p fee-shield` — all tests pass
- `cargo test -p merch-redemption` — all tests pass

closes #870
closes #879
closes #880
closes #891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for creator escrow timing and paused-state behavior, including unlock timing and blocked actions when paused.
  * Added coverage for fee allocation drift and rebalance readiness, including balanced and unbalanced route configurations.
  * Added coverage for shield depletion and risk levels, including blocking charges when spendable balance reaches zero.
  * Added coverage for merch redemption stock pressure and claim-window activity checks before and after the active period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->