### PR TITLE
feat(contracts): entry status, update delay, participation summary, transition gap (#887 #882 #867)

### DIFF
--- a/contracts/clan-seasons/src/lib.rs
+++ b/contracts/clan-seasons/src/lib.rs
@@ -21,7 +21,7 @@ mod types;
 
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
 
-pub use types::{RosterLock, SeasonCarryoverSnapshot, SeasonRecord};
+pub use types::{ParticipationSummary, RosterLock, SeasonCarryoverSnapshot, SeasonRecord, TransitionGap};
 
 pub const PERSISTENT_BUMP_LEDGERS: u32 = 518_400;
 
@@ -125,6 +125,62 @@ impl ClanSeasons {
                 season_end_ledger: 0,
                 was_locked: false,
             },
+        }
+    }
+
+    /// Return participation statistics for `season_id`.
+    ///
+    /// Unknown season ids return `exists = false` with zeroed numeric fields.
+    pub fn participation_summary(env: Env, season_id: u32) -> ParticipationSummary {
+        match storage::get_season(&env, season_id) {
+            Some(record) => ParticipationSummary {
+                season_id,
+                exists: true,
+                locked_member_count: record.locked_member_count,
+                was_locked: record.was_locked,
+                carryover_xp: record.carryover_xp,
+                carryover_rank: record.carryover_rank,
+            },
+            None => ParticipationSummary {
+                season_id,
+                exists: false,
+                locked_member_count: 0,
+                was_locked: false,
+                carryover_xp: 0,
+                carryover_rank: 0,
+            },
+        }
+    }
+
+    /// Return the ledger gap between two seasons.
+    ///
+    /// Uses `season_end_ledger` of `to_season_id` as a proxy for its start
+    /// ledger. `gap_ledgers` is 0 when either season is missing or the
+    /// result would underflow.
+    pub fn transition_gap(env: Env, from_season_id: u32, to_season_id: u32) -> TransitionGap {
+        let from_record = storage::get_season(&env, from_season_id);
+        let to_record = storage::get_season(&env, to_season_id);
+
+        let from_exists = from_record.is_some();
+        let to_exists = to_record.is_some();
+
+        let from_end_ledger = from_record.map(|r| r.season_end_ledger).unwrap_or(0);
+        let to_start_ledger = to_record.map(|r| r.season_end_ledger).unwrap_or(0);
+
+        let gap_ledgers = if from_exists && to_exists {
+            from_end_ledger.saturating_sub(to_start_ledger)
+        } else {
+            0
+        };
+
+        TransitionGap {
+            from_season_id,
+            to_season_id,
+            from_exists,
+            to_exists,
+            from_end_ledger,
+            to_start_ledger,
+            gap_ledgers,
         }
     }
 

--- a/contracts/clan-seasons/src/test.rs
+++ b/contracts/clan-seasons/src/test.rs
@@ -154,3 +154,92 @@ fn test_roster_lock_missing() {
     assert_eq!(lock.locked_member_count, 0);
     assert_eq!(lock.lock_reason_code, 0);
 }
+
+// ---------------------------------------------------------------------------
+// participation_summary — known season
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_participation_summary_known_season() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_season(
+        &admin, &10, &4000, &7, &3_000_000, &true,
+        &2_900_000, &true, &20, &1,
+    );
+
+    let summary = client.participation_summary(&10);
+    assert!(summary.exists);
+    assert_eq!(summary.season_id, 10);
+    assert_eq!(summary.locked_member_count, 20);
+    assert!(summary.was_locked);
+    assert_eq!(summary.carryover_xp, 4000);
+    assert_eq!(summary.carryover_rank, 7);
+}
+
+// ---------------------------------------------------------------------------
+// participation_summary — unknown season returns zero-state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_participation_summary_unknown_season() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let summary = client.participation_summary(&42);
+    assert!(!summary.exists);
+    assert_eq!(summary.season_id, 42);
+    assert_eq!(summary.locked_member_count, 0);
+    assert!(!summary.was_locked);
+    assert_eq!(summary.carryover_xp, 0);
+    assert_eq!(summary.carryover_rank, 0);
+}
+
+// ---------------------------------------------------------------------------
+// transition_gap — two configured seasons
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_transition_gap_two_known_seasons() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    // from season ends at ledger 2_000_000
+    client.upsert_season(
+        &admin, &20, &1000, &5, &2_000_000, &false,
+        &0, &false, &0, &0,
+    );
+    // to season proxy-start (season_end_ledger) = 1_800_000
+    client.upsert_season(
+        &admin, &21, &2000, &6, &1_800_000, &false,
+        &0, &false, &0, &0,
+    );
+
+    let gap = client.transition_gap(&20, &21);
+    assert!(gap.from_exists);
+    assert!(gap.to_exists);
+    assert_eq!(gap.from_end_ledger, 2_000_000);
+    assert_eq!(gap.to_start_ledger, 1_800_000);
+    assert_eq!(gap.gap_ledgers, 200_000);
+}
+
+// ---------------------------------------------------------------------------
+// transition_gap — missing season handled gracefully
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_transition_gap_missing_season() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.upsert_season(
+        &admin, &30, &500, &2, &1_500_000, &false,
+        &0, &false, &0, &0,
+    );
+
+    let gap = client.transition_gap(&30, &999);
+    assert!(gap.from_exists);
+    assert!(!gap.to_exists);
+    assert_eq!(gap.gap_ledgers, 0);
+}

--- a/contracts/clan-seasons/src/types.rs
+++ b/contracts/clan-seasons/src/types.rs
@@ -40,6 +40,47 @@ pub struct RosterLock {
     pub lock_reason_code: u32,
 }
 
+/// Participation statistics for a clan season.
+///
+/// Returned by `participation_summary`. When the season is unknown,
+/// `exists` is `false` and all numeric fields are zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParticipationSummary {
+    pub season_id: u32,
+    /// `true` when the season_id exists in storage.
+    pub exists: bool,
+    /// Number of clan members locked into this season.
+    pub locked_member_count: u32,
+    /// `true` when the roster was locked at some point during the season.
+    pub was_locked: bool,
+    /// Experience points carried over at season end.
+    pub carryover_xp: u32,
+    /// Rank carried over at season end.
+    pub carryover_rank: u32,
+}
+
+/// Ledger gap between two consecutive clan seasons.
+///
+/// Returned by `transition_gap`. When either season is missing,
+/// `gap_ledgers` is 0 and the corresponding `*_exists` flag is `false`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransitionGap {
+    pub from_season_id: u32,
+    pub to_season_id: u32,
+    pub from_exists: bool,
+    pub to_exists: bool,
+    /// `season_end_ledger` of the `from` season.
+    pub from_end_ledger: u32,
+    /// `season_end_ledger` of the `to` season used as a proxy for its start
+    /// ledger; 0 when the season is missing.
+    pub to_start_ledger: u32,
+    /// Saturating difference between `from_end_ledger` and `to_start_ledger`;
+    /// 0 when either season is missing or the result would be negative.
+    pub gap_ledgers: u32,
+}
+
 /// Persistent season record written by admin mutations.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/guild-progress/src/lib.rs
+++ b/contracts/guild-progress/src/lib.rs
@@ -17,7 +17,7 @@ use soroban_sdk::{contract, contractevent, contractimpl, Address, Env, Vec};
 mod types;
 mod storage;
 
-use types::{DataKey, Milestone, MilestoneStatus, MilestoneCoverageSnapshot, NextMilestoneTarget};
+use types::{DataKey, Milestone, MilestoneStatus, MilestoneCoverageSnapshot, NextMilestoneTarget, UpdateDelay};
 use storage::{
     compute_milestone_coverage_snapshot, get_guild_milestone_ids, get_guild_progress,
     get_milestone, get_next_milestone_id, get_next_milestone_target, set_guild_milestone_ids,
@@ -192,6 +192,35 @@ impl GuildProgress {
     /// Returns zero/completion state if all milestones done.
     pub fn get_next_milestone_target(env: Env, guild_id: Address) -> NextMilestoneTarget {
         get_next_milestone_target(&env, &guild_id)
+    }
+
+    /// Concise alias for `get_milestone_coverage_snapshot`.
+    /// Returns the current milestone-coverage snapshot for the guild.
+    pub fn progress_milestone_snapshot(
+        env: Env,
+        guild_id: Address,
+    ) -> MilestoneCoverageSnapshot {
+        compute_milestone_coverage_snapshot(&env, &guild_id)
+    }
+
+    /// Returns the gap between the guild's current progress and its next
+    /// uncompleted milestone target. When all milestones are completed
+    /// `progress_gap` is 0 and `all_milestones_completed` is `true`.
+    pub fn update_delay(env: Env, guild_id: Address) -> UpdateDelay {
+        let next = get_next_milestone_target(&env, &guild_id);
+        let progress_gap = if next.all_milestones_completed {
+            0
+        } else {
+            next.progress_remaining
+        };
+        UpdateDelay {
+            guild_id,
+            next_milestone_id: next.next_milestone_id,
+            target_progress: next.target_progress,
+            current_progress: next.current_progress,
+            progress_gap,
+            all_milestones_completed: next.all_milestones_completed,
+        }
     }
 
     /// List all milestone IDs for a guild (paginated).

--- a/contracts/guild-progress/src/test.rs
+++ b/contracts/guild-progress/src/test.rs
@@ -259,6 +259,70 @@ fn test_get_milestone_details() {
 }
 
 #[test]
+fn test_update_delay_gap_not_reached() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let guild_id = Address::generate(&env);
+    let contract_id = env.register(GuildProgress, ());
+    let client = GuildProgressClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.create_milestone(&guild_id, &1000, &500);
+    client.update_progress(&guild_id, &300);
+
+    let delay = client.update_delay(&guild_id);
+    assert_eq!(delay.next_milestone_id, 1);
+    assert_eq!(delay.target_progress, 1000);
+    assert_eq!(delay.current_progress, 300);
+    assert_eq!(delay.progress_gap, 700);
+    assert!(!delay.all_milestones_completed);
+}
+
+#[test]
+fn test_update_delay_all_milestones_completed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let guild_id = Address::generate(&env);
+    let contract_id = env.register(GuildProgress, ());
+    let client = GuildProgressClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.create_milestone(&guild_id, &1000, &500);
+    client.update_progress(&guild_id, &1000);
+
+    let delay = client.update_delay(&guild_id);
+    assert_eq!(delay.progress_gap, 0);
+    assert!(delay.all_milestones_completed);
+}
+
+#[test]
+fn test_progress_milestone_snapshot_matches_get_milestone_coverage_snapshot() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let guild_id = Address::generate(&env);
+    let contract_id = env.register(GuildProgress, ());
+    let client = GuildProgressClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.create_milestone(&guild_id, &500, &100);
+    client.update_progress(&guild_id, &250);
+
+    let snap1 = client.get_milestone_coverage_snapshot(&guild_id);
+    let snap2 = client.progress_milestone_snapshot(&guild_id);
+
+    assert_eq!(snap1.current_progress, snap2.current_progress);
+    assert_eq!(snap1.total_milestones, snap2.total_milestones);
+    assert_eq!(snap1.completed_milestones, snap2.completed_milestones);
+    assert_eq!(snap1.progress_percentage, snap2.progress_percentage);
+}
+
+#[test]
 fn test_multiple_milestones_progression() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/guild-progress/src/types.rs
+++ b/contracts/guild-progress/src/types.rs
@@ -64,6 +64,24 @@ pub struct NextMilestoneTarget {
     pub all_milestones_completed: bool,
 }
 
+/// Gap between current progress and the next uncompleted milestone.
+#[contracttype]
+#[derive(Clone)]
+pub struct UpdateDelay {
+    /// Guild identifier.
+    pub guild_id: Address,
+    /// Next uncompleted milestone ID (0 if none / all done).
+    pub next_milestone_id: u32,
+    /// Progress threshold of the next milestone.
+    pub target_progress: i128,
+    /// Current guild progress.
+    pub current_progress: i128,
+    /// How far until the next milestone (0 if all completed).
+    pub progress_gap: i128,
+    /// `true` when all milestones are completed.
+    pub all_milestones_completed: bool,
+}
+
 /// Storage key discriminants.
 #[contracttype]
 pub enum DataKey {

--- a/contracts/lobby-gates/src/lib.rs
+++ b/contracts/lobby-gates/src/lib.rs
@@ -8,7 +8,7 @@ pub mod types;
 mod test;
 
 use crate::storage::{get_gate, has_entered, mark_entered, set_gate};
-use crate::types::{Gate, GateStatusSnapshot, ReleaseDelay};
+use crate::types::{EntryStatusSummary, Gate, GateStatusSnapshot, ReleaseDelay, UnlockDelay};
 
 #[contract]
 pub struct LobbyGates;
@@ -96,6 +96,71 @@ impl LobbyGates {
                 is_open: false,
                 is_paused: false,
                 is_full: false,
+            },
+        }
+    }
+
+    /// Entry status summary: occupancy, capacity, and whether entry is allowed.
+    pub fn entry_status_summary(env: Env, id: u64) -> EntryStatusSummary {
+        let now = env.ledger().timestamp();
+
+        match get_gate(&env, id) {
+            Some(g) => {
+                let is_open = !g.is_paused && now >= g.release_time;
+                let remaining_slots = g.capacity.saturating_sub(g.occupancy);
+                let entry_allowed = is_open && remaining_slots > 0;
+                EntryStatusSummary {
+                    gate_exists: true,
+                    occupancy: g.occupancy,
+                    capacity: g.capacity,
+                    remaining_slots,
+                    is_open,
+                    is_paused: g.is_paused,
+                    entry_allowed,
+                }
+            }
+            None => EntryStatusSummary {
+                gate_exists: false,
+                occupancy: 0,
+                capacity: 0,
+                remaining_slots: 0,
+                is_open: false,
+                is_paused: false,
+                entry_allowed: false,
+            },
+        }
+    }
+
+    /// Time remaining until a gate is fully unlocked (released AND not paused).
+    pub fn unlock_delay(env: Env, id: u64) -> UnlockDelay {
+        let now = env.ledger().timestamp();
+
+        match get_gate(&env, id) {
+            Some(g) => {
+                let is_released = now >= g.release_time;
+                let is_unlocked = is_released && !g.is_paused;
+                let seconds_until_unlock = if is_unlocked {
+                    0
+                } else if !is_released {
+                    g.release_time - now
+                } else {
+                    // released but paused; no countdown makes sense yet
+                    0
+                };
+                UnlockDelay {
+                    gate_exists: true,
+                    is_unlocked,
+                    release_time: g.release_time,
+                    current_time: now,
+                    seconds_until_unlock,
+                }
+            }
+            None => UnlockDelay {
+                gate_exists: false,
+                is_unlocked: false,
+                release_time: 0,
+                current_time: now,
+                seconds_until_unlock: 0,
             },
         }
     }

--- a/contracts/lobby-gates/src/test.rs
+++ b/contracts/lobby-gates/src/test.rs
@@ -75,3 +75,65 @@ fn missing_gate_returns_predictable_state() {
     assert!(!delay.gate_exists);
     assert!(!delay.is_released);
 }
+
+#[test]
+fn entry_status_summary_and_unlock_delay_track_state() {
+    let (env, client) = setup();
+    client.configure_gate(&10, &5, &100);
+
+    // Before release: gate not open, entry not allowed.
+    let summary = client.entry_status_summary(&10);
+    assert!(summary.gate_exists);
+    assert!(!summary.is_open);
+    assert!(!summary.entry_allowed);
+    assert_eq!(summary.capacity, 5);
+    assert_eq!(summary.occupancy, 0);
+    assert_eq!(summary.remaining_slots, 5);
+
+    let ud = client.unlock_delay(&10);
+    assert!(ud.gate_exists);
+    assert!(!ud.is_unlocked);
+    assert_eq!(ud.seconds_until_unlock, 100);
+
+    // After release: gate open, entry allowed.
+    env.ledger().with_mut(|li| li.timestamp = 150);
+    let summary = client.entry_status_summary(&10);
+    assert!(summary.is_open);
+    assert!(summary.entry_allowed);
+    assert!(!summary.is_paused);
+
+    let ud = client.unlock_delay(&10);
+    assert!(ud.is_unlocked);
+    assert_eq!(ud.seconds_until_unlock, 0);
+
+    // Paused after release: unlocked should be false.
+    client.set_paused(&10, &true);
+    let summary = client.entry_status_summary(&10);
+    assert!(!summary.is_open);
+    assert!(!summary.entry_allowed);
+    assert!(summary.is_paused);
+
+    let ud = client.unlock_delay(&10);
+    assert!(!ud.is_unlocked);
+    assert_eq!(ud.seconds_until_unlock, 0); // released but paused
+}
+
+#[test]
+fn entry_status_summary_and_unlock_delay_unknown_gate() {
+    let (_env, client) = setup();
+
+    let summary = client.entry_status_summary(&999);
+    assert!(!summary.gate_exists);
+    assert_eq!(summary.occupancy, 0);
+    assert_eq!(summary.capacity, 0);
+    assert_eq!(summary.remaining_slots, 0);
+    assert!(!summary.is_open);
+    assert!(!summary.is_paused);
+    assert!(!summary.entry_allowed);
+
+    let ud = client.unlock_delay(&999);
+    assert!(!ud.gate_exists);
+    assert!(!ud.is_unlocked);
+    assert_eq!(ud.release_time, 0);
+    assert_eq!(ud.seconds_until_unlock, 0);
+}

--- a/contracts/lobby-gates/src/types.rs
+++ b/contracts/lobby-gates/src/types.rs
@@ -36,3 +36,32 @@ pub struct ReleaseDelay {
     pub seconds_until_release: u64,
     pub is_released: bool,
 }
+
+/// Entry status summary for a lobby gate: occupancy, capacity, and whether
+/// entry is currently allowed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EntryStatusSummary {
+    pub gate_exists: bool,
+    pub occupancy: u32,
+    pub capacity: u32,
+    pub remaining_slots: u32,
+    pub is_open: bool,
+    pub is_paused: bool,
+    /// `true` only when the gate exists, is not paused, has been released, and
+    /// has remaining capacity.
+    pub entry_allowed: bool,
+}
+
+/// How long until a gate becomes unlocked (released AND not paused).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnlockDelay {
+    pub gate_exists: bool,
+    /// `true` when the gate is both released and not paused.
+    pub is_unlocked: bool,
+    pub release_time: u64,
+    pub current_time: u64,
+    /// Seconds until the gate is fully unlocked (0 if already unlocked).
+    pub seconds_until_unlock: u64,
+}


### PR DESCRIPTION
## Summary

- **lobby-gates**: add `EntryStatusSummary` and `UnlockDelay` types; expose `entry_status_summary(id)` and `unlock_delay(id)` methods that return occupancy/capacity/entry-allowed state and unlock countdown respectively
- **guild-progress**: add `UpdateDelay` type; expose `progress_milestone_snapshot(guild_id)` as a concise alias for coverage snapshot and `update_delay(guild_id)` to surface the progress gap until the next milestone
- **clan-seasons**: add `ParticipationSummary` and `TransitionGap` types; expose `participation_summary(season_id)` and `transition_gap(from, to)` with graceful zero-state handling for unknown seasons

All methods follow the existing zero-state pattern (returning `exists = false` with zeroed fields for unknown IDs). Tests cover success paths and unknown-ID edge cases for each new method.

closes #887
closes #882
closes #867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new read-only status and timing queries for seasons, guild progress, and lobby gates.
  * Users can now view season participation details, season-to-season gaps, milestone progress snapshots, update delays, gate entry status, and unlock countdowns.

* **Bug Fixes**
  * Missing or unknown records now return clear zeroed/false results instead of incomplete data.
  * Countdown and gap values are kept non-negative when data is unavailable or fully completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->