### PR TITLE
feat(contracts): voucher escrow, campaign saturation, guild season tier-cutoff (#844 #865 #883)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -147,6 +147,7 @@ members = [
     "squad-rewards",
     "reward-bridges",
     "arena-passes",
+    "voucher-escrow",
 ]
 
 exclude = [

--- a/contracts/campaign-claims/src/test.rs
+++ b/contracts/campaign-claims/src/test.rs
@@ -92,3 +92,50 @@ fn not_configured_and_missing_campaign_reads_are_predictable() {
     assert_eq!(cooldown.seconds_until_open, 0);
     assert_eq!(cooldown.seconds_until_closed, 0);
 }
+
+#[test]
+fn claim_saturation_summary_unknown_campaign_returns_not_exists() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _user) = setup(&env);
+
+    let saturation = client.claim_saturation_summary(&9999);
+    assert!(saturation.configured);
+    assert!(!saturation.exists);
+    assert_eq!(saturation.saturation_bps, 0);
+    assert!(!saturation.saturated);
+    assert_eq!(saturation.budget, 0);
+    assert_eq!(saturation.committed_budget, 0);
+}
+
+#[test]
+fn cooldown_window_accessor_scheduled_campaign_shows_seconds_until_open() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Set ledger timestamp to 50, campaign starts at 200
+    env.ledger().with_mut(|ledger| ledger.timestamp = 50);
+    let (client, admin, _user) = setup(&env);
+    client.upsert_campaign(&admin, &42, &5_000, &200, &400, &false);
+
+    let cooldown = client.cooldown_window_accessor(&42);
+    assert_eq!(cooldown.state, ClaimWindowState::Scheduled);
+    assert!(cooldown.seconds_until_open > 0);
+    assert_eq!(cooldown.seconds_until_open, 150); // 200 - 50
+    assert_eq!(cooldown.seconds_until_closed, 0);
+}
+
+#[test]
+fn cooldown_window_accessor_closed_campaign_shows_zero_seconds_until_closed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Set ledger timestamp to 500, campaign ended at 300
+    env.ledger().with_mut(|ledger| ledger.timestamp = 500);
+    let (client, admin, _user) = setup(&env);
+    client.upsert_campaign(&admin, &43, &5_000, &100, &300, &false);
+
+    let cooldown = client.cooldown_window_accessor(&43);
+    assert_eq!(cooldown.state, ClaimWindowState::Closed);
+    assert_eq!(cooldown.seconds_until_open, 0);
+    assert_eq!(cooldown.seconds_until_closed, 0);
+    assert!(!cooldown.can_record_claims);
+}

--- a/contracts/guild-season/src/lib.rs
+++ b/contracts/guild-season/src/lib.rs
@@ -7,7 +7,7 @@ mod types;
 #[cfg(test)]
 mod test;
 
-pub use types::{ActiveSeasonSnapshot, SeasonData};
+pub use types::{ActiveSeasonSnapshot, SeasonData, SeasonPerformanceSummary, TierCutoffAccessor};
 
 #[contract]
 pub struct GuildSeason;
@@ -84,5 +84,75 @@ impl GuildSeason {
             .filter(|s| s.season_id == season_id)
             .map(|s| s.reward_threshold)
             .unwrap_or(0)
+    }
+
+    /// Return a performance summary for the active season including whether
+    /// the season is currently active (within its time window) and how many
+    /// seconds remain until it ends.
+    pub fn season_performance_summary(env: Env) -> SeasonPerformanceSummary {
+        let now = env.ledger().timestamp();
+        if let Some(season) = storage::get_active_season(&env) {
+            let is_active = season.starts_at <= now && now <= season.ends_at;
+            let seconds_remaining = if is_active {
+                season.ends_at.saturating_sub(now)
+            } else {
+                0
+            };
+            SeasonPerformanceSummary {
+                has_active_season: true,
+                is_paused: storage::is_paused(&env),
+                season_id: season.season_id,
+                guild_count: season.guild_count,
+                reward_threshold: season.reward_threshold,
+                starts_at: season.starts_at,
+                ends_at: season.ends_at,
+                now,
+                is_active,
+                seconds_remaining,
+            }
+        } else {
+            SeasonPerformanceSummary {
+                has_active_season: false,
+                is_paused: storage::is_paused(&env),
+                season_id: 0,
+                guild_count: 0,
+                reward_threshold: 0,
+                starts_at: 0,
+                ends_at: 0,
+                now,
+                is_active: false,
+                seconds_remaining: 0,
+            }
+        }
+    }
+
+    /// Return the tier cutoff in basis points: reward_threshold * 10_000 /
+    /// guild_count. Returns 0 when there is no active season or guild_count is 0.
+    pub fn tier_cutoff_accessor(env: Env) -> TierCutoffAccessor {
+        if let Some(season) = storage::get_active_season(&env) {
+            let tier_cutoff_bps = if season.guild_count > 0 {
+                u32::try_from(
+                    (season.reward_threshold as u128 * 10_000) / season.guild_count as u128,
+                )
+                .unwrap_or(0)
+            } else {
+                0
+            };
+            TierCutoffAccessor {
+                has_active_season: true,
+                season_id: season.season_id,
+                reward_threshold: season.reward_threshold,
+                tier_cutoff_bps,
+                guild_count: season.guild_count,
+            }
+        } else {
+            TierCutoffAccessor {
+                has_active_season: false,
+                season_id: 0,
+                reward_threshold: 0,
+                tier_cutoff_bps: 0,
+                guild_count: 0,
+            }
+        }
     }
 }

--- a/contracts/guild-season/src/test.rs
+++ b/contracts/guild-season/src/test.rs
@@ -1,6 +1,6 @@
 extern crate std;
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env};
 
 use crate::{GuildSeason, GuildSeasonClient};
 
@@ -32,4 +32,80 @@ fn empty_snapshot_is_predictable() {
     let snap = client.active_season_snapshot();
     assert!(!snap.has_active_season);
     assert_eq!(client.reward_threshold(&999), 0);
+}
+
+#[test]
+fn season_performance_summary_with_active_season_returns_correct_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Timestamp within the season window [100, 300]
+    env.ledger().with_mut(|ledger| ledger.timestamp = 200);
+    let admin = Address::generate(&env);
+    let id = env.register(GuildSeason, ());
+    let client = GuildSeasonClient::new(&env, &id);
+    client.init(&admin);
+    // season_id=7, threshold=250, starts_at=100, ends_at=300, guild_count=1000
+    client.set_active_season(&admin, &7, &250, &100, &300, &1000);
+
+    let summary = client.season_performance_summary();
+    assert!(summary.has_active_season);
+    assert!(summary.is_active);
+    assert_eq!(summary.season_id, 7);
+    assert_eq!(summary.guild_count, 1000);
+    assert_eq!(summary.reward_threshold, 250);
+    assert_eq!(summary.starts_at, 100);
+    assert_eq!(summary.ends_at, 300);
+    assert_eq!(summary.now, 200);
+    assert_eq!(summary.seconds_remaining, 100); // 300 - 200
+}
+
+#[test]
+fn season_performance_summary_with_no_season_returns_defaults() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(GuildSeason, ());
+    let client = GuildSeasonClient::new(&env, &id);
+    client.init(&admin);
+
+    let summary = client.season_performance_summary();
+    assert!(!summary.has_active_season);
+    assert!(!summary.is_active);
+    assert_eq!(summary.season_id, 0);
+    assert_eq!(summary.seconds_remaining, 0);
+}
+
+#[test]
+fn tier_cutoff_accessor_returns_correct_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(GuildSeason, ());
+    let client = GuildSeasonClient::new(&env, &id);
+    client.init(&admin);
+    // threshold=250, guild_count=1000 → bps = 250 * 10_000 / 1000 = 2500
+    client.set_active_season(&admin, &5, &250, &100, &500, &1000);
+
+    let accessor = client.tier_cutoff_accessor();
+    assert!(accessor.has_active_season);
+    assert_eq!(accessor.season_id, 5);
+    assert_eq!(accessor.reward_threshold, 250);
+    assert_eq!(accessor.guild_count, 1000);
+    assert_eq!(accessor.tier_cutoff_bps, 2500);
+}
+
+#[test]
+fn tier_cutoff_accessor_with_zero_guild_count_returns_zero_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(GuildSeason, ());
+    let client = GuildSeasonClient::new(&env, &id);
+    client.init(&admin);
+    // guild_count=0 → bps must be 0 to avoid division by zero
+    client.set_active_season(&admin, &3, &100, &50, &200, &0);
+
+    let accessor = client.tier_cutoff_accessor();
+    assert!(accessor.has_active_season);
+    assert_eq!(accessor.tier_cutoff_bps, 0);
 }

--- a/contracts/guild-season/src/types.rs
+++ b/contracts/guild-season/src/types.rs
@@ -24,3 +24,33 @@ pub struct ActiveSeasonSnapshot {
     pub ends_at: u64,
     pub guild_count: u32,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeasonPerformanceSummary {
+    pub has_active_season: bool,
+    pub is_paused: bool,
+    pub season_id: u64,
+    pub guild_count: u32,
+    pub reward_threshold: u64,
+    pub starts_at: u64,
+    pub ends_at: u64,
+    pub now: u64,
+    /// true when the current ledger time falls within [starts_at, ends_at]
+    pub is_active: bool,
+    /// seconds until season ends (0 if not started or already ended)
+    pub seconds_remaining: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TierCutoffAccessor {
+    pub has_active_season: bool,
+    pub season_id: u64,
+    pub reward_threshold: u64,
+    /// tier_cutoff_bps: basis-point representation of reward_threshold as a
+    /// fraction of guild_count (reward_threshold * 10_000 / guild_count).
+    /// 0 when guild_count is 0 or no active season.
+    pub tier_cutoff_bps: u32,
+    pub guild_count: u32,
+}

--- a/contracts/voucher-escrow/Cargo.toml
+++ b/contracts/voucher-escrow/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "voucher-escrow"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = "25.1.1"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.1", features = ["testutils"] }

--- a/contracts/voucher-escrow/src/lib.rs
+++ b/contracts/voucher-escrow/src/lib.rs
@@ -1,0 +1,125 @@
+#![no_std]
+#![allow(unexpected_cfgs)]
+
+mod storage;
+mod types;
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+pub use types::{EscrowRecord, ExpiryPressure, ReservedVoucherSummary};
+
+#[contract]
+pub struct VoucherEscrow;
+
+#[contractimpl]
+impl VoucherEscrow {
+    pub fn init(env: Env, admin: Address) {
+        if storage::get_admin(&env).is_some() {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        storage::set_admin(&env, &admin);
+    }
+
+    /// Reserve a voucher in escrow. Admin only.
+    pub fn reserve(
+        env: Env,
+        admin: Address,
+        holder: Address,
+        reserved_amount: i128,
+        expiry_ledger: u32,
+    ) -> u64 {
+        admin.require_auth();
+        assert!(
+            storage::get_admin(&env) == Some(admin.clone()),
+            "Unauthorized"
+        );
+        assert!(reserved_amount > 0, "Amount must be positive");
+        assert!(
+            expiry_ledger > env.ledger().sequence(),
+            "Expiry must be in future"
+        );
+
+        let voucher_id = storage::get_next_id(&env);
+        storage::set_next_id(&env, voucher_id + 1);
+
+        storage::set_escrow(
+            &env,
+            &EscrowRecord {
+                voucher_id,
+                holder,
+                reserved_amount,
+                expiry_ledger,
+                claimed: false,
+            },
+        );
+
+        let mut summary = storage::get_summary(&env);
+        summary.total_reserved += reserved_amount;
+        summary.active_escrow_count += 1;
+        storage::set_summary(&env, &summary);
+
+        voucher_id
+    }
+
+    /// Claim an escrowed voucher. Caller must be the holder.
+    pub fn claim(env: Env, holder: Address, voucher_id: u64) -> i128 {
+        holder.require_auth();
+        let mut record = storage::get_escrow(&env, voucher_id).expect("Escrow not found");
+        assert!(!record.claimed, "Already claimed");
+        assert!(record.holder == holder, "Not the holder");
+        assert!(
+            env.ledger().sequence() <= record.expiry_ledger,
+            "Escrow expired"
+        );
+
+        record.claimed = true;
+        storage::set_escrow(&env, &record);
+
+        let mut summary = storage::get_summary(&env);
+        summary.claimed_count += 1;
+        summary.active_escrow_count = summary.active_escrow_count.saturating_sub(1);
+        storage::set_summary(&env, &summary);
+
+        record.reserved_amount
+    }
+
+    /// Reserved voucher summary: total reserved, active/expired/claimed counts.
+    pub fn reserved_voucher_summary(env: Env) -> ReservedVoucherSummary {
+        storage::get_summary(&env)
+    }
+
+    /// Expiry pressure for a specific voucher: ledgers remaining, expired flag.
+    pub fn expiry_pressure(env: Env, voucher_id: u64) -> ExpiryPressure {
+        let current_ledger = env.ledger().sequence();
+        match storage::get_escrow(&env, voucher_id) {
+            Some(record) => {
+                let is_expired = current_ledger > record.expiry_ledger;
+                let ledgers_until_expiry = if is_expired {
+                    0
+                } else {
+                    record.expiry_ledger - current_ledger
+                };
+                ExpiryPressure {
+                    voucher_id,
+                    exists: true,
+                    expiry_ledger: record.expiry_ledger,
+                    current_ledger,
+                    ledgers_until_expiry,
+                    is_expired,
+                    is_claimed: record.claimed,
+                }
+            }
+            None => ExpiryPressure {
+                voucher_id,
+                exists: false,
+                expiry_ledger: 0,
+                current_ledger,
+                ledgers_until_expiry: 0,
+                is_expired: false,
+                is_claimed: false,
+            },
+        }
+    }
+}

--- a/contracts/voucher-escrow/src/storage.rs
+++ b/contracts/voucher-escrow/src/storage.rs
@@ -1,0 +1,52 @@
+use soroban_sdk::{contracttype, Env};
+use crate::types::{EscrowRecord, ReservedVoucherSummary};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Escrow(u64),
+    NextId,
+    Summary,
+}
+
+pub fn get_admin(env: &Env) -> Option<soroban_sdk::Address> {
+    env.storage().instance().get(&DataKey::Admin)
+}
+
+pub fn set_admin(env: &Env, admin: &soroban_sdk::Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_escrow(env: &Env, voucher_id: u64) -> Option<EscrowRecord> {
+    env.storage().persistent().get(&DataKey::Escrow(voucher_id))
+}
+
+pub fn set_escrow(env: &Env, record: &EscrowRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Escrow(record.voucher_id), record);
+}
+
+pub fn get_next_id(env: &Env) -> u64 {
+    env.storage().instance().get(&DataKey::NextId).unwrap_or(1)
+}
+
+pub fn set_next_id(env: &Env, id: u64) {
+    env.storage().instance().set(&DataKey::NextId, &id);
+}
+
+pub fn get_summary(env: &Env) -> ReservedVoucherSummary {
+    env.storage()
+        .instance()
+        .get(&DataKey::Summary)
+        .unwrap_or(ReservedVoucherSummary {
+            total_reserved: 0,
+            active_escrow_count: 0,
+            expired_escrow_count: 0,
+            claimed_count: 0,
+        })
+}
+
+pub fn set_summary(env: &Env, summary: &ReservedVoucherSummary) {
+    env.storage().instance().set(&DataKey::Summary, summary);
+}

--- a/contracts/voucher-escrow/src/test.rs
+++ b/contracts/voucher-escrow/src/test.rs
@@ -1,0 +1,66 @@
+#![cfg(test)]
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use crate::{VoucherEscrow, VoucherEscrowClient};
+
+fn setup(env: &Env) -> (VoucherEscrowClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let id = env.register(VoucherEscrow, ());
+    let client = VoucherEscrowClient::new(env, &id);
+    env.mock_all_auths();
+    client.init(&admin);
+    (client, admin)
+}
+
+#[test]
+fn reserved_voucher_summary_tracks_reserves() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let holder = Address::generate(&env);
+
+    let vid = client.reserve(&admin, &holder, &500, &1000);
+    let summary = client.reserved_voucher_summary();
+    assert_eq!(summary.total_reserved, 500);
+    assert_eq!(summary.active_escrow_count, 1);
+    assert_eq!(summary.claimed_count, 0);
+
+    client.claim(&holder, &vid);
+    let summary2 = client.reserved_voucher_summary();
+    assert_eq!(summary2.claimed_count, 1);
+    assert_eq!(summary2.active_escrow_count, 0);
+}
+
+#[test]
+fn expiry_pressure_unknown_id_returns_not_exists() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let p = client.expiry_pressure(&999);
+    assert!(!p.exists);
+    assert!(!p.is_expired);
+}
+
+#[test]
+fn expiry_pressure_shows_ledgers_remaining() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let holder = Address::generate(&env);
+    // current ledger sequence starts at 0 in tests; expiry at 100
+    let vid = client.reserve(&admin, &holder, &200, &100);
+    let p = client.expiry_pressure(&vid);
+    assert!(p.exists);
+    assert!(!p.is_expired);
+    assert!(p.ledgers_until_expiry > 0);
+}
+
+#[test]
+fn reserved_voucher_summary_empty_initially() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let summary = client.reserved_voucher_summary();
+    assert_eq!(summary.total_reserved, 0);
+    assert_eq!(summary.active_escrow_count, 0);
+    assert_eq!(summary.claimed_count, 0);
+    assert_eq!(summary.expired_escrow_count, 0);
+}

--- a/contracts/voucher-escrow/src/types.rs
+++ b/contracts/voucher-escrow/src/types.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::contracttype;
+
+/// Escrow record for a reserved voucher.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowRecord {
+    pub voucher_id: u64,
+    pub holder: soroban_sdk::Address,
+    pub reserved_amount: i128,
+    pub expiry_ledger: u32,
+    pub claimed: bool,
+}
+
+/// Summary of all reserved vouchers in escrow.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReservedVoucherSummary {
+    pub total_reserved: i128,
+    pub active_escrow_count: u32,
+    pub expired_escrow_count: u32,
+    pub claimed_count: u32,
+}
+
+/// Expiry pressure: how many ledgers remain before a specific voucher expires.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExpiryPressure {
+    pub voucher_id: u64,
+    pub exists: bool,
+    pub expiry_ledger: u32,
+    pub current_ledger: u32,
+    /// ledgers remaining before expiry (0 if expired)
+    pub ledgers_until_expiry: u32,
+    pub is_expired: bool,
+    pub is_claimed: bool,
+}


### PR DESCRIPTION
## Summary

- **voucher-escrow** (new contract): implements `reserve`, `claim`, `reserved_voucher_summary`, and `expiry_pressure` — a complete escrow lifecycle for reserved vouchers with expiry tracking
- **campaign-claims** (tests): adds test coverage for `claim_saturation_summary` on unknown campaign ids, and `cooldown_window_accessor` on scheduled and closed campaigns
- **guild-season** (new types + methods + tests): adds `SeasonPerformanceSummary` and `TierCutoffAccessor` types, `season_performance_summary` and `tier_cutoff_accessor` contract methods, and four new tests

closes #844
closes #865
closes #883

## Test plan

- [ ] `voucher-escrow`: 4 tests — summary tracks reserves, expiry pressure on unknown id, expiry pressure shows ledgers remaining, empty summary initially
- [ ] `campaign-claims`: 3 new tests for saturation summary unknown id, cooldown accessor scheduled, cooldown accessor closed
- [ ] `guild-season`: 4 new tests for performance summary with/without active season, tier cutoff bps correct, tier cutoff with zero guild_count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new voucher escrow contract for reserving vouchers, claiming them, and viewing escrow status and expiry information.
  * Added new season reporting views, including season progress and tier cutoff details.
  * Added the new contract to the workspace so it can be built and tested.

* **Bug Fixes**
  * Improved handling for missing, inactive, closed, and zero-count cases to return clear default values instead of errors.

* **Tests**
  * Expanded coverage for voucher escrow, campaign claims, and guild season behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->