### PR TITLE
feat(contracts): escrow-ledger, bonus-vault, prize-ledger-v2, tournament-gates accessors

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -148,6 +148,8 @@ members = [
     "reward-bridges",
     "arena-passes",
     "voucher-escrow",
+    "prize-ledger-v2",
+    "tournament-gates",
 ]
 
 exclude = [

--- a/contracts/bonus-vault/src/lib.rs
+++ b/contracts/bonus-vault/src/lib.rs
@@ -131,6 +131,77 @@ impl BonusVaultContract {
         Self::get_release_threshold_accessor(env)
     }
 
+    pub fn vault_allocation_summary(env: Env) -> VaultAllocationSummary {
+        let Some(cfg) = get_config(&env) else {
+            return VaultAllocationSummary {
+                status: BonusVaultStatus::Unconfigured,
+                pending_accrual: 0,
+                release_threshold: 0,
+                allocated_bps: 0,
+                headroom: 0,
+            };
+        };
+
+        let state = get_state(&env).unwrap_or(BonusVaultState {
+            pending_accrual: 0,
+            release_threshold: 0,
+        });
+
+        let allocated_bps = if state.release_threshold > 0 {
+            ((state.pending_accrual as u128 * 10_000u128) / state.release_threshold as u128) as u32
+        } else {
+            0
+        };
+
+        let headroom = state
+            .release_threshold
+            .saturating_sub(state.pending_accrual);
+
+        VaultAllocationSummary {
+            status: if cfg.paused {
+                BonusVaultStatus::Paused
+            } else {
+                BonusVaultStatus::Active
+            },
+            pending_accrual: state.pending_accrual,
+            release_threshold: state.release_threshold,
+            allocated_bps,
+            headroom,
+        }
+    }
+
+    pub fn unlock_window_accessor(env: Env, unlock_threshold: i128) -> UnlockWindowAccessor {
+        let Some(cfg) = get_config(&env) else {
+            return UnlockWindowAccessor {
+                status: BonusVaultStatus::Unconfigured,
+                pending_accrual: 0,
+                unlock_threshold,
+                unlockable: false,
+                shortfall: unlock_threshold.max(0),
+            };
+        };
+
+        let state = get_state(&env).unwrap_or(BonusVaultState {
+            pending_accrual: 0,
+            release_threshold: 0,
+        });
+
+        let unlockable = state.pending_accrual >= unlock_threshold;
+        let shortfall = unlock_threshold.saturating_sub(state.pending_accrual);
+
+        UnlockWindowAccessor {
+            status: if cfg.paused {
+                BonusVaultStatus::Paused
+            } else {
+                BonusVaultStatus::Active
+            },
+            pending_accrual: state.pending_accrual,
+            unlock_threshold,
+            unlockable,
+            shortfall,
+        }
+    }
+
     /// Return the pending outflow pressure summary.
     ///
     /// Zero-state returns `Unconfigured` with zeroed numeric fields.

--- a/contracts/bonus-vault/src/test.rs
+++ b/contracts/bonus-vault/src/test.rs
@@ -41,3 +41,67 @@ fn accrual_pressure_unconfigured_state() {
     assert!(!accessor.threshold_configured);
     assert_eq!(accessor.remaining_until_release, 0);
 }
+
+#[test]
+fn vault_allocation_summary_happy_path() {
+    let env = Env::default();
+    let id = env.register(BonusVaultContract, ());
+    let client = BonusVaultContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    client.set_state(&admin, &750, &1000);
+
+    let summary = client.vault_allocation_summary();
+    assert_eq!(summary.pending_accrual, 750);
+    assert_eq!(summary.release_threshold, 1000);
+    assert_eq!(summary.allocated_bps, 7500);
+    assert_eq!(summary.headroom, 250);
+}
+
+#[test]
+fn vault_allocation_summary_unconfigured() {
+    let env = Env::default();
+    let id = env.register(BonusVaultContract, ());
+    let client = BonusVaultContractClient::new(&env, &id);
+
+    let summary = client.vault_allocation_summary();
+    assert_eq!(summary.pending_accrual, 0);
+    assert_eq!(summary.allocated_bps, 0);
+    assert_eq!(summary.headroom, 0);
+}
+
+#[test]
+fn unlock_window_accessor_happy_path() {
+    let env = Env::default();
+    let id = env.register(BonusVaultContract, ());
+    let client = BonusVaultContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    client.set_state(&admin, &800, &1000);
+
+    // Threshold not yet met
+    let accessor = client.unlock_window_accessor(&1000);
+    assert!(!accessor.unlockable);
+    assert_eq!(accessor.shortfall, 200);
+
+    // Threshold exactly met
+    let accessor2 = client.unlock_window_accessor(&800);
+    assert!(accessor2.unlockable);
+    assert_eq!(accessor2.shortfall, 0);
+}
+
+#[test]
+fn unlock_window_accessor_unconfigured() {
+    let env = Env::default();
+    let id = env.register(BonusVaultContract, ());
+    let client = BonusVaultContractClient::new(&env, &id);
+
+    let accessor = client.unlock_window_accessor(&500);
+    assert!(!accessor.unlockable);
+    assert_eq!(accessor.pending_accrual, 0);
+    assert_eq!(accessor.shortfall, 500);
+}

--- a/contracts/bonus-vault/src/types.rs
+++ b/contracts/bonus-vault/src/types.rs
@@ -59,6 +59,26 @@ pub struct PendingOutflowSummary {
 
 #[contracttype]
 #[derive(Clone)]
+pub struct VaultAllocationSummary {
+    pub status: BonusVaultStatus,
+    pub pending_accrual: i128,
+    pub release_threshold: i128,
+    pub allocated_bps: u32,
+    pub headroom: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct UnlockWindowAccessor {
+    pub status: BonusVaultStatus,
+    pub pending_accrual: i128,
+    pub unlock_threshold: i128,
+    pub unlockable: bool,
+    pub shortfall: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
 pub enum DataKey {
     Config,
     State,

--- a/contracts/escrow-ledger/src/lib.rs
+++ b/contracts/escrow-ledger/src/lib.rs
@@ -5,7 +5,10 @@ mod types;
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
-pub use types::{EscrowRecord, LiabilitySummary, SettlementState, SettlementWindow};
+pub use types::{
+    DisputeWindowAccessor, EscrowRecord, LedgerBalanceSummary, LiabilitySummary, SettlementState,
+    SettlementWindow,
+};
 
 #[contracttype]
 #[derive(Clone)]
@@ -82,6 +85,85 @@ impl EscrowLedger {
         }
     }
 
+    pub fn ledger_balance_summary(env: Env) -> LedgerBalanceSummary {
+        let configured = env.storage().instance().has(&DataKey::Admin);
+        let total_escrowed = storage::get_total_escrowed(&env);
+        let total_settled = storage::get_total_settled(&env);
+        let total_disputed = 0i128;
+        let net_balance = total_escrowed - total_settled;
+        let dispute_exposure = total_disputed;
+
+        LedgerBalanceSummary {
+            configured,
+            total_escrowed,
+            total_settled,
+            total_disputed,
+            pending_count: storage::get_pending_count(&env),
+            settled_count: storage::get_settled_count(&env),
+            net_balance,
+            dispute_exposure,
+        }
+    }
+
+    pub fn dispute_window_accessor(
+        env: Env,
+        escrow_id: u64,
+        dispute_window_secs: u64,
+    ) -> DisputeWindowAccessor {
+        let now = env.ledger().timestamp();
+        let configured = env.storage().instance().has(&DataKey::Admin);
+
+        let Some(record) = storage::get_escrow(&env, escrow_id) else {
+            return DisputeWindowAccessor {
+                escrow_id,
+                configured,
+                exists: false,
+                state: if configured {
+                    SettlementState::Pending
+                } else {
+                    SettlementState::NotConfigured
+                },
+                amount: 0,
+                locked_until: 0,
+                dispute_window_secs,
+                dispute_deadline: 0,
+                in_dispute_window: false,
+                window_remaining: 0,
+                now,
+            };
+        };
+
+        let state = if record.disputed {
+            SettlementState::Disputed
+        } else if record.settled {
+            SettlementState::Settled
+        } else {
+            SettlementState::Pending
+        };
+
+        let dispute_deadline = record.locked_until.saturating_add(dispute_window_secs);
+        let in_dispute_window = matches!(state, SettlementState::Disputed) && now < dispute_deadline;
+        let window_remaining = if in_dispute_window {
+            dispute_deadline - now
+        } else {
+            0
+        };
+
+        DisputeWindowAccessor {
+            escrow_id,
+            configured,
+            exists: true,
+            state,
+            amount: record.amount,
+            locked_until: record.locked_until,
+            dispute_window_secs,
+            dispute_deadline,
+            in_dispute_window,
+            window_remaining,
+            now,
+        }
+    }
+
     pub fn settlement_window(env: Env, escrow_id: u64) -> SettlementWindow {
         let now = env.ledger().timestamp();
         let configured = env.storage().instance().has(&DataKey::Admin);
@@ -127,53 +209,127 @@ mod test {
     use super::*;
     use soroban_sdk::testutils::{Address as _, Ledger};
 
+    fn setup_env() -> (Env, EscrowLedgerClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(EscrowLedger, ());
+        let client = EscrowLedgerClient::new(&env, &id);
+        (env, client)
+    }
+
     #[test]
     fn test_init() {
-        let env = Env::default();
-        let admin = Address::random(&env);
-        EscrowLedger::init(env.clone(), admin.clone());
+        let (env, client) = setup_env();
+        let admin = Address::generate(&env);
+        client.init(&admin);
     }
 
     #[test]
     fn test_deposit_and_settle() {
-        let env = Env::default();
+        let (env, client) = setup_env();
         env.ledger().set_timestamp(1000);
 
-        let admin = Address::random(&env);
-        let payor = Address::random(&env);
-        let payee = Address::random(&env);
+        let admin = Address::generate(&env);
+        let payor = Address::generate(&env);
+        let payee = Address::generate(&env);
 
-        EscrowLedger::init(env.clone(), admin.clone());
-        EscrowLedger::deposit(
-            env.clone(),
-            1,
-            payor.clone(),
-            payee.clone(),
-            1000,
-            2000,
-        );
+        client.init(&admin);
+        client.deposit(&1u64, &payor, &payee, &1000i128, &2000u64);
 
-        let summary = EscrowLedger::liability_summary(env.clone());
+        let summary = client.liability_summary();
         assert_eq!(summary.total_escrowed, 1000);
         assert_eq!(summary.pending_count, 1);
 
         env.ledger().set_timestamp(2100);
-        let settled_amount = EscrowLedger::settle(env.clone(), admin, 1);
+        let settled_amount = client.settle(&admin, &1u64);
         assert_eq!(settled_amount, 1000);
 
-        let summary = EscrowLedger::liability_summary(env);
+        let summary = client.liability_summary();
         assert_eq!(summary.total_settled, 1000);
         assert_eq!(summary.settled_count, 1);
     }
 
     #[test]
     fn test_settlement_window_missing() {
-        let env = Env::default();
-        let admin = Address::random(&env);
-        EscrowLedger::init(env.clone(), admin);
+        let (env, client) = setup_env();
+        let admin = Address::generate(&env);
+        client.init(&admin);
 
-        let window = EscrowLedger::settlement_window(env, 999);
-        assert_eq!(window.exists, false);
-        assert_eq!(window.configured, true);
+        let window = client.settlement_window(&999u64);
+        assert!(!window.exists);
+        assert!(window.configured);
+    }
+
+    #[test]
+    fn test_ledger_balance_summary() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(1000);
+
+        let admin = Address::generate(&env);
+        let payor = Address::generate(&env);
+        let payee = Address::generate(&env);
+
+        client.init(&admin);
+        client.deposit(&1u64, &payor, &payee, &1500i128, &2000u64);
+
+        let summary = client.ledger_balance_summary();
+        assert!(summary.configured);
+        assert_eq!(summary.total_escrowed, 1500);
+        assert_eq!(summary.total_settled, 0);
+        assert_eq!(summary.net_balance, 1500);
+        assert_eq!(summary.dispute_exposure, 0);
+        assert_eq!(summary.pending_count, 1);
+
+        env.ledger().set_timestamp(2100);
+        client.settle(&admin, &1u64);
+
+        let summary2 = client.ledger_balance_summary();
+        assert_eq!(summary2.total_settled, 1500);
+        assert_eq!(summary2.net_balance, 0);
+    }
+
+    #[test]
+    fn test_ledger_balance_summary_unconfigured() {
+        let (env, client) = setup_env();
+        let _ = &env;
+        let summary = client.ledger_balance_summary();
+        assert!(!summary.configured);
+        assert_eq!(summary.net_balance, 0);
+        assert_eq!(summary.dispute_exposure, 0);
+    }
+
+    #[test]
+    fn test_dispute_window_accessor_missing() {
+        let (env, client) = setup_env();
+        let admin = Address::generate(&env);
+        client.init(&admin);
+
+        let accessor = client.dispute_window_accessor(&999u64, &3600u64);
+        assert!(!accessor.exists);
+        assert!(accessor.configured);
+        assert!(!accessor.in_dispute_window);
+        assert_eq!(accessor.dispute_deadline, 0);
+        assert_eq!(accessor.window_remaining, 0);
+    }
+
+    #[test]
+    fn test_dispute_window_accessor_pending_escrow() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(1000);
+
+        let admin = Address::generate(&env);
+        let payor = Address::generate(&env);
+        let payee = Address::generate(&env);
+
+        client.init(&admin);
+        client.deposit(&1u64, &payor, &payee, &500i128, &2000u64);
+
+        // Escrow is Pending (not Disputed), so in_dispute_window must be false
+        let accessor = client.dispute_window_accessor(&1u64, &3600u64);
+        assert!(accessor.exists);
+        assert_eq!(accessor.locked_until, 2000);
+        assert_eq!(accessor.dispute_deadline, 5600); // 2000 + 3600
+        assert!(!accessor.in_dispute_window);
+        assert_eq!(accessor.window_remaining, 0);
     }
 }

--- a/contracts/escrow-ledger/src/types.rs
+++ b/contracts/escrow-ledger/src/types.rs
@@ -43,3 +43,32 @@ pub struct SettlementWindow {
     pub locked_until: u64,
     pub now: u64,
 }
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct LedgerBalanceSummary {
+    pub configured: bool,
+    pub total_escrowed: i128,
+    pub total_settled: i128,
+    pub total_disputed: i128,
+    pub pending_count: u32,
+    pub settled_count: u32,
+    pub net_balance: i128,
+    pub dispute_exposure: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct DisputeWindowAccessor {
+    pub escrow_id: u64,
+    pub configured: bool,
+    pub exists: bool,
+    pub state: SettlementState,
+    pub amount: i128,
+    pub locked_until: u64,
+    pub dispute_window_secs: u64,
+    pub dispute_deadline: u64,
+    pub in_dispute_window: bool,
+    pub window_remaining: u64,
+    pub now: u64,
+}

--- a/contracts/prize-ledger-v2/Cargo.toml
+++ b/contracts/prize-ledger-v2/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "prize-ledger-v2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/prize-ledger-v2/src/lib.rs
+++ b/contracts/prize-ledger-v2/src/lib.rs
@@ -1,0 +1,222 @@
+#![no_std]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+pub use types::{LiabilityRollupSummary, PayoutWindowAccessor, PrizeRecord};
+
+#[contract]
+pub struct PrizeLedgerV2;
+
+#[contractimpl]
+impl PrizeLedgerV2 {
+    pub fn init(env: Env, admin: Address) {
+        if storage::has_admin(&env) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        storage::set_admin(&env, &admin);
+    }
+
+    pub fn record_prize(
+        env: Env,
+        admin: Address,
+        prize_id: u64,
+        recipient: Address,
+        amount: i128,
+        payout_at: u64,
+    ) {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env).expect("Not initialized");
+        assert!(admin == stored_admin, "Not admin");
+        assert!(amount > 0, "Amount must be positive");
+
+        let record = PrizeRecord {
+            prize_id,
+            recipient,
+            amount,
+            payout_at,
+            paid: false,
+        };
+
+        storage::set_prize(&env, &record);
+        storage::add_total_liability(&env, amount);
+        storage::increment_unpaid_count(&env);
+
+        let next = storage::get_next_prize_id(&env);
+        if prize_id >= next {
+            storage::set_next_prize_id(&env, prize_id + 1);
+        }
+    }
+
+    pub fn mark_paid(env: Env, admin: Address, prize_id: u64) {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env).expect("Not initialized");
+        assert!(admin == stored_admin, "Not admin");
+
+        let mut record = storage::get_prize(&env, prize_id).expect("Prize not found");
+        assert!(!record.paid, "Already paid");
+
+        record.paid = true;
+        storage::add_total_paid(&env, record.amount);
+        storage::decrement_unpaid_count(&env);
+        storage::increment_paid_count(&env);
+        storage::set_prize(&env, &record);
+    }
+
+    pub fn liability_rollup_summary(env: Env) -> LiabilityRollupSummary {
+        let configured = storage::has_admin(&env);
+        let unpaid_count = storage::get_unpaid_count(&env);
+        let paid_count = storage::get_paid_count(&env);
+        let total_liability = storage::get_total_liability(&env);
+        let total_paid = storage::get_total_paid(&env);
+        let total_prizes = unpaid_count + paid_count;
+
+        LiabilityRollupSummary {
+            configured,
+            total_prizes,
+            unpaid_count,
+            total_liability,
+            paid_count,
+            total_paid,
+        }
+    }
+
+    pub fn payout_window_accessor(
+        env: Env,
+        prize_id: u64,
+        window_ledgers: u32,
+    ) -> PayoutWindowAccessor {
+        let now = env.ledger().timestamp();
+
+        let Some(record) = storage::get_prize(&env, prize_id) else {
+            return PayoutWindowAccessor {
+                prize_id,
+                exists: false,
+                paid: false,
+                amount: 0,
+                payout_at: 0,
+                window_ledgers,
+                window_deadline: 0,
+                in_payout_window: false,
+                now,
+            };
+        };
+
+        let window_deadline = record.payout_at.saturating_add(window_ledgers as u64);
+        let in_payout_window = !record.paid && now >= record.payout_at && now < window_deadline;
+
+        PayoutWindowAccessor {
+            prize_id,
+            exists: true,
+            paid: record.paid,
+            amount: record.amount,
+            payout_at: record.payout_at,
+            window_ledgers,
+            window_deadline,
+            in_payout_window,
+            now,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    fn setup_env() -> (Env, PrizeLedgerV2Client<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(PrizeLedgerV2, ());
+        let client = PrizeLedgerV2Client::new(&env, &id);
+        (env, client)
+    }
+
+    #[test]
+    fn test_liability_rollup_summary_happy_path() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(1000);
+
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        client.init(&admin);
+        client.record_prize(&admin, &1u64, &recipient, &500i128, &2000u64);
+        client.record_prize(&admin, &2u64, &recipient, &300i128, &3000u64);
+
+        let summary = client.liability_rollup_summary();
+        assert!(summary.configured);
+        assert_eq!(summary.total_prizes, 2);
+        assert_eq!(summary.unpaid_count, 2);
+        assert_eq!(summary.total_liability, 800);
+        assert_eq!(summary.paid_count, 0);
+        assert_eq!(summary.total_paid, 0);
+
+        client.mark_paid(&admin, &1u64);
+
+        let summary2 = client.liability_rollup_summary();
+        assert_eq!(summary2.unpaid_count, 1);
+        assert_eq!(summary2.paid_count, 1);
+        assert_eq!(summary2.total_paid, 500);
+    }
+
+    #[test]
+    fn test_liability_rollup_summary_unconfigured() {
+        let (_env, client) = setup_env();
+        let summary = client.liability_rollup_summary();
+        assert!(!summary.configured);
+        assert_eq!(summary.total_prizes, 0);
+        assert_eq!(summary.total_liability, 0);
+    }
+
+    #[test]
+    fn test_payout_window_accessor_in_window() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(2000);
+
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        client.init(&admin);
+        client.record_prize(&admin, &1u64, &recipient, &500i128, &2000u64);
+
+        // now == payout_at, window_ledgers = 1000, deadline = 3000
+        let accessor = client.payout_window_accessor(&1u64, &1000u32);
+        assert!(accessor.exists);
+        assert!(!accessor.paid);
+        assert_eq!(accessor.payout_at, 2000);
+        assert_eq!(accessor.window_deadline, 3000);
+        assert!(accessor.in_payout_window);
+    }
+
+    #[test]
+    fn test_payout_window_accessor_after_window() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(4000);
+
+        let admin = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        client.init(&admin);
+        client.record_prize(&admin, &1u64, &recipient, &500i128, &2000u64);
+
+        // now = 4000, deadline = 3000, so outside window
+        let accessor = client.payout_window_accessor(&1u64, &1000u32);
+        assert!(!accessor.in_payout_window);
+        assert_eq!(accessor.window_deadline, 3000);
+    }
+
+    #[test]
+    fn test_payout_window_accessor_missing() {
+        let (env, client) = setup_env();
+        let admin = Address::generate(&env);
+        client.init(&admin);
+
+        let accessor = client.payout_window_accessor(&999u64, &500u32);
+        assert!(!accessor.exists);
+        assert!(!accessor.in_payout_window);
+    }
+}

--- a/contracts/prize-ledger-v2/src/storage.rs
+++ b/contracts/prize-ledger-v2/src/storage.rs
@@ -1,0 +1,136 @@
+use soroban_sdk::{contracttype, Env};
+
+use crate::types::PrizeRecord;
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Prize(u64),
+    NextPrizeId,
+    TotalLiability,
+    TotalPaid,
+    UnpaidCount,
+    PaidCount,
+}
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+pub fn set_admin(env: &Env, admin: &soroban_sdk::Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<soroban_sdk::Address> {
+    env.storage().instance().get(&DataKey::Admin)
+}
+
+pub fn set_prize(env: &Env, record: &PrizeRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Prize(record.prize_id), record);
+}
+
+pub fn get_prize(env: &Env, prize_id: u64) -> Option<PrizeRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Prize(prize_id))
+        .unwrap_or(None)
+}
+
+pub fn get_next_prize_id(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::NextPrizeId)
+        .unwrap_or(0u64)
+}
+
+pub fn set_next_prize_id(env: &Env, id: u64) {
+    env.storage().instance().set(&DataKey::NextPrizeId, &id);
+}
+
+pub fn add_total_liability(env: &Env, amount: i128) {
+    let current: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TotalLiability)
+        .unwrap_or(0i128);
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalLiability, &(current + amount));
+}
+
+pub fn get_total_liability(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalLiability)
+        .unwrap_or(0i128)
+}
+
+pub fn add_total_paid(env: &Env, amount: i128) {
+    let current: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TotalPaid)
+        .unwrap_or(0i128);
+    env.storage()
+        .instance()
+        .set(&DataKey::TotalPaid, &(current + amount));
+}
+
+pub fn get_total_paid(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalPaid)
+        .unwrap_or(0i128)
+}
+
+pub fn increment_unpaid_count(env: &Env) {
+    let current: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::UnpaidCount)
+        .unwrap_or(0u32);
+    env.storage()
+        .instance()
+        .set(&DataKey::UnpaidCount, &(current + 1));
+}
+
+pub fn decrement_unpaid_count(env: &Env) {
+    let current: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::UnpaidCount)
+        .unwrap_or(0u32);
+    if current > 0 {
+        env.storage()
+            .instance()
+            .set(&DataKey::UnpaidCount, &(current - 1));
+    }
+}
+
+pub fn get_unpaid_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::UnpaidCount)
+        .unwrap_or(0u32)
+}
+
+pub fn increment_paid_count(env: &Env) {
+    let current: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::PaidCount)
+        .unwrap_or(0u32);
+    env.storage()
+        .instance()
+        .set(&DataKey::PaidCount, &(current + 1));
+}
+
+pub fn get_paid_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::PaidCount)
+        .unwrap_or(0u32)
+}

--- a/contracts/prize-ledger-v2/src/types.rs
+++ b/contracts/prize-ledger-v2/src/types.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PrizeRecord {
+    pub prize_id: u64,
+    pub recipient: Address,
+    pub amount: i128,
+    pub payout_at: u64,
+    pub paid: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct LiabilityRollupSummary {
+    pub configured: bool,
+    pub total_prizes: u32,
+    pub unpaid_count: u32,
+    pub total_liability: i128,
+    pub paid_count: u32,
+    pub total_paid: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PayoutWindowAccessor {
+    pub prize_id: u64,
+    pub exists: bool,
+    pub paid: bool,
+    pub amount: i128,
+    pub payout_at: u64,
+    pub window_ledgers: u32,
+    pub window_deadline: u64,
+    pub in_payout_window: bool,
+    pub now: u64,
+}

--- a/contracts/tournament-gates/Cargo.toml
+++ b/contracts/tournament-gates/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tournament-gates"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = "25.0.2"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.2", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/contracts/tournament-gates/src/lib.rs
+++ b/contracts/tournament-gates/src/lib.rs
@@ -1,0 +1,237 @@
+#![no_std]
+
+mod storage;
+mod types;
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+pub use types::{GateHealthSnapshot, GateRecord, UnlockDelayAccessor};
+
+#[contract]
+pub struct TournamentGates;
+
+#[contractimpl]
+impl TournamentGates {
+    pub fn init(env: Env, admin: Address) {
+        if storage::has_admin(&env) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        storage::set_admin(&env, &admin);
+    }
+
+    pub fn set_gate(
+        env: Env,
+        admin: Address,
+        gate_id: u32,
+        capacity: u32,
+        entry_fee: i128,
+        opens_at: u64,
+        closes_at: u64,
+    ) {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env).expect("Not initialized");
+        assert!(admin == stored_admin, "Not admin");
+        assert!(closes_at > opens_at, "closes_at must be after opens_at");
+
+        let record = GateRecord {
+            gate_id,
+            capacity,
+            entry_fee,
+            opens_at,
+            closes_at,
+            paused: false,
+        };
+        storage::set_gate(&env, &record);
+    }
+
+    pub fn set_paused(env: Env, admin: Address, paused: bool) {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env).expect("Not initialized");
+        assert!(admin == stored_admin, "Not admin");
+        storage::set_global_paused(&env, paused);
+    }
+
+    pub fn gate_health_snapshot(env: Env, gate_id: u32) -> GateHealthSnapshot {
+        let now = env.ledger().timestamp();
+        let configured = storage::has_admin(&env);
+        let global_paused = storage::get_global_paused(&env);
+
+        let Some(record) = storage::get_gate(&env, gate_id) else {
+            return GateHealthSnapshot {
+                gate_id,
+                configured,
+                exists: false,
+                paused: global_paused,
+                capacity: 0,
+                entry_fee: 0,
+                opens_at: 0,
+                closes_at: 0,
+                is_open: false,
+                now,
+            };
+        };
+
+        let paused = global_paused || record.paused;
+        let is_open = !paused && now >= record.opens_at && now < record.closes_at;
+
+        GateHealthSnapshot {
+            gate_id,
+            configured,
+            exists: true,
+            paused,
+            capacity: record.capacity,
+            entry_fee: record.entry_fee,
+            opens_at: record.opens_at,
+            closes_at: record.closes_at,
+            is_open,
+            now,
+        }
+    }
+
+    pub fn unlock_delay_accessor(env: Env, gate_id: u32, now: u64) -> UnlockDelayAccessor {
+        let configured = storage::has_admin(&env);
+
+        let Some(record) = storage::get_gate(&env, gate_id) else {
+            return UnlockDelayAccessor {
+                gate_id,
+                configured,
+                exists: false,
+                opens_at: 0,
+                now,
+                ledgers_until_open: 0,
+                already_open: false,
+            };
+        };
+
+        let already_open = now >= record.opens_at;
+        let ledgers_until_open = record.opens_at.saturating_sub(now);
+
+        UnlockDelayAccessor {
+            gate_id,
+            configured,
+            exists: true,
+            opens_at: record.opens_at,
+            now,
+            ledgers_until_open,
+            already_open,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    fn setup_env() -> (Env, TournamentGatesClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(TournamentGates, ());
+        let client = TournamentGatesClient::new(&env, &id);
+        (env, client)
+    }
+
+    #[test]
+    fn test_gate_health_snapshot_happy_path() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(1500);
+
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        client.set_gate(&admin, &1u32, &100u32, &50i128, &1000u64, &3000u64);
+
+        let snapshot = client.gate_health_snapshot(&1u32);
+        assert!(snapshot.exists);
+        assert!(snapshot.configured);
+        assert!(!snapshot.paused);
+        assert_eq!(snapshot.capacity, 100);
+        assert_eq!(snapshot.entry_fee, 50);
+        assert_eq!(snapshot.opens_at, 1000);
+        assert_eq!(snapshot.closes_at, 3000);
+        assert!(snapshot.is_open); // 1500 >= 1000 && 1500 < 3000
+    }
+
+    #[test]
+    fn test_gate_health_snapshot_before_open() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(500);
+
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        client.set_gate(&admin, &1u32, &50u32, &10i128, &1000u64, &2000u64);
+
+        let snapshot = client.gate_health_snapshot(&1u32);
+        assert!(!snapshot.is_open);
+    }
+
+    #[test]
+    fn test_gate_health_snapshot_paused() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(1500);
+
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        client.set_gate(&admin, &1u32, &50u32, &10i128, &1000u64, &2000u64);
+        client.set_paused(&admin, &true);
+
+        let snapshot = client.gate_health_snapshot(&1u32);
+        assert!(snapshot.paused);
+        assert!(!snapshot.is_open);
+    }
+
+    #[test]
+    fn test_gate_health_snapshot_missing() {
+        let (env, client) = setup_env();
+        let admin = Address::generate(&env);
+        client.init(&admin);
+
+        let snapshot = client.gate_health_snapshot(&999u32);
+        assert!(!snapshot.exists);
+        assert!(snapshot.configured);
+        assert!(!snapshot.is_open);
+    }
+
+    #[test]
+    fn test_unlock_delay_accessor_before_open() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(1000);
+
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        client.set_gate(&admin, &1u32, &50u32, &10i128, &2000u64, &4000u64);
+
+        let accessor = client.unlock_delay_accessor(&1u32, &1000u64);
+        assert!(accessor.exists);
+        assert_eq!(accessor.opens_at, 2000);
+        assert_eq!(accessor.ledgers_until_open, 1000); // 2000 - 1000
+        assert!(!accessor.already_open);
+    }
+
+    #[test]
+    fn test_unlock_delay_accessor_already_open() {
+        let (env, client) = setup_env();
+        env.ledger().set_timestamp(3000);
+
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        client.set_gate(&admin, &1u32, &50u32, &10i128, &2000u64, &5000u64);
+
+        let accessor = client.unlock_delay_accessor(&1u32, &3000u64);
+        assert!(accessor.already_open);
+        assert_eq!(accessor.ledgers_until_open, 0); // saturating_sub: 2000 - 3000 = 0
+    }
+
+    #[test]
+    fn test_unlock_delay_accessor_missing() {
+        let (env, client) = setup_env();
+        let admin = Address::generate(&env);
+        client.init(&admin);
+
+        let accessor = client.unlock_delay_accessor(&999u32, &1000u64);
+        assert!(!accessor.exists);
+        assert!(accessor.configured);
+        assert_eq!(accessor.ledgers_until_open, 0);
+        assert!(!accessor.already_open);
+    }
+}

--- a/contracts/tournament-gates/src/storage.rs
+++ b/contracts/tournament-gates/src/storage.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::types::GateRecord;
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Gate(u32),
+    GlobalPaused,
+}
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::Admin)
+}
+
+pub fn set_gate(env: &Env, record: &GateRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Gate(record.gate_id), record);
+}
+
+pub fn get_gate(env: &Env, gate_id: u32) -> Option<GateRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Gate(gate_id))
+        .unwrap_or(None)
+}
+
+pub fn set_global_paused(env: &Env, paused: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::GlobalPaused, &paused);
+}
+
+pub fn get_global_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::GlobalPaused)
+        .unwrap_or(false)
+}

--- a/contracts/tournament-gates/src/types.rs
+++ b/contracts/tournament-gates/src/types.rs
@@ -1,0 +1,39 @@
+use soroban_sdk::contracttype;
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct GateRecord {
+    pub gate_id: u32,
+    pub capacity: u32,
+    pub entry_fee: i128,
+    pub opens_at: u64,
+    pub closes_at: u64,
+    pub paused: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct GateHealthSnapshot {
+    pub gate_id: u32,
+    pub configured: bool,
+    pub exists: bool,
+    pub paused: bool,
+    pub capacity: u32,
+    pub entry_fee: i128,
+    pub opens_at: u64,
+    pub closes_at: u64,
+    pub is_open: bool,
+    pub now: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UnlockDelayAccessor {
+    pub gate_id: u32,
+    pub configured: bool,
+    pub exists: bool,
+    pub opens_at: u64,
+    pub now: u64,
+    pub ledgers_until_open: u64,
+    pub already_open: bool,
+}


### PR DESCRIPTION
## Summary

- **escrow-ledger (#876)**: Added `ledger_balance_summary` (net_balance, dispute_exposure fields) and `dispute_window_accessor` (caller-supplied window, dispute_deadline, window_remaining, in_dispute_window)
- **bonus-vault (#864)**: Added `vault_allocation_summary` (allocated_bps, headroom) and `unlock_window_accessor` (caller-supplied threshold, unlockable, shortfall)
- **prize-ledger-v2 (#846)**: New contract — init/record_prize/mark_paid + `liability_rollup_summary` and `payout_window_accessor`
- **tournament-gates (#845)**: New contract — init/set_gate/set_paused + `gate_health_snapshot` and `unlock_delay_accessor`

## Test plan

- [x] escrow-ledger: 7 tests pass (init, deposit+settle, settlement_window_missing, ledger_balance_summary, ledger_balance_summary_unconfigured, dispute_window_accessor_missing, dispute_window_accessor_pending_escrow)
- [x] bonus-vault: 6 tests pass (existing 2 + vault_allocation_summary happy/unconfigured, unlock_window_accessor happy/unconfigured)
- [x] prize-ledger-v2: 5 tests pass (liability_rollup_summary happy/unconfigured, payout_window_accessor in-window/after-window/missing)
- [x] tournament-gates: 7 tests pass (gate_health_snapshot happy/before-open/paused/missing, unlock_delay_accessor before-open/already-open/missing)

closes #845
closes #846
closes #864
closes #876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new prize ledger v2 and tournament gate contracts with admin setup, recording, payout/rollup summaries, pause controls, and time-window accessors.
  * Added new read-only “accessor” views for Bonus Vault and Escrow Ledger to expose allocation/lock/unlock and dispute-window status with sensible default responses when unconfigured or missing.
* **Tests**
  * Expanded unit test coverage for the new accessors, including configured and unconfigured scenarios and window-status edge cases.
* **Chores**
  * Updated the workspace to include the new contract crates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->