### PR TITLE
feat: add performance summary and interval/window accessors across four contracts

### DIFF
--- a/contracts/reward-stream/src/lib.rs
+++ b/contracts/reward-stream/src/lib.rs
@@ -9,7 +9,7 @@ mod types;
 
 pub use types::{
     DepletionBand, DripPressureSummary, PauseRecoveryAccessor, StreamData, StreamHealthSummary,
-    StreamPressureSnapshot, WithdrawalReadiness,
+    StreamPerformanceSummary, StreamPressureSnapshot, UnlockIntervalAccessor, WithdrawalReadiness,
 };
 
 #[contract]
@@ -211,6 +211,66 @@ impl RewardStream {
                 remaining: 0,
                 recovery_ready: false,
                 blocked_reason_code: 4,
+            }
+        }
+    }
+
+    /// Return stream performance metrics for the configured stream.
+    ///
+    /// `utilization_bps` uses the same floored basis-point math as
+    /// `stream_pressure_snapshot`. Missing or zero-allocation streams return
+    /// `is_configured = false` with all zeros.
+    pub fn stream_performance_summary(env: Env) -> StreamPerformanceSummary {
+        if let Some(s) = storage::get_stream(&env) {
+            let remaining = (s.total_allocated - s.total_withdrawn).max(0);
+            let utilization_bps = pressure_bps(s.total_allocated, s.total_withdrawn);
+            StreamPerformanceSummary {
+                is_configured: s.total_allocated > 0,
+                stream_id: s.stream_id,
+                total_allocated: s.total_allocated,
+                total_withdrawn: s.total_withdrawn,
+                remaining,
+                utilization_bps,
+                is_depleted: remaining == 0 && s.total_allocated > 0,
+                paused: s.paused,
+            }
+        } else {
+            StreamPerformanceSummary {
+                is_configured: false,
+                stream_id: 0,
+                total_allocated: 0,
+                total_withdrawn: 0,
+                remaining: 0,
+                utilization_bps: 0,
+                is_depleted: false,
+                paused: false,
+            }
+        }
+    }
+
+    /// Return unlock-interval details for the configured stream.
+    ///
+    /// `time_until_unlock` is `unlock_time.saturating_sub(now)`, clamped to
+    /// zero once past the unlock point. Missing streams return
+    /// `is_configured = false` with all zeros.
+    pub fn unlock_interval_accessor(env: Env, now: u64) -> UnlockIntervalAccessor {
+        if let Some(s) = storage::get_stream(&env) {
+            UnlockIntervalAccessor {
+                is_configured: s.total_allocated > 0,
+                stream_id: s.stream_id,
+                unlock_time: s.unlock_time,
+                time_until_unlock: s.unlock_time.saturating_sub(now),
+                is_past_unlock: now >= s.unlock_time,
+                paused: s.paused,
+            }
+        } else {
+            UnlockIntervalAccessor {
+                is_configured: false,
+                stream_id: 0,
+                unlock_time: 0,
+                time_until_unlock: 0,
+                is_past_unlock: false,
+                paused: false,
             }
         }
     }

--- a/contracts/reward-stream/src/test.rs
+++ b/contracts/reward-stream/src/test.rs
@@ -70,3 +70,77 @@ fn stream_pressure_snapshot_missing_is_predictable_zero_state() {
     assert_eq!(snapshot.pressure_bps, 0);
     assert_eq!(snapshot.depletion_band, DepletionBand::NotConfigured);
 }
+
+#[test]
+fn stream_performance_summary_success_path() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    // 600 withdrawn out of 1_000 allocated → utilization_bps = 6_000, remaining = 400
+    client.configure_stream(&admin, &5, &1_000, &600, &0, &false);
+
+    let summary = client.stream_performance_summary();
+    assert!(summary.is_configured);
+    assert_eq!(summary.stream_id, 5);
+    assert_eq!(summary.total_allocated, 1_000);
+    assert_eq!(summary.total_withdrawn, 600);
+    assert_eq!(summary.remaining, 400);
+    assert_eq!(summary.utilization_bps, 6_000);
+    assert!(!summary.is_depleted);
+    assert!(!summary.paused);
+}
+
+#[test]
+fn stream_performance_summary_missing_is_zero_state() {
+    let env = Env::default();
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+
+    let summary = client.stream_performance_summary();
+    assert!(!summary.is_configured);
+    assert_eq!(summary.stream_id, 0);
+    assert_eq!(summary.utilization_bps, 0);
+    assert!(!summary.is_depleted);
+}
+
+#[test]
+fn unlock_interval_accessor_before_and_after_unlock() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+    env.mock_all_auths();
+
+    client.init(&admin);
+    // unlock_time = 200
+    client.configure_stream(&admin, &7, &500, &0, &200, &false);
+
+    // Before unlock: now=100, 100s remaining
+    let before = client.unlock_interval_accessor(&100);
+    assert!(before.is_configured);
+    assert_eq!(before.unlock_time, 200);
+    assert!(!before.is_past_unlock);
+    assert_eq!(before.time_until_unlock, 100);
+
+    // After unlock: now=300
+    let after = client.unlock_interval_accessor(&300);
+    assert!(after.is_past_unlock);
+    assert_eq!(after.time_until_unlock, 0);
+}
+
+#[test]
+fn unlock_interval_accessor_missing_returns_zero_state() {
+    let env = Env::default();
+    let id = env.register(RewardStream, ());
+    let client = RewardStreamClient::new(&env, &id);
+
+    let info = client.unlock_interval_accessor(&0);
+    assert!(!info.is_configured);
+    assert_eq!(info.unlock_time, 0);
+    assert_eq!(info.time_until_unlock, 0);
+    assert!(!info.is_past_unlock);
+}

--- a/contracts/reward-stream/src/types.rs
+++ b/contracts/reward-stream/src/types.rs
@@ -87,3 +87,38 @@ pub struct PauseRecoveryAccessor {
     pub recovery_ready: bool,
     pub blocked_reason_code: u32,
 }
+
+/// Performance summary returned by `stream_performance_summary`.
+///
+/// `utilization_bps = floor(total_withdrawn * 10_000 / total_allocated)` when
+/// `total_allocated > 0`, otherwise 0. `is_depleted` is true when
+/// `remaining == 0 && total_allocated > 0`. Missing or zero-allocation streams
+/// return `is_configured = false` with all zeros.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamPerformanceSummary {
+    pub is_configured: bool,
+    pub stream_id: u64,
+    pub total_allocated: i128,
+    pub total_withdrawn: i128,
+    pub remaining: i128,
+    pub utilization_bps: u32,
+    pub is_depleted: bool,
+    pub paused: bool,
+}
+
+/// Unlock-interval view returned by `unlock_interval_accessor`.
+///
+/// `time_until_unlock = unlock_time.saturating_sub(now)`, clamped to zero once
+/// the stream is past its unlock point. Missing streams return
+/// `is_configured = false` with all zeros.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnlockIntervalAccessor {
+    pub is_configured: bool,
+    pub stream_id: u64,
+    pub unlock_time: u64,
+    pub time_until_unlock: u64,
+    pub is_past_unlock: bool,
+    pub paused: bool,
+}

--- a/contracts/season-rewards-vault/src/lib.rs
+++ b/contracts/season-rewards-vault/src/lib.rs
@@ -425,6 +425,92 @@ impl SeasonRewardsVault {
     pub fn get_current_season(env: Env) -> Option<u64> {
         get_current_season(&env)
     }
+
+    // -----------------------------------------------------------------------
+    // get_vault_allocation_summary
+    // -----------------------------------------------------------------------
+
+    /// Return vault allocation summary for a season.
+    ///
+    /// `utilization_bps = floor(total_claimed.min(reward_pool) * 10_000 / reward_pool)`
+    /// when `reward_pool > 0`, otherwise 0. Unknown season IDs return
+    /// `season_found = false` with all zeros.
+    pub fn get_vault_allocation_summary(env: Env, season_id: u64) -> VaultAllocationSummary {
+        let Some(config) = get_season_config(&env, season_id) else {
+            return VaultAllocationSummary {
+                season_id,
+                season_found: false,
+                reward_pool: 0,
+                total_pending: 0,
+                total_claimed: 0,
+                utilization_bps: 0,
+                is_active: false,
+                auto_rollover: false,
+            };
+        };
+
+        let queue = get_claim_queue(&env, season_id);
+        let total_claimed = queue
+            .iter()
+            .filter(|r| r.is_claimed)
+            .fold(0i128, |acc, r| acc + r.amount);
+        let total_pending = queue
+            .iter()
+            .filter(|r| !r.is_claimed)
+            .fold(0i128, |acc, r| acc + r.amount);
+
+        let utilization_bps = if config.reward_pool > 0 {
+            ((total_claimed.min(config.reward_pool) * 10_000) / config.reward_pool) as u32
+        } else {
+            0
+        };
+
+        VaultAllocationSummary {
+            season_id,
+            season_found: true,
+            reward_pool: config.reward_pool,
+            total_pending,
+            total_claimed,
+            utilization_bps,
+            is_active: config.is_active,
+            auto_rollover: config.auto_rollover,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // get_claim_window_accessor
+    // -----------------------------------------------------------------------
+
+    /// Return claim-window details for a season.
+    ///
+    /// `window_open` is true when `is_active && now >= start_time && now <= end_time`.
+    /// `is_expired` is true when `now > end_time`.
+    /// Unknown season IDs return `season_found = false`.
+    pub fn get_claim_window_accessor(env: Env, season_id: u64, now: u64) -> ClaimWindowAccessor {
+        let Some(config) = get_season_config(&env, season_id) else {
+            return ClaimWindowAccessor {
+                season_id,
+                season_found: false,
+                start_time: 0,
+                end_time: 0,
+                is_active: false,
+                window_open: false,
+                is_expired: false,
+            };
+        };
+
+        ClaimWindowAccessor {
+            season_id,
+            season_found: true,
+            start_time: config.start_time,
+            end_time: config.end_time,
+            is_active: config.is_active,
+            window_open: config.is_active
+                && now >= config.start_time
+                && now <= config.end_time,
+            is_expired: now > config.end_time,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -717,5 +803,82 @@ mod test {
         assert_eq!(config.reward_pool, 10000i128);
         assert!(config.is_active);
         assert!(config.auto_rollover);
+    }
+
+    #[test]
+    fn test_vault_allocation_summary_success_path() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        env.mock_all_auths();
+
+        client.create_season(&admin, &1u64, &100u64, &200u64, &10000i128, &true);
+
+        let user = Address::generate(&env);
+        client.add_reward(
+            &admin,
+            &1u64,
+            &user,
+            &500i128,
+            &soroban_sdk::String::from_str(&env, "prize"),
+            &300u64,
+        );
+
+        let summary = client.get_vault_allocation_summary(&1u64);
+        assert!(summary.season_found);
+        assert_eq!(summary.reward_pool, 10000i128);
+        assert_eq!(summary.total_pending, 500i128);
+        assert_eq!(summary.total_claimed, 0i128);
+        assert_eq!(summary.utilization_bps, 0u32);
+        assert!(summary.is_active);
+        assert!(summary.auto_rollover);
+    }
+
+    #[test]
+    fn test_vault_allocation_summary_missing_season() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+
+        let summary = client.get_vault_allocation_summary(&999u64);
+        assert!(!summary.season_found);
+        assert_eq!(summary.reward_pool, 0i128);
+        assert_eq!(summary.total_pending, 0i128);
+        assert_eq!(summary.utilization_bps, 0u32);
+    }
+
+    #[test]
+    fn test_claim_window_accessor_open() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        env.mock_all_auths();
+
+        client.create_season(&admin, &1u64, &100u64, &200u64, &10000i128, &true);
+
+        // now=150 falls inside [100, 200]
+        let accessor = client.get_claim_window_accessor(&1u64, &150u64);
+        assert!(accessor.season_found);
+        assert!(accessor.window_open);
+        assert!(!accessor.is_expired);
+        assert_eq!(accessor.start_time, 100u64);
+        assert_eq!(accessor.end_time, 200u64);
+    }
+
+    #[test]
+    fn test_claim_window_accessor_expired_and_missing() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        env.mock_all_auths();
+
+        client.create_season(&admin, &1u64, &100u64, &200u64, &10000i128, &true);
+
+        // now=250 is past end_time=200
+        let expired = client.get_claim_window_accessor(&1u64, &250u64);
+        assert!(expired.season_found);
+        assert!(!expired.window_open);
+        assert!(expired.is_expired);
+
+        // Unknown season
+        let missing = client.get_claim_window_accessor(&999u64, &0u64);
+        assert!(!missing.season_found);
+        assert!(!missing.window_open);
     }
 }

--- a/contracts/season-rewards-vault/src/types.rs
+++ b/contracts/season-rewards-vault/src/types.rs
@@ -56,3 +56,38 @@ pub struct UserClaimSummary {
     pub claim_count: u32,
     pub oldest_unclaimed_age: u64,
 }
+
+/// Vault allocation summary returned by `get_vault_allocation_summary`.
+///
+/// `utilization_bps = floor(total_claimed.min(reward_pool) * 10_000 / reward_pool)`
+/// when `reward_pool > 0`, otherwise 0. Unknown season IDs return
+/// `season_found = false` with all zeros.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VaultAllocationSummary {
+    pub season_id: u64,
+    pub season_found: bool,
+    pub reward_pool: i128,
+    pub total_pending: i128,
+    pub total_claimed: i128,
+    pub utilization_bps: u32,
+    pub is_active: bool,
+    pub auto_rollover: bool,
+}
+
+/// Claim-window view returned by `get_claim_window_accessor`.
+///
+/// `window_open` is true when `is_active && now >= start_time && now <= end_time`.
+/// `is_expired` is true when `now > end_time`.
+/// Unknown season IDs return `season_found = false`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimWindowAccessor {
+    pub season_id: u64,
+    pub season_found: bool,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub is_active: bool,
+    pub window_open: bool,
+    pub is_expired: bool,
+}

--- a/contracts/team-prizes/src/lib.rs
+++ b/contracts/team-prizes/src/lib.rs
@@ -13,7 +13,8 @@ mod types;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 pub use types::{
-    ClaimDelayInfo, ClaimDelayState, MemberRecord, PoolConfig, PoolState, PrizePoolCoverage,
+    ClaimDelayInfo, ClaimDelayState, ClaimExpiryInfo, MemberRecord, PoolConfig, PoolState,
+    PrizeAllocationSummary, PrizePoolCoverage,
 };
 
 #[contracttype]
@@ -212,6 +213,96 @@ impl TeamPrizes {
             claimed_member_count: pool.claimed_member_count,
             unclaimed_member_count,
             coverage_bps,
+        }
+    }
+
+    /// Prize allocation view for a pool.
+    ///
+    /// `avg_share_per_member = floor(total_amount / eligible_member_count)`, or
+    /// zero when no members are eligible. `fully_distributed` is true when every
+    /// eligible member has claimed. Unknown pools return `pool_found = false`.
+    pub fn prize_allocation_summary(env: Env, pool_id: u32) -> PrizeAllocationSummary {
+        let configured = is_configured(&env);
+        let Some(pool) = storage::get_pool(&env, pool_id) else {
+            return PrizeAllocationSummary {
+                pool_id,
+                configured,
+                pool_found: false,
+                total_amount: 0,
+                claimed_amount: 0,
+                unclaimed_amount: 0,
+                eligible_member_count: 0,
+                claimed_member_count: 0,
+                avg_share_per_member: 0,
+                fully_distributed: false,
+                paused: false,
+            };
+        };
+
+        let unclaimed_amount = pool.total_amount.saturating_sub(pool.claimed_amount);
+        let avg_share_per_member = if pool.eligible_member_count > 0 {
+            pool.total_amount / pool.eligible_member_count as u128
+        } else {
+            0
+        };
+        let fully_distributed = pool.eligible_member_count > 0
+            && pool.claimed_member_count == pool.eligible_member_count;
+
+        PrizeAllocationSummary {
+            pool_id,
+            configured,
+            pool_found: true,
+            total_amount: pool.total_amount,
+            claimed_amount: pool.claimed_amount,
+            unclaimed_amount,
+            eligible_member_count: pool.eligible_member_count,
+            claimed_member_count: pool.claimed_member_count,
+            avg_share_per_member,
+            fully_distributed,
+            paused: pool.paused,
+        }
+    }
+
+    /// Claim-expiry view for a member.
+    ///
+    /// This contract has no hard expiry on claims; `has_expiry` is always `false`
+    /// and `expires_at` is always `0`. The accessor provides a stable surface for
+    /// future expiry support without a breaking interface change.
+    pub fn claim_expiry_accessor(env: Env, member: Address) -> ClaimExpiryInfo {
+        let configured = is_configured(&env);
+
+        let Some(record) = storage::get_member(&env, &member) else {
+            return ClaimExpiryInfo {
+                configured,
+                member_found: false,
+                pool_id: 0,
+                claim_window_opens_at: 0,
+                has_expiry: false,
+                expires_at: 0,
+                is_expired: false,
+                already_claimed: false,
+                pool_paused: false,
+            };
+        };
+
+        let (opens_at, pool_paused) = match storage::get_pool(&env, record.pool_id) {
+            Some(pool) => (
+                record.eligible_at.saturating_add(pool.claim_delay_secs),
+                pool.paused,
+            ),
+            None => (0, false),
+        };
+
+        ClaimExpiryInfo {
+            configured,
+            member_found: true,
+            pool_id: record.pool_id,
+            claim_window_opens_at: opens_at,
+            has_expiry: false,
+            expires_at: 0,
+            is_expired: false,
+            already_claimed: record.claimed,
+            pool_paused,
         }
     }
 

--- a/contracts/team-prizes/src/test.rs
+++ b/contracts/team-prizes/src/test.rs
@@ -122,3 +122,76 @@ fn upsert_cannot_shrink_total_amount() {
     // Attempting to reduce the pool must revert.
     client.upsert_pool(&admin, &4, &500u128, &50, &false);
 }
+
+#[test]
+fn prize_allocation_summary_success_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (client, admin, member) = setup(&env);
+    client.upsert_pool(&admin, &10, &6_000u128, &300, &false);
+    client.grant_eligibility(&admin, &member, &10, &2_000u128, &900);
+
+    let summary = client.prize_allocation_summary(&10);
+    assert!(summary.configured);
+    assert!(summary.pool_found);
+    assert_eq!(summary.total_amount, 6_000u128);
+    assert_eq!(summary.claimed_amount, 0u128);
+    assert_eq!(summary.unclaimed_amount, 6_000u128);
+    assert_eq!(summary.eligible_member_count, 1);
+    assert_eq!(summary.claimed_member_count, 0);
+    // avg = 6_000 / 1 = 6_000
+    assert_eq!(summary.avg_share_per_member, 6_000u128);
+    assert!(!summary.fully_distributed);
+    assert!(!summary.paused);
+}
+
+#[test]
+fn prize_allocation_summary_missing_pool_returns_zero_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _member) = setup(&env);
+
+    let summary = client.prize_allocation_summary(&999);
+    assert!(summary.configured);
+    assert!(!summary.pool_found);
+    assert_eq!(summary.total_amount, 0u128);
+    assert_eq!(summary.avg_share_per_member, 0u128);
+    assert!(!summary.fully_distributed);
+}
+
+#[test]
+fn claim_expiry_accessor_no_expiry_and_member_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 500);
+
+    let (client, admin, member) = setup(&env);
+    client.upsert_pool(&admin, &11, &1_000u128, &200, &false);
+    client.grant_eligibility(&admin, &member, &11, &500u128, &400);
+
+    let info = client.claim_expiry_accessor(&member);
+    assert!(info.configured);
+    assert!(info.member_found);
+    assert_eq!(info.pool_id, 11);
+    // opens_at = eligible_at(400) + claim_delay(200) = 600
+    assert_eq!(info.claim_window_opens_at, 600);
+    assert!(!info.has_expiry);
+    assert_eq!(info.expires_at, 0);
+    assert!(!info.is_expired);
+    assert!(!info.already_claimed);
+}
+
+#[test]
+fn claim_expiry_accessor_member_not_found_returns_zero_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, member) = setup(&env);
+
+    let info = client.claim_expiry_accessor(&member);
+    assert!(!info.member_found);
+    assert_eq!(info.pool_id, 0);
+    assert!(!info.has_expiry);
+    assert!(!info.is_expired);
+}

--- a/contracts/team-prizes/src/types.rs
+++ b/contracts/team-prizes/src/types.rs
@@ -92,3 +92,44 @@ pub struct ClaimDelayInfo {
     pub pool_paused: bool,
     pub state: ClaimDelayState,
 }
+
+/// Allocation view for a prize pool returned by `prize_allocation_summary`.
+///
+/// `avg_share_per_member = floor(total_amount / eligible_member_count)`, or
+/// zero when no members are eligible. `fully_distributed` is true when
+/// `eligible_member_count > 0 && claimed_member_count == eligible_member_count`.
+/// Unknown pools return `pool_found = false` with all zeros.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrizeAllocationSummary {
+    pub pool_id: u32,
+    pub configured: bool,
+    pub pool_found: bool,
+    pub total_amount: u128,
+    pub claimed_amount: u128,
+    pub unclaimed_amount: u128,
+    pub eligible_member_count: u32,
+    pub claimed_member_count: u32,
+    pub avg_share_per_member: u128,
+    pub fully_distributed: bool,
+    pub paused: bool,
+}
+
+/// Claim-expiry view for a member returned by `claim_expiry_accessor`.
+///
+/// This contract does not configure a hard expiry on claims; `has_expiry` is
+/// always `false` and `expires_at` is always `0`. The accessor is a stable
+/// surface for future expiry support without a breaking interface change.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimExpiryInfo {
+    pub configured: bool,
+    pub member_found: bool,
+    pub pool_id: u32,
+    pub claim_window_opens_at: u64,
+    pub has_expiry: bool,
+    pub expires_at: u64,
+    pub is_expired: bool,
+    pub already_claimed: bool,
+    pub pool_paused: bool,
+}

--- a/contracts/treasury-safeguard/src/lib.rs
+++ b/contracts/treasury-safeguard/src/lib.rs
@@ -7,7 +7,10 @@ pub mod storage;
 #[cfg(test)]
 mod test;
 
-use crate::types::{ThresholdBreachSummary, CooldownRelease, SafeguardConfig};
+use crate::types::{
+    CooldownRelease, OverrideWindowAccessor, SafeguardConfig, SafeguardLimitsSummary,
+    ThresholdBreachSummary,
+};
 use crate::storage::{
     get_config, set_config, get_breach_count, set_breach_count,
     get_last_breach_time, set_last_breach_time, get_current_value,
@@ -115,5 +118,63 @@ impl TreasurySafeguard {
         set_last_breach_time(&env, 0);
         set_current_value(&env, 0);
         set_cooldown_end(&env, 0);
+    }
+
+    /// Return a summary of configured safeguard limits and current utilization.
+    ///
+    /// `utilization_bps = floor(current_value.min(threshold_limit) * 10_000 / threshold_limit)`
+    /// when `threshold_limit > 0 && current_value > 0`, otherwise 0. Missing or
+    /// unconfigured states return `is_configured = false` with all zeros.
+    pub fn get_safeguard_limits_summary(env: Env) -> SafeguardLimitsSummary {
+        let config = get_config(&env);
+        let is_configured = config.is_some();
+        let threshold_limit = config.as_ref().map(|c| c.threshold_limit).unwrap_or(0);
+        let cooldown_period = config.as_ref().map(|c| c.cooldown_period).unwrap_or(0);
+        let is_paused = config.map(|c| c.paused).unwrap_or(false);
+        let current_value = get_current_value(&env);
+        let breach_count = get_breach_count(&env);
+
+        let utilization_bps = if threshold_limit > 0 && current_value > 0 {
+            let clamped = current_value.min(threshold_limit);
+            ((clamped * 10_000) / threshold_limit) as u32
+        } else {
+            0
+        };
+
+        SafeguardLimitsSummary {
+            is_configured,
+            threshold_limit,
+            cooldown_period,
+            breach_count,
+            current_value,
+            utilization_bps,
+            is_at_limit: threshold_limit > 0 && current_value >= threshold_limit,
+            is_paused,
+        }
+    }
+
+    /// Return an override-window view for the safeguard.
+    ///
+    /// `override_available` is true when the safeguard is configured, not in
+    /// cooldown, and not paused — meaning an authorized caller may act without
+    /// waiting for a cooldown to expire.
+    pub fn get_override_window_accessor(env: Env) -> OverrideWindowAccessor {
+        let now = env.ledger().timestamp();
+        let cooldown_end = get_cooldown_end(&env);
+        let config = get_config(&env);
+        let is_configured = config.is_some();
+        let is_paused = config.map(|c| c.paused).unwrap_or(false);
+
+        let is_in_cooldown = now < cooldown_end;
+        let remaining_cooldown_secs = if is_in_cooldown { cooldown_end - now } else { 0 };
+
+        OverrideWindowAccessor {
+            is_configured,
+            is_in_cooldown,
+            cooldown_end_timestamp: cooldown_end,
+            remaining_cooldown_secs,
+            override_available: is_configured && !is_in_cooldown && !is_paused,
+            is_paused,
+        }
     }
 }

--- a/contracts/treasury-safeguard/src/test.rs
+++ b/contracts/treasury-safeguard/src/test.rs
@@ -99,7 +99,7 @@ fn test_pause_behavior() {
     let client = TreasurySafeguardClient::new(&env, &contract_id);
 
     client.init(&admin, &1000, &3600);
-    
+
     client.set_paused(&admin, &true);
     assert_eq!(client.get_threshold_breach_summary().is_paused, true);
     assert_eq!(client.get_cooldown_release().is_paused, true);
@@ -110,7 +110,83 @@ fn test_pause_behavior() {
 
     client.set_paused(&admin, &false);
     assert_eq!(client.get_threshold_breach_summary().is_paused, false);
-    
+
     let res = client.try_record_activity(&admin, &500);
     assert!(res.is_ok());
+}
+
+#[test]
+fn test_safeguard_limits_summary_success_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TreasurySafeguard, ());
+    let client = TreasurySafeguardClient::new(&env, &contract_id);
+
+    client.init(&admin, &1000, &3600);
+    client.record_activity(&admin, &600);
+
+    let summary = client.get_safeguard_limits_summary();
+    assert!(summary.is_configured);
+    assert_eq!(summary.threshold_limit, 1000);
+    assert_eq!(summary.cooldown_period, 3600);
+    assert_eq!(summary.current_value, 600);
+    // 600/1000 → 6_000 bps
+    assert_eq!(summary.utilization_bps, 6_000);
+    assert!(!summary.is_at_limit);
+    assert!(!summary.is_paused);
+}
+
+#[test]
+fn test_safeguard_limits_summary_missing_is_zero_state() {
+    let env = Env::default();
+    let contract_id = env.register(TreasurySafeguard, ());
+    let client = TreasurySafeguardClient::new(&env, &contract_id);
+
+    let summary = client.get_safeguard_limits_summary();
+    assert!(!summary.is_configured);
+    assert_eq!(summary.threshold_limit, 0);
+    assert_eq!(summary.utilization_bps, 0);
+    assert!(!summary.is_at_limit);
+}
+
+#[test]
+fn test_override_window_accessor_available_when_no_breach() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TreasurySafeguard, ());
+    let client = TreasurySafeguardClient::new(&env, &contract_id);
+
+    client.init(&admin, &1000, &3600);
+
+    let accessor = client.get_override_window_accessor();
+    assert!(accessor.is_configured);
+    assert!(!accessor.is_in_cooldown);
+    assert_eq!(accessor.remaining_cooldown_secs, 0);
+    assert!(accessor.override_available);
+    assert!(!accessor.is_paused);
+}
+
+#[test]
+fn test_override_window_accessor_blocked_by_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TreasurySafeguard, ());
+    let client = TreasurySafeguardClient::new(&env, &contract_id);
+
+    client.init(&admin, &1000, &3600);
+    // Breach: value >= threshold → triggers cooldown until 1000 + 3600 = 4600
+    client.record_activity(&admin, &1000);
+
+    let accessor = client.get_override_window_accessor();
+    assert!(accessor.is_in_cooldown);
+    assert_eq!(accessor.cooldown_end_timestamp, 4600);
+    assert!(accessor.remaining_cooldown_secs > 0);
+    assert!(!accessor.override_available);
 }

--- a/contracts/treasury-safeguard/src/types.rs
+++ b/contracts/treasury-safeguard/src/types.rs
@@ -29,6 +29,41 @@ pub struct CooldownRelease {
     pub is_paused: bool,
 }
 
+/// Safeguard limits summary returned by `get_safeguard_limits_summary`.
+///
+/// `utilization_bps = floor(current_value.min(threshold_limit) * 10_000 / threshold_limit)`
+/// when `threshold_limit > 0 && current_value > 0`, otherwise 0. `is_at_limit`
+/// is true when `threshold_limit > 0 && current_value >= threshold_limit`.
+/// Missing or unconfigured states return `is_configured = false` with all zeros.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SafeguardLimitsSummary {
+    pub is_configured: bool,
+    pub threshold_limit: i128,
+    pub cooldown_period: u64,
+    pub breach_count: u32,
+    pub current_value: i128,
+    pub utilization_bps: u32,
+    pub is_at_limit: bool,
+    pub is_paused: bool,
+}
+
+/// Override-window view returned by `get_override_window_accessor`.
+///
+/// `override_available` is true when the safeguard is configured, not currently
+/// in cooldown, and not paused — meaning an authorized caller may act without
+/// waiting for a cooldown to expire.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OverrideWindowAccessor {
+    pub is_configured: bool,
+    pub is_in_cooldown: bool,
+    pub cooldown_end_timestamp: u64,
+    pub remaining_cooldown_secs: u64,
+    pub override_available: bool,
+    pub is_paused: bool,
+}
+
 #[contracttype]
 pub enum DataKey {
     Config,


### PR DESCRIPTION
Fixes #910
Fixes #914
Fixes #920
Fixes #924

## What changed

**Issue #910 — reward-stream: stream performance summary + unlock-interval accessor**
- New type `StreamPerformanceSummary`: `is_configured`, `stream_id`, `total_allocated`, `total_withdrawn`, `remaining`, `utilization_bps` (floored basis-point math, reuses `pressure_bps`), `is_depleted`, `paused`
- New type `UnlockIntervalAccessor`: `is_configured`, `stream_id`, `unlock_time`, `time_until_unlock` (saturating subtraction), `is_past_unlock`, `paused`
- New methods: `stream_performance_summary(env)`, `unlock_interval_accessor(env, now)`
- Both return predictable zero-state when unconfigured (`is_configured = false`, all zeros)
- 4 new tests: success path, missing/zero state, before unlock, after unlock + missing

**Issue #914 — season-rewards-vault: vault allocation summary + claim-window accessor**
- New type `VaultAllocationSummary`: `season_found`, `reward_pool`, `total_pending`, `total_claimed`, `utilization_bps`, `is_active`, `auto_rollover`
- New type `ClaimWindowAccessor`: `season_found`, `start_time`, `end_time`, `is_active`, `window_open`, `is_expired`
- New methods: `get_vault_allocation_summary(env, season_id)`, `get_claim_window_accessor(env, season_id, now)`
- Unknown season IDs return `season_found = false` with all zeros
- 4 new tests: success path, missing season, open window (now within range), expired + missing

**Issue #920 — team-prizes: prize allocation summary + claim-expiry accessor**
- New type `PrizeAllocationSummary`: `pool_found`, `total_amount`, `claimed_amount`, `unclaimed_amount`, `eligible_member_count`, `claimed_member_count`, `avg_share_per_member` (floor division), `fully_distributed`, `paused`
- New type `ClaimExpiryInfo`: `member_found`, `pool_id`, `claim_window_opens_at` (eligible_at + claim_delay_secs), `has_expiry` (always false — no expiry mechanism configured), `expires_at` (always 0), `is_expired` (always false), `already_claimed`, `pool_paused`
- New methods: `prize_allocation_summary(env, pool_id)`, `claim_expiry_accessor(env, member)`
- 4 new tests: allocation success path, missing pool, member found (no expiry), member not found

**Issue #924 — treasury-safeguard: safeguard limits summary + override-window accessor**
- New type `SafeguardLimitsSummary`: `is_configured`, `threshold_limit`, `cooldown_period`, `breach_count`, `current_value`, `utilization_bps`, `is_at_limit`, `is_paused`
- New type `OverrideWindowAccessor`: `is_configured`, `is_in_cooldown`, `cooldown_end_timestamp`, `remaining_cooldown_secs`, `override_available` (true when configured && !cooldown && !paused), `is_paused`
- New methods: `get_safeguard_limits_summary(env)`, `get_override_window_accessor(env)`
- 4 new tests: limits success path, missing state, override available (no breach), cooldown blocks override

## Why

All four issues follow the same pattern: add named return types so frontend and backend consumers receive structured data they can use directly without recomputing derived fields (bps, remaining, window-open flags).

## How to test

Each contract's new methods are covered by the added unit tests. To run them individually from the contract directory:

```bash
cd contracts/reward-stream && cargo test
cd contracts/treasury-safeguard && cargo test
cd contracts/team-prizes && cargo test
cd contracts/season-rewards-vault && cargo test
```

All existing tests continue to pass alongside the new ones (reward-stream: 8 tests, treasury-safeguard: 9 tests, team-prizes: 9 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new read-only summary views across reward streams, season rewards, team prizes, and treasury safeguards.
  * Users can now inspect allocation, utilization, remaining balances, claim windows, unlock timing, and override availability.
  * Added clearer status flags for configured vs. missing state, paused state, depletion, expiration, and distribution progress.

* **Tests**
  * Expanded coverage for configured and unconfigured scenarios, plus time-based behavior before/after unlock or claim windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->