### PR TITLE
feat: finalization status summary, routing snapshot, threshold summary, empty search results

### DIFF
--- a/contracts/reserve-manager/src/lib.rs
+++ b/contracts/reserve-manager/src/lib.rs
@@ -7,8 +7,11 @@ mod storage;
 mod test;
 
 use soroban_sdk::{contract, contractimpl, contractevent, Address, Env, Vec, contracterror};
-use crate::types::{ManagerConfig, ReserveState, ReserveStatus, ReserveSnapshot};
+use crate::types::{ManagerConfig, ManagerThresholdSummary, ReserveState, ReserveStatus, ReserveSnapshot};
 use crate::storage::{get_config, set_config, get_assets, set_assets, get_reserve_state, set_reserve_state};
+
+/// Sweep cooldown expressed in ledgers (2_880 ≈ 4 hours at 5 s/ledger).
+const SWEEP_COOLDOWN_LEDGERS: u32 = 2_880;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -130,5 +133,51 @@ impl ReserveManager {
     /// Returns whether the manager is paused.
     pub fn is_paused(env: Env) -> bool {
         get_config(&env).map(|c| c.is_paused).unwrap_or(true)
+    }
+
+    /// Return the sweep cooldown in ledgers.
+    ///
+    /// The sweep cooldown is the minimum gap between successive treasury sweeps.
+    /// It is a fixed contract constant so consumers share a single source of truth.
+    pub fn sweep_cooldown_ledgers(_env: Env) -> u32 {
+        SWEEP_COOLDOWN_LEDGERS
+    }
+
+    /// Return a threshold health summary across all managed reserves.
+    ///
+    /// Counts healthy, below-target, and critical reserves, and the number that
+    /// meet or exceed their target balance. Returns zero counts when uninitialized.
+    pub fn manager_threshold_summary(env: Env) -> ManagerThresholdSummary {
+        let config = get_config(&env);
+        let is_paused = config.as_ref().map(|c| c.is_paused).unwrap_or(false);
+        let assets = get_assets(&env);
+
+        let mut healthy_count = 0u32;
+        let mut below_target_count = 0u32;
+        let mut critical_count = 0u32;
+
+        for asset in assets.iter() {
+            if let Some(state) = get_reserve_state(&env, &asset) {
+                match state.status {
+                    ReserveStatus::Healthy => healthy_count = healthy_count.saturating_add(1),
+                    ReserveStatus::BelowTarget => below_target_count = below_target_count.saturating_add(1),
+                    ReserveStatus::Critical => critical_count = critical_count.saturating_add(1),
+                    ReserveStatus::Paused => {}
+                }
+            }
+        }
+
+        let total_assets = assets.len();
+        let at_or_above_threshold_count = healthy_count;
+
+        ManagerThresholdSummary {
+            total_assets,
+            healthy_count,
+            below_target_count,
+            critical_count,
+            at_or_above_threshold_count,
+            sweep_cooldown_ledgers: SWEEP_COOLDOWN_LEDGERS,
+            is_paused,
+        }
     }
 }

--- a/contracts/reserve-manager/src/test.rs
+++ b/contracts/reserve-manager/src/test.rs
@@ -97,3 +97,56 @@ fn test_uninitialized_snapshot() {
     assert!(snapshot.config.is_none());
     assert_eq!(snapshot.reserves.len(), 0);
 }
+
+#[test]
+fn test_sweep_cooldown_returns_constant() {
+    let s = setup();
+    assert_eq!(s.client.sweep_cooldown_ledgers(), 2_880u32);
+}
+
+#[test]
+fn test_manager_threshold_summary_empty() {
+    let s = setup();
+    s.client.init(&s.admin, &s.treasury);
+
+    let summary = s.client.manager_threshold_summary();
+    assert_eq!(summary.total_assets, 0);
+    assert_eq!(summary.healthy_count, 0);
+    assert_eq!(summary.below_target_count, 0);
+    assert_eq!(summary.critical_count, 0);
+    assert_eq!(summary.at_or_above_threshold_count, 0);
+    assert_eq!(summary.sweep_cooldown_ledgers, 2_880u32);
+    assert!(!summary.is_paused);
+}
+
+#[test]
+fn test_manager_threshold_summary_counts() {
+    let s = setup();
+    s.client.init(&s.admin, &s.treasury);
+
+    let healthy = Address::generate(&s.env);
+    let below = Address::generate(&s.env);
+    let critical = Address::generate(&s.env);
+
+    s.client.update_reserve(&healthy, &1000, &1000); // Healthy
+    s.client.update_reserve(&below, &600, &1000);    // BelowTarget
+    s.client.update_reserve(&critical, &200, &1000); // Critical
+
+    let summary = s.client.manager_threshold_summary();
+    assert_eq!(summary.total_assets, 3);
+    assert_eq!(summary.healthy_count, 1);
+    assert_eq!(summary.below_target_count, 1);
+    assert_eq!(summary.critical_count, 1);
+    assert_eq!(summary.at_or_above_threshold_count, 1);
+    assert!(!summary.is_paused);
+}
+
+#[test]
+fn test_manager_threshold_summary_paused() {
+    let s = setup();
+    s.client.init(&s.admin, &s.treasury);
+    s.client.set_pause(&true);
+
+    let summary = s.client.manager_threshold_summary();
+    assert!(summary.is_paused);
+}

--- a/contracts/reserve-manager/src/types.rs
+++ b/contracts/reserve-manager/src/types.rs
@@ -9,6 +9,23 @@ pub enum ReserveStatus {
     Paused = 3,
 }
 
+/// Summary of threshold health across all managed reserves.
+///
+/// `at_or_above_threshold_count` counts reserves whose balance meets or exceeds
+/// their target. `sweep_cooldown_ledgers` is a fixed constant exported here so
+/// callers do not need to hard-code it separately.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ManagerThresholdSummary {
+    pub total_assets: u32,
+    pub healthy_count: u32,
+    pub below_target_count: u32,
+    pub critical_count: u32,
+    pub at_or_above_threshold_count: u32,
+    pub sweep_cooldown_ledgers: u32,
+    pub is_paused: bool,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ManagerConfig {

--- a/contracts/reward-router/src/lib.rs
+++ b/contracts/reward-router/src/lib.rs
@@ -6,7 +6,7 @@ mod types;
 mod test;
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
-pub use types::{RouteImbalanceSummary, FallbackBucket, RouteData};
+pub use types::{RouteImbalanceSummary, FallbackBucket, RouteData, RoutingStateSnapshot};
 
 #[contract]
 pub struct RewardRouter;
@@ -78,6 +78,59 @@ impl RewardRouter {
 
         route.allocated = allocated;
         storage::set_route(&env, &route_id, &route);
+        storage::add_route_id(&env, &route_id);
+    }
+
+    /// Return the split ratio for a specific route in basis points.
+    ///
+    /// `split_ratio_bps = routed * 10_000 / allocated`, floored to 0 when
+    /// `allocated == 0` or the route does not exist.
+    pub fn split_ratio(env: Env, route_id: Symbol) -> u32 {
+        let route = storage::get_route(&env, &route_id).unwrap_or(RouteData {
+            allocated: 0,
+            routed: 0,
+        });
+        if route.allocated == 0 {
+            return 0;
+        }
+        ((route.routed * 10_000) / route.allocated) as u32
+    }
+
+    /// Return an aggregate snapshot of routing state across all tracked routes.
+    ///
+    /// `split_ratio_bps` reflects what fraction of total allocated rewards have
+    /// been routed: `total_routed * 10_000 / total_allocated`. Returns zeroed
+    /// snapshot before any routes are configured.
+    pub fn routing_state_snapshot(env: Env) -> RoutingStateSnapshot {
+        let ids = storage::get_route_ids(&env);
+        let mut total_allocated: i128 = 0;
+        let mut total_routed: i128 = 0;
+
+        for route_id in ids.iter() {
+            if let Some(route) = storage::get_route(&env, &route_id) {
+                total_allocated = total_allocated.saturating_add(route.allocated);
+                total_routed = total_routed.saturating_add(route.routed);
+            }
+        }
+
+        let total_imbalance = total_allocated.saturating_sub(total_routed);
+        let split_ratio_bps = if total_allocated == 0 {
+            0
+        } else {
+            ((total_routed * 10_000) / total_allocated) as u32
+        };
+
+        let fallback = storage::get_fallback(&env);
+        let fallback_collected = fallback.as_ref().map(|f| f.total_collected).unwrap_or(0);
+
+        RoutingStateSnapshot {
+            total_allocated,
+            total_routed,
+            total_imbalance,
+            split_ratio_bps,
+            fallback_collected,
+            has_fallback: fallback.is_some(),
+        }
     }
 
     /// Route a reward. Updates routed amount or collects in fallback if route missing.

--- a/contracts/reward-router/src/storage.rs
+++ b/contracts/reward-router/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Env, Symbol};
+use soroban_sdk::{contracttype, Env, Symbol, Vec};
 use crate::types::{RouteData, FallbackBucket};
 
 #[contracttype]
@@ -6,6 +6,7 @@ pub enum DataKey {
     Admin,
     Route(Symbol),
     Fallback,
+    RouteIds,
 }
 
 pub fn get_admin(env: &Env) -> Option<soroban_sdk::Address> {
@@ -30,4 +31,16 @@ pub fn get_fallback(env: &Env) -> Option<FallbackBucket> {
 
 pub fn set_fallback(env: &Env, data: &FallbackBucket) {
     env.storage().instance().set(&DataKey::Fallback, data);
+}
+
+pub fn get_route_ids(env: &Env) -> Vec<Symbol> {
+    env.storage().instance().get(&DataKey::RouteIds).unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn add_route_id(env: &Env, route_id: &Symbol) {
+    let mut ids = get_route_ids(env);
+    if !ids.contains(route_id.clone()) {
+        ids.push_back(route_id.clone());
+        env.storage().instance().set(&DataKey::RouteIds, &ids);
+    }
 }

--- a/contracts/reward-router/src/test.rs
+++ b/contracts/reward-router/src/test.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{Env, Symbol};
 #[test]
 fn test_route_imbalance_summary() {
     let env = Env::default();
+    env.mock_all_auths();
     let admin = Address::generate(&env);
     let contract_id = env.register_contract(None, RewardRouter);
     let client = RewardRouterClient::new(&env, &contract_id);
@@ -50,6 +51,7 @@ fn test_route_imbalance_summary() {
 #[test]
 fn test_fallback_bucket() {
     let env = Env::default();
+    env.mock_all_auths();
     let admin = Address::generate(&env);
     let contract_id = env.register_contract(None, RewardRouter);
     let client = RewardRouterClient::new(&env, &contract_id);
@@ -73,4 +75,75 @@ fn test_fallback_bucket() {
     let fallback = client.fallback_bucket().unwrap();
     assert_eq!(fallback.total_collected, 500);
     assert!(fallback.last_fallback_ledger > 0);
+}
+
+#[test]
+fn test_routing_state_snapshot_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, RewardRouter);
+    let client = RewardRouterClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let snap = client.routing_state_snapshot();
+    assert_eq!(snap.total_allocated, 0);
+    assert_eq!(snap.total_routed, 0);
+    assert_eq!(snap.total_imbalance, 0);
+    assert_eq!(snap.split_ratio_bps, 0);
+    assert_eq!(snap.fallback_collected, 0);
+    assert!(!snap.has_fallback);
+}
+
+#[test]
+fn test_routing_state_snapshot_with_routes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, RewardRouter);
+    let client = RewardRouterClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let r1 = Symbol::new(&env, "route_a");
+    let r2 = Symbol::new(&env, "route_b");
+    client.update_route(&admin, &r1, &1000);
+    client.update_route(&admin, &r2, &500);
+    client.route_reward(&r1, &400);
+
+    let snap = client.routing_state_snapshot();
+    assert_eq!(snap.total_allocated, 1500);
+    assert_eq!(snap.total_routed, 400);
+    assert_eq!(snap.total_imbalance, 1100);
+    // 400 * 10_000 / 1500 = 2666
+    assert_eq!(snap.split_ratio_bps, 2666);
+    assert!(!snap.has_fallback);
+}
+
+#[test]
+fn test_split_ratio_empty_route() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, RewardRouter);
+    let client = RewardRouterClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let route_id = Symbol::new(&env, "new_route");
+    assert_eq!(client.split_ratio(&route_id), 0);
+}
+
+#[test]
+fn test_split_ratio_partial_routing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, RewardRouter);
+    let client = RewardRouterClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let route_id = Symbol::new(&env, "my_route");
+    client.update_route(&admin, &route_id, &1000);
+    client.route_reward(&route_id, &500);
+    // 500 * 10_000 / 1000 = 5000 bps (50%)
+    assert_eq!(client.split_ratio(&route_id), 5000);
 }

--- a/contracts/reward-router/src/types.rs
+++ b/contracts/reward-router/src/types.rs
@@ -24,3 +24,19 @@ pub struct RouteData {
     pub allocated: i128,
     pub routed: i128,
 }
+
+/// Snapshot of overall routing state across all routes.
+///
+/// `split_ratio_bps` is the basis-point share of total allocated rewards that
+/// have been routed: `total_routed * 10_000 / total_allocated`, floored to 0
+/// when `total_allocated == 0`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingStateSnapshot {
+    pub total_allocated: i128,
+    pub total_routed: i128,
+    pub total_imbalance: i128,
+    pub split_ratio_bps: u32,
+    pub fallback_collected: i128,
+    pub has_fallback: bool,
+}

--- a/contracts/round-finalizer/src/lib.rs
+++ b/contracts/round-finalizer/src/lib.rs
@@ -9,6 +9,9 @@ mod types;
 use storage::*;
 use types::*;
 
+/// Dispute window expressed in ledgers (1_440 ≈ 2 hours at 5 s/ledger).
+pub(crate) const DISPUTE_WINDOW_LEDGERS: u32 = 1_440;
+
 #[contract]
 pub struct RoundFinalizerContract;
 
@@ -204,6 +207,59 @@ impl RoundFinalizerContract {
             blocked_rounds,
             unresolved_ops,
             next_active_round_id,
+        }
+    }
+
+    /// Return the dispute window in ledgers.
+    ///
+    /// The dispute window is the period after a round is marked ready during which
+    /// challenges may be raised. It is a fixed contract constant so consumers do not
+    /// need to hard-code it out-of-band.
+    pub fn dispute_window_ledgers(_env: Env) -> u32 {
+        DISPUTE_WINDOW_LEDGERS
+    }
+
+    /// Return a finalization-status summary for dashboard consumers.
+    ///
+    /// Counts finalized rounds (zero unresolved ops, has checkpoint) vs unresolved,
+    /// and surfaces the dispute window constant alongside paused state.
+    pub fn finalization_status_summary(env: Env) -> FinalizationStatusSummary {
+        let Some(cfg) = get_config(&env) else {
+            return FinalizationStatusSummary {
+                status: RoundFinalizerStatus::Unconfigured,
+                total_rounds: 0,
+                finalized_rounds: 0,
+                unresolved_rounds: 0,
+                dispute_window_ledgers: DISPUTE_WINDOW_LEDGERS,
+                finalization_paused: false,
+            };
+        };
+
+        let ids = get_round_ids(&env);
+        let mut unresolved_rounds = 0u32;
+
+        for round_id in ids.iter() {
+            if let Some(round) = get_round(&env, round_id) {
+                if round.unresolved_ops > 0 || !round.has_checkpoint {
+                    unresolved_rounds = unresolved_rounds.saturating_add(1);
+                }
+            }
+        }
+
+        let total_rounds = ids.len();
+        let finalized_rounds = total_rounds.saturating_sub(unresolved_rounds);
+
+        FinalizationStatusSummary {
+            status: if cfg.paused {
+                RoundFinalizerStatus::Paused
+            } else {
+                RoundFinalizerStatus::Active
+            },
+            total_rounds,
+            finalized_rounds,
+            unresolved_rounds,
+            dispute_window_ledgers: DISPUTE_WINDOW_LEDGERS,
+            finalization_paused: cfg.paused,
         }
     }
 

--- a/contracts/round-finalizer/src/test.rs
+++ b/contracts/round-finalizer/src/test.rs
@@ -3,6 +3,7 @@
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 use crate::{RoundFinalizerContract, RoundFinalizerContractClient};
+use crate::DISPUTE_WINDOW_LEDGERS;
 
 #[test]
 fn unresolved_summary_and_readiness_happy_path() {
@@ -62,4 +63,64 @@ fn unresolved_summary_unconfigured_and_missing_round() {
     let pressure = client.finalization_pressure();
     assert_eq!(pressure.total_rounds, 0);
     assert_eq!(pressure.pressure_bps, 0);
+}
+
+#[test]
+fn dispute_window_returns_constant() {
+    let env = Env::default();
+    let id = env.register(RoundFinalizerContract, ());
+    let client = RoundFinalizerContractClient::new(&env, &id);
+    assert_eq!(client.dispute_window_ledgers(), DISPUTE_WINDOW_LEDGERS);
+}
+
+#[test]
+fn finalization_status_summary_unconfigured() {
+    let env = Env::default();
+    let id = env.register(RoundFinalizerContract, ());
+    let client = RoundFinalizerContractClient::new(&env, &id);
+
+    let summary = client.finalization_status_summary();
+    assert_eq!(summary.total_rounds, 0);
+    assert_eq!(summary.finalized_rounds, 0);
+    assert_eq!(summary.unresolved_rounds, 0);
+    assert_eq!(summary.dispute_window_ledgers, DISPUTE_WINDOW_LEDGERS);
+    assert!(!summary.finalization_paused);
+}
+
+#[test]
+fn finalization_status_summary_counts_finalized_and_unresolved() {
+    let env = Env::default();
+    let id = env.register(RoundFinalizerContract, ());
+    let client = RoundFinalizerContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    // Round 1: finalized (no unresolved ops, has checkpoint)
+    client.upsert_round(&admin, &1, &0, &true);
+    // Round 2: unresolved (pending ops)
+    client.upsert_round(&admin, &2, &3, &true);
+    // Round 3: unresolved (missing checkpoint)
+    client.upsert_round(&admin, &3, &0, &false);
+
+    let summary = client.finalization_status_summary();
+    assert_eq!(summary.total_rounds, 3);
+    assert_eq!(summary.finalized_rounds, 1);
+    assert_eq!(summary.unresolved_rounds, 2);
+    assert!(!summary.finalization_paused);
+}
+
+#[test]
+fn finalization_status_summary_reflects_paused() {
+    let env = Env::default();
+    let id = env.register(RoundFinalizerContract, ());
+    let client = RoundFinalizerContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    client.set_paused(&admin, &true);
+
+    let summary = client.finalization_status_summary();
+    assert!(summary.finalization_paused);
 }

--- a/contracts/round-finalizer/src/types.rs
+++ b/contracts/round-finalizer/src/types.rs
@@ -79,6 +79,22 @@ pub struct FinalizationPressure {
     pub finalization_paused: bool,
 }
 
+/// Finalization status summary for dashboard read consumers.
+///
+/// `finalized_rounds` = total_rounds minus unresolved_rounds.
+/// `dispute_window_ledgers` is a fixed constant (1_440 ledgers ≈ 2 hours at 5 s/ledger)
+/// exported here so front-end and off-chain tooling share a single source of truth.
+#[contracttype]
+#[derive(Clone)]
+pub struct FinalizationStatusSummary {
+    pub status: RoundFinalizerStatus,
+    pub total_rounds: u32,
+    pub finalized_rounds: u32,
+    pub unresolved_rounds: u32,
+    pub dispute_window_ledgers: u32,
+    pub finalization_paused: bool,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {

--- a/frontend/src/components/EmptySearchResults.tsx
+++ b/frontend/src/components/EmptySearchResults.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from "react";
+
+export interface EmptySearchResultsProps {
+  /** The search term that returned no results. Used in the default message when `message` is omitted. */
+  query?: string;
+  /** Override the primary message text. */
+  message?: string;
+  /** Optional secondary hint (e.g. "Try broader keywords"). */
+  hint?: string;
+  /** Optional call-to-action rendered below the hint. */
+  action?: ReactNode;
+  /** Additional class names for the container. */
+  className?: string;
+}
+
+/**
+ * Reusable empty-state container for search results.
+ *
+ * Accessibility: rendered as a live region so screen readers announce the
+ * empty state without requiring focus. The role="status" maps to
+ * aria-live="polite" so it does not interrupt ongoing speech.
+ */
+export function EmptySearchResults({
+  query,
+  message,
+  hint,
+  action,
+  className = "",
+}: EmptySearchResultsProps) {
+  const primaryText =
+    message ??
+    (query ? `No results for "${query}"` : "No results found");
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="empty-search-results"
+      style={styles.root}
+      className={className}
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        style={styles.icon}
+      >
+        <circle cx="18" cy="18" r="11" stroke="currentColor" strokeWidth="2" fill="none" />
+        <line x1="26.5" y1="26.5" x2="34" y2="34" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        <line x1="14" y1="18" x2="22" y2="18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+
+      <p style={styles.primary}>{primaryText}</p>
+
+      {hint && <p style={styles.hint}>{hint}</p>}
+
+      {action && <div style={styles.action}>{action}</div>}
+    </div>
+  );
+}
+
+const styles = {
+  root: {
+    display: "flex",
+    flexDirection: "column" as const,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "0.5rem",
+    padding: "2.5rem 1rem",
+    textAlign: "center" as const,
+    color: "#64748b",
+  },
+  icon: {
+    color: "#94a3b8",
+    marginBottom: "0.25rem",
+  },
+  primary: {
+    margin: 0,
+    fontSize: "0.9375rem",
+    fontWeight: 500,
+    color: "#334155",
+  },
+  hint: {
+    margin: 0,
+    fontSize: "0.8125rem",
+    color: "#64748b",
+  },
+  action: {
+    marginTop: "0.5rem",
+  },
+} as const;

--- a/frontend/tests/components/EmptySearchResults.test.tsx
+++ b/frontend/tests/components/EmptySearchResults.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { EmptySearchResults } from "@/components/EmptySearchResults";
+
+describe("EmptySearchResults", () => {
+  // -------------------------------------------------------------------------
+  // Default rendering
+  // -------------------------------------------------------------------------
+  it("renders default message when no props provided", () => {
+    render(<EmptySearchResults />);
+    expect(screen.getByText("No results found")).toBeInTheDocument();
+  });
+
+  it("renders query-based message when query is supplied", () => {
+    render(<EmptySearchResults query="stellar" />);
+    expect(screen.getByText(/No results for "stellar"/)).toBeInTheDocument();
+  });
+
+  it("renders custom message overriding the default", () => {
+    render(<EmptySearchResults message="Nothing matched your filters" />);
+    expect(screen.getByText("Nothing matched your filters")).toBeInTheDocument();
+  });
+
+  it("custom message takes precedence over query", () => {
+    render(<EmptySearchResults query="foo" message="Custom override" />);
+    expect(screen.getByText("Custom override")).toBeInTheDocument();
+    expect(screen.queryByText(/No results for/)).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Hint and action
+  // -------------------------------------------------------------------------
+  it("renders hint text when provided", () => {
+    render(<EmptySearchResults hint="Try broader keywords" />);
+    expect(screen.getByText("Try broader keywords")).toBeInTheDocument();
+  });
+
+  it("does not render hint section when omitted", () => {
+    render(<EmptySearchResults />);
+    expect(screen.queryByText(/Try/)).not.toBeInTheDocument();
+  });
+
+  it("renders action element when provided", () => {
+    render(
+      <EmptySearchResults
+        action={<button type="button">Clear filters</button>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /clear filters/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render action slot when omitted", () => {
+    render(<EmptySearchResults />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+  it("has role=status for live-region announcement", () => {
+    render(<EmptySearchResults />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("has aria-live=polite", () => {
+    render(<EmptySearchResults />);
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("has aria-atomic=true", () => {
+    render(<EmptySearchResults />);
+    expect(screen.getByRole("status")).toHaveAttribute("aria-atomic", "true");
+  });
+
+  it("search icon is aria-hidden", () => {
+    render(<EmptySearchResults />);
+    const svg = document.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge / regression cases
+  // -------------------------------------------------------------------------
+  it("applies custom className to container", () => {
+    render(<EmptySearchResults className="mt-8" />);
+    expect(screen.getByRole("status")).toHaveClass("mt-8");
+  });
+
+  it("renders without crashing when all props are provided", () => {
+    render(
+      <EmptySearchResults
+        query="nft"
+        message="Nothing here"
+        hint="Adjust filters"
+        action={<button type="button">Reset</button>}
+        className="custom"
+      />,
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+    expect(screen.getByText("Adjust filters")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- **round-finalizer**: add `finalization_status_summary()` — counts finalized vs unresolved rounds, paused state, and dispute window constant in a single struct; add `dispute_window_ledgers()` read-only accessor (1_440 ledgers ≈ 2 hours)
- **reward-router**: add `routing_state_snapshot()` — aggregate allocated/routed/imbalance across all routes with basis-point split ratio; add `split_ratio(route_id)` per-route accessor; track route IDs in persistent storage at `update_route` time so enumeration is O(1)
- **reserve-manager**: add `manager_threshold_summary()` — healthy/below-target/critical counts with sweep cooldown constant; add `sweep_cooldown_ledgers()` read-only accessor (2_880 ledgers ≈ 4 hours)
- **frontend**: add reusable `EmptySearchResults` component with accessible `role="status"` live region, query-interpolated message, hint, action slot, and custom className; 14 Vitest tests

## Test plan

- [ ] `cargo test` (round-finalizer isolated): 6 tests pass including 4 new — `finalization_status_summary_*`, `dispute_window_returns_constant`
- [ ] `cargo test` (reward-router isolated): 5/6 pass including 4 new — `test_routing_state_snapshot_*`, `test_split_ratio_*`; `test_fallback_bucket` fails on `last_fallback_ledger > 0` — pre-existing bug (test env ledger starts at 0), not introduced by this PR
- [ ] `cargo test` (reserve-manager): pre-existing compile error in `update_reserve` (`#[contractevent]` + `Events::publish` SDK mismatch at line 97); my additions at lines 135–185 have no errors; 4 new tests written
- [ ] Frontend: `vitest run EmptySearchResults.test.tsx` — 14/14 pass

## Pre-existing CI failures

`build:content` and `check:links` are red on clean `theblockcade/stellarcade:main`; the reserve-manager `#[contractevent]` compile error and reward-router `test_fallback_bucket` assertion are pre-existing on `main`. This PR adds no new failures.

closes #908
closes #909
closes #912
closes #933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dashboard-style summary views for reserve health, route allocation (snapshot + split ratio), and round finalization status.
  * Added quick-access timing constants for reserve sweep cooldown and the round finalization dispute window.
  * Introduced a reusable empty search results UI with optional hint and action content.
* **Bug Fixes**
  * Improved reserve, route, and finalization summary calculations for empty states and paused behavior, with more consistent counting/ratio handling.
* **Tests**
  * Added unit test coverage for new dashboard summary methods and the empty search component (including accessibility expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->