### PR TITLE
feat: add clan roster table, toast queue, and contract accessors

### DIFF
--- a/contracts/reserve-auction/src/lib.rs
+++ b/contracts/reserve-auction/src/lib.rs
@@ -6,7 +6,7 @@ mod types;
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
 
 pub use types::{
-    AuctionPhase, ReserveAuctionLot, ReserveAuctionSnapshot, SellerAuctionStats,
+    AuctionPhase, BidDelayConfig, ReserveAuctionLot, ReserveAuctionSnapshot, SellerAuctionStats,
     SellerAuctionSummary, SettlementOutcome,
 };
 
@@ -21,6 +21,7 @@ pub enum DataKey {
     NextAuctionId,
     Auction(u64),
     SellerStats(Address),
+    BidDelayBlocks,
 }
 
 #[contracterror]
@@ -259,6 +260,25 @@ impl ReserveAuction {
             settled_auction_count: stats.settled_auction_count,
             reserve_met_count: stats.reserve_met_count,
             highest_open_bid,
+        }
+    }
+
+    pub fn set_bid_delay(env: Env, blocks: u32) -> Result<(), Error> {
+        Self::require_admin(&env)?;
+        storage::set_bid_delay_blocks(&env, blocks);
+        Ok(())
+    }
+
+    pub fn bid_delay_config(env: Env) -> BidDelayConfig {
+        match storage::get_bid_delay_blocks(&env) {
+            Some(blocks) => BidDelayConfig {
+                bid_delay_blocks: blocks,
+                configured: true,
+            },
+            None => BidDelayConfig {
+                bid_delay_blocks: 0,
+                configured: false,
+            },
         }
     }
 

--- a/contracts/reserve-auction/src/storage.rs
+++ b/contracts/reserve-auction/src/storage.rs
@@ -55,3 +55,11 @@ pub fn set_seller_stats(env: &Env, seller: &Address, stats: &SellerAuctionStats)
         .persistent()
         .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
 }
+
+pub fn get_bid_delay_blocks(env: &Env) -> Option<u32> {
+    env.storage().instance().get(&DataKey::BidDelayBlocks)
+}
+
+pub fn set_bid_delay_blocks(env: &Env, blocks: u32) {
+    env.storage().instance().set(&DataKey::BidDelayBlocks, &blocks);
+}

--- a/contracts/reserve-auction/src/test.rs
+++ b/contracts/reserve-auction/src/test.rs
@@ -66,6 +66,29 @@ fn test_unknown_auction_returns_empty_snapshot() {
 }
 
 #[test]
+fn test_bid_delay_config_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _seller, _bidder) = setup(&env);
+
+    let config = client.bid_delay_config();
+    assert!(!config.configured);
+    assert_eq!(config.bid_delay_blocks, 0);
+}
+
+#[test]
+fn test_bid_delay_config_after_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _seller, _bidder) = setup(&env);
+
+    client.set_bid_delay(&5);
+    let config = client.bid_delay_config();
+    assert!(config.configured);
+    assert_eq!(config.bid_delay_blocks, 5);
+}
+
+#[test]
 fn test_pause_blocks_bid_workflow() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/reserve-auction/src/types.rs
+++ b/contracts/reserve-auction/src/types.rs
@@ -67,6 +67,13 @@ pub struct SellerAuctionSummary {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BidDelayConfig {
+    pub bid_delay_blocks: u32,
+    pub configured: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SettlementOutcome {
     pub auction_id: u64,
     pub seller: Address,

--- a/contracts/tournament-lobby/src/lib.rs
+++ b/contracts/tournament-lobby/src/lib.rs
@@ -6,7 +6,7 @@ mod types;
 mod test;
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
-pub use types::{ReadyCheckSummary, SeatAvailability, LobbyData, Participant};
+pub use types::{LobbyConfigSnapshot, LobbyData, Participant, ReadyCheckSummary, SeatAvailability, StartGraceConfig};
 
 #[contract]
 pub struct TournamentLobby;
@@ -131,5 +131,56 @@ impl TournamentLobby {
 
         lobby.participants = new_participants;
         storage::set_lobby(&env, lobby_id, &lobby);
+    }
+
+    /// Set global paused state. Admin only.
+    pub fn set_paused(env: Env, admin: Address, paused: bool) {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env).expect("Not initialized");
+        assert!(admin == stored_admin, "Unauthorized");
+        storage::set_paused(&env, paused);
+    }
+
+    /// Return a snapshot of the lobby configuration.
+    pub fn lobby_config_snapshot(env: Env, lobby_id: u64) -> LobbyConfigSnapshot {
+        let paused = storage::get_paused(&env);
+        match storage::get_lobby(&env, lobby_id) {
+            Some(lobby) => LobbyConfigSnapshot {
+                lobby_id,
+                exists: true,
+                max_seats: lobby.max_seats,
+                participant_count: lobby.participants.len(),
+                paused,
+            },
+            None => LobbyConfigSnapshot {
+                lobby_id,
+                exists: false,
+                max_seats: 0,
+                participant_count: 0,
+                paused,
+            },
+        }
+    }
+
+    /// Set start grace period for a lobby. Admin only.
+    pub fn set_start_grace(env: Env, admin: Address, lobby_id: u64, grace_blocks: u32) {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env).expect("Not initialized");
+        assert!(admin == stored_admin, "Unauthorized");
+        storage::set_start_grace_blocks(&env, lobby_id, grace_blocks);
+    }
+
+    /// Return the start grace configuration for a lobby.
+    pub fn start_grace_config(env: Env, lobby_id: u64) -> StartGraceConfig {
+        match storage::get_start_grace_blocks(&env, lobby_id) {
+            Some(blocks) => StartGraceConfig {
+                grace_blocks: blocks,
+                configured: true,
+            },
+            None => StartGraceConfig {
+                grace_blocks: 0,
+                configured: false,
+            },
+        }
     }
 }

--- a/contracts/tournament-lobby/src/storage.rs
+++ b/contracts/tournament-lobby/src/storage.rs
@@ -5,6 +5,8 @@ use crate::types::LobbyData;
 pub enum DataKey {
     Admin,
     Lobby(u64),
+    Paused,
+    StartGraceBlocks(u64),
 }
 
 pub fn get_admin(env: &Env) -> Option<soroban_sdk::Address> {
@@ -21,4 +23,20 @@ pub fn get_lobby(env: &Env, lobby_id: u64) -> Option<LobbyData> {
 
 pub fn set_lobby(env: &Env, lobby_id: u64, data: &LobbyData) {
     env.storage().persistent().set(&DataKey::Lobby(lobby_id), data);
+}
+
+pub fn get_paused(env: &Env) -> bool {
+    env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().instance().set(&DataKey::Paused, &paused);
+}
+
+pub fn get_start_grace_blocks(env: &Env, lobby_id: u64) -> Option<u32> {
+    env.storage().persistent().get(&DataKey::StartGraceBlocks(lobby_id))
+}
+
+pub fn set_start_grace_blocks(env: &Env, lobby_id: u64, grace_blocks: u32) {
+    env.storage().persistent().set(&DataKey::StartGraceBlocks(lobby_id), &grace_blocks);
 }

--- a/contracts/tournament-lobby/src/test.rs
+++ b/contracts/tournament-lobby/src/test.rs
@@ -46,6 +46,80 @@ fn test_ready_check_summary() {
 }
 
 #[test]
+fn test_lobby_config_snapshot_missing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, TournamentLobby);
+    let client = TournamentLobbyClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let snapshot = client.lobby_config_snapshot(&999u64);
+    assert!(!snapshot.exists);
+    assert_eq!(snapshot.lobby_id, 999u64);
+    assert_eq!(snapshot.max_seats, 0);
+    assert_eq!(snapshot.participant_count, 0);
+    assert!(!snapshot.paused);
+}
+
+#[test]
+fn test_lobby_config_snapshot_with_participants() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, TournamentLobby);
+    let client = TournamentLobbyClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let lobby_id = 1u64;
+    client.create_lobby(&admin, &lobby_id, &4);
+
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+    client.join_lobby(&lobby_id, &player1);
+    client.join_lobby(&lobby_id, &player2);
+
+    let snapshot = client.lobby_config_snapshot(&lobby_id);
+    assert!(snapshot.exists);
+    assert_eq!(snapshot.lobby_id, lobby_id);
+    assert_eq!(snapshot.max_seats, 4);
+    assert_eq!(snapshot.participant_count, 2);
+    assert!(!snapshot.paused);
+}
+
+#[test]
+fn test_start_grace_config_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, TournamentLobby);
+    let client = TournamentLobbyClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let config = client.start_grace_config(&1u64);
+    assert!(!config.configured);
+    assert_eq!(config.grace_blocks, 0);
+}
+
+#[test]
+fn test_start_grace_config_after_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, TournamentLobby);
+    let client = TournamentLobbyClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let lobby_id = 1u64;
+    client.create_lobby(&admin, &lobby_id, &2);
+    client.set_start_grace(&admin, &lobby_id, &10);
+
+    let config = client.start_grace_config(&lobby_id);
+    assert!(config.configured);
+    assert_eq!(config.grace_blocks, 10);
+}
+
+#[test]
 fn test_seat_availability() {
     let env = Env::default();
     let admin = Address::generate(&env);

--- a/contracts/tournament-lobby/src/types.rs
+++ b/contracts/tournament-lobby/src/types.rs
@@ -31,3 +31,20 @@ pub struct LobbyData {
     pub max_seats: u32,
     pub participants: Vec<Participant>,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LobbyConfigSnapshot {
+    pub lobby_id: u64,
+    pub exists: bool,
+    pub max_seats: u32,
+    pub participant_count: u32,
+    pub paused: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StartGraceConfig {
+    pub grace_blocks: u32,
+    pub configured: bool,
+}

--- a/frontend/src/components/ClanRosterTable.tsx
+++ b/frontend/src/components/ClanRosterTable.tsx
@@ -1,0 +1,282 @@
+import type { CSSProperties } from "react";
+
+export type ClanMember = {
+  address: string;
+  role: "owner" | "member";
+  joinedAt: string;
+  isActive: boolean;
+};
+
+export interface ClanRosterTableProps {
+  clanId: string;
+  members: ClanMember[];
+  isLoading?: boolean;
+  emptyMessage?: string;
+}
+
+function truncateAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+function formatDate(dateStr: string): string {
+  try {
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+/**
+ * Displays the active member roster for a given clan. Shows address
+ * (truncated), role, join date, and active/inactive status badge.
+ * Handles loading and empty states gracefully.
+ */
+export function ClanRosterTable({
+  clanId,
+  members,
+  isLoading = false,
+  emptyMessage,
+}: ClanRosterTableProps) {
+  if (isLoading) {
+    return (
+      <div
+        className="clan-roster-table clan-roster-table--loading"
+        data-testid="clan-roster-loading"
+        data-clan-id={clanId}
+        style={styles.loadingContainer}
+        role="status"
+        aria-label="Loading clan roster"
+        aria-live="polite"
+      >
+        <div style={styles.skeletonRow} aria-hidden="true" />
+        <div style={styles.skeletonRow} aria-hidden="true" />
+        <div style={styles.skeletonRow} aria-hidden="true" />
+        <span style={styles.srOnly}>Loading…</span>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div
+        className="clan-roster-table clan-roster-table--empty"
+        data-testid="clan-roster-empty"
+        data-clan-id={clanId}
+        style={styles.emptyContainer}
+        role="status"
+        aria-live="polite"
+      >
+        {emptyMessage ?? "No active members"}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="clan-roster-table"
+      data-testid="clan-roster-table"
+      data-clan-id={clanId}
+      style={styles.tableWrapper}
+    >
+      <table style={styles.table} aria-label="Clan member roster">
+        <thead>
+          <tr style={styles.headerRow}>
+            <th scope="col" style={styles.th}>
+              Address
+            </th>
+            <th scope="col" style={styles.th}>
+              Role
+            </th>
+            <th scope="col" style={styles.th}>
+              Joined
+            </th>
+            <th scope="col" style={styles.th}>
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {members.map((member, idx) => (
+            <tr
+              key={`${member.address}-${idx}`}
+              style={{
+                ...styles.row,
+                ...(member.isActive ? {} : styles.rowInactive),
+              }}
+              data-testid={`clan-roster-row-${idx}`}
+              aria-label={`Member ${member.address}${member.isActive ? "" : ", inactive"}`}
+            >
+              <td style={styles.td}>
+                <span
+                  title={member.address}
+                  data-testid={`clan-roster-address-${idx}`}
+                  style={styles.addressCell}
+                >
+                  {truncateAddress(member.address)}
+                </span>
+              </td>
+              <td style={styles.td}>
+                <span
+                  style={{
+                    ...styles.roleBadge,
+                    ...(member.role === "owner"
+                      ? styles.roleBadgeOwner
+                      : styles.roleBadgeMember),
+                  }}
+                >
+                  {member.role === "owner" ? "Owner" : "Member"}
+                </span>
+              </td>
+              <td style={styles.td}>
+                <span style={styles.dateCell}>{formatDate(member.joinedAt)}</span>
+              </td>
+              <td style={styles.td}>
+                <span
+                  style={{
+                    ...styles.statusBadge,
+                    ...(member.isActive
+                      ? styles.statusActive
+                      : styles.statusInactive),
+                  }}
+                  data-testid={`clan-roster-status-${idx}`}
+                  aria-label={member.isActive ? "Active" : "Inactive"}
+                >
+                  {member.isActive ? "Active" : "Inactive"}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const styles = {
+  tableWrapper: {
+    width: "100%",
+    overflowX: "auto" as const,
+    borderRadius: "0.5rem",
+    border: "1px solid var(--border-subtle, rgba(255,255,255,0.1))",
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse" as const,
+    fontSize: "0.875rem",
+    color: "var(--text-primary, #f5f7fb)",
+  },
+  headerRow: {
+    borderBottom: "1px solid var(--border-subtle, rgba(255,255,255,0.1))",
+  },
+  th: {
+    padding: "0.625rem 1rem",
+    textAlign: "left" as const,
+    fontWeight: 600,
+    fontSize: "0.75rem",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.05em",
+    color: "var(--text-muted, rgba(245,247,251,0.6))",
+    backgroundColor: "var(--surface-1, #11161e)",
+    whiteSpace: "nowrap" as const,
+  },
+  row: {
+    borderBottom: "1px solid var(--border-subtle, rgba(255,255,255,0.06))",
+    transition: "background 0.15s ease",
+  } as CSSProperties,
+  rowInactive: {
+    opacity: 0.45,
+  } as CSSProperties,
+  td: {
+    padding: "0.625rem 1rem",
+    verticalAlign: "middle" as const,
+  },
+  addressCell: {
+    fontFamily: "monospace",
+    fontSize: "0.8125rem",
+    letterSpacing: "0.02em",
+  } as CSSProperties,
+  dateCell: {
+    color: "var(--text-muted, rgba(245,247,251,0.65))",
+    fontSize: "0.8125rem",
+  } as CSSProperties,
+  roleBadge: {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "0.125rem 0.5rem",
+    borderRadius: "9999px",
+    fontSize: "0.6875rem",
+    fontWeight: 600,
+    border: "1px solid transparent",
+  } as CSSProperties,
+  roleBadgeOwner: {
+    color: "#a78bfa",
+    backgroundColor: "rgba(167,139,250,0.12)",
+    borderColor: "rgba(167,139,250,0.3)",
+  } as CSSProperties,
+  roleBadgeMember: {
+    color: "var(--text-muted, rgba(245,247,251,0.6))",
+    backgroundColor: "rgba(255,255,255,0.06)",
+    borderColor: "rgba(255,255,255,0.1)",
+  } as CSSProperties,
+  statusBadge: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.3rem",
+    padding: "0.125rem 0.5rem",
+    borderRadius: "9999px",
+    fontSize: "0.6875rem",
+    fontWeight: 600,
+    border: "1px solid transparent",
+  } as CSSProperties,
+  statusActive: {
+    color: "#22c55e",
+    backgroundColor: "rgba(34,197,94,0.1)",
+    borderColor: "rgba(34,197,94,0.3)",
+  } as CSSProperties,
+  statusInactive: {
+    color: "var(--text-muted, rgba(245,247,251,0.45))",
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderColor: "rgba(255,255,255,0.08)",
+  } as CSSProperties,
+  loadingContainer: {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: "0.5rem",
+    padding: "1rem",
+    borderRadius: "0.5rem",
+    border: "1px solid var(--border-subtle, rgba(255,255,255,0.1))",
+  },
+  skeletonRow: {
+    height: "2rem",
+    borderRadius: "0.25rem",
+    backgroundColor: "rgba(255,255,255,0.07)",
+    animation: "pulse 1.5s ease-in-out infinite",
+  } as CSSProperties,
+  emptyContainer: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "2.5rem 1rem",
+    borderRadius: "0.5rem",
+    border: "1px solid var(--border-subtle, rgba(255,255,255,0.1))",
+    color: "var(--text-muted, rgba(245,247,251,0.55))",
+    fontSize: "0.9375rem",
+    fontWeight: 500,
+  },
+  srOnly: {
+    position: "absolute" as const,
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: "hidden" as const,
+    clip: "rect(0,0,0,0)",
+    whiteSpace: "nowrap" as const,
+    borderWidth: 0,
+  },
+} as const;

--- a/frontend/src/components/ToastQueue.tsx
+++ b/frontend/src/components/ToastQueue.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useRef } from "react";
+
+export type ToastType = "success" | "error" | "info" | "warning";
+
+export type Toast = {
+  id: string;
+  message: string;
+  type: ToastType;
+  duration?: number;
+};
+
+export interface ToastQueueProps {
+  toasts: Toast[];
+  onDismiss: (id: string) => void;
+}
+
+const MAX_VISIBLE = 5;
+const DEFAULT_DURATION = 4000;
+
+const TYPE_ICONS: Record<ToastType, string> = {
+  success: "✓",
+  error: "✕",
+  info: "ℹ",
+  warning: "⚠",
+};
+
+const TYPE_COLORS: Record<
+  ToastType,
+  { fg: string; bg: string; border: string; iconBg: string }
+> = {
+  success: {
+    fg: "#22c55e",
+    bg: "rgba(34,197,94,0.1)",
+    border: "rgba(34,197,94,0.3)",
+    iconBg: "rgba(34,197,94,0.15)",
+  },
+  error: {
+    fg: "#ef4444",
+    bg: "rgba(239,68,68,0.1)",
+    border: "rgba(239,68,68,0.3)",
+    iconBg: "rgba(239,68,68,0.15)",
+  },
+  info: {
+    fg: "#3b82f6",
+    bg: "rgba(59,130,246,0.1)",
+    border: "rgba(59,130,246,0.3)",
+    iconBg: "rgba(59,130,246,0.15)",
+  },
+  warning: {
+    fg: "#f59e0b",
+    bg: "rgba(245,158,11,0.1)",
+    border: "rgba(245,158,11,0.3)",
+    iconBg: "rgba(245,158,11,0.15)",
+  },
+};
+
+interface ToastItemProps {
+  toast: Toast;
+  onDismiss: (id: string) => void;
+}
+
+function ToastItem({ toast, onDismiss }: ToastItemProps) {
+  const colors = TYPE_COLORS[toast.type];
+  const duration = toast.duration ?? DEFAULT_DURATION;
+  const dismissRef = useRef(onDismiss);
+  dismissRef.current = onDismiss;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      dismissRef.current(toast.id);
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [toast.id, duration]);
+
+  return (
+    <div
+      role={toast.type === "error" || toast.type === "warning" ? "alert" : "status"}
+      aria-live={toast.type === "error" ? "assertive" : "polite"}
+      aria-atomic="true"
+      data-testid={`toast-item-${toast.id}`}
+      data-type={toast.type}
+      style={{
+        ...styles.toastItem,
+        backgroundColor: colors.bg,
+        borderColor: colors.border,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        data-testid={`toast-icon-${toast.id}`}
+        style={{
+          ...styles.icon,
+          color: colors.fg,
+          backgroundColor: colors.iconBg,
+        }}
+      >
+        {TYPE_ICONS[toast.type]}
+      </span>
+      <span style={styles.message} data-testid={`toast-message-${toast.id}`}>
+        {toast.message}
+      </span>
+      <button
+        type="button"
+        onClick={() => onDismiss(toast.id)}
+        aria-label={`Dismiss notification: ${toast.message}`}
+        data-testid={`toast-dismiss-${toast.id}`}
+        style={styles.closeButton}
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Renders a fixed-position stack of toast notifications in the bottom-right
+ * corner. At most MAX_VISIBLE (5) toasts are shown; additional toasts are
+ * queued and displayed as older ones are dismissed.
+ *
+ * Auto-dismiss is handled per-item via the `duration` field (default 4 s).
+ */
+export function ToastQueue({ toasts, onDismiss }: ToastQueueProps) {
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  const visible = toasts.slice(-MAX_VISIBLE);
+
+  return (
+    <div
+      data-testid="toast-queue"
+      aria-label="Notifications"
+      style={styles.container}
+    >
+      {visible.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    position: "fixed" as const,
+    bottom: "1.5rem",
+    right: "1.5rem",
+    zIndex: 9999,
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: "0.5rem",
+    width: "22rem",
+    maxWidth: "calc(100vw - 3rem)",
+    pointerEvents: "auto" as const,
+  },
+  toastItem: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: "0.625rem",
+    padding: "0.75rem 0.875rem",
+    borderRadius: "0.5rem",
+    border: "1px solid transparent",
+    backgroundColor: "var(--surface-1, #11161e)",
+    boxShadow:
+      "0 4px 16px rgba(0,0,0,0.35), 0 1px 4px rgba(0,0,0,0.2)",
+    color: "var(--text-primary, #f5f7fb)",
+    fontSize: "0.875rem",
+    lineHeight: 1.45,
+  },
+  icon: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    width: "1.375rem",
+    height: "1.375rem",
+    borderRadius: "9999px",
+    fontSize: "0.75rem",
+    fontWeight: 700,
+  },
+  message: {
+    flex: 1,
+    minWidth: 0,
+    paddingTop: "0.125rem",
+  },
+  closeButton: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    width: "1.375rem",
+    height: "1.375rem",
+    border: "none",
+    borderRadius: "0.25rem",
+    background: "transparent",
+    color: "var(--text-muted, rgba(245,247,251,0.5))",
+    fontSize: "1.125rem",
+    lineHeight: 1,
+    cursor: "pointer",
+    padding: 0,
+    transition: "background 0.15s ease",
+  },
+} as const;

--- a/frontend/src/components/useToastQueue.ts
+++ b/frontend/src/components/useToastQueue.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+import type { Toast, ToastType } from "./ToastQueue";
+
+let _counter = 0;
+function nextId(): string {
+  _counter += 1;
+  return `toast-${_counter}-${Date.now()}`;
+}
+
+export interface UseToastQueueReturn {
+  toasts: Toast[];
+  addToast: (message: string, type: ToastType, duration?: number) => string;
+  dismissToast: (id: string) => void;
+}
+
+/**
+ * Manages a queue of toast notifications.
+ *
+ * - `addToast(message, type, duration?)` — enqueues a new toast and returns
+ *   its generated id. The ToastQueue component handles auto-dismiss via a
+ *   per-item timer; call `dismissToast` from the `onDismiss` prop.
+ * - `dismissToast(id)` — removes the toast with the given id immediately.
+ */
+export function useToastQueue(): UseToastQueueReturn {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback(
+    (message: string, type: ToastType, duration?: number): string => {
+      const id = nextId();
+      const toast: Toast = { id, message, type, duration };
+      setToasts((prev) => [...prev, toast]);
+      return id;
+    },
+    []
+  );
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { toasts, addToast, dismissToast };
+}

--- a/frontend/tests/components/ClanRosterTable.test.tsx
+++ b/frontend/tests/components/ClanRosterTable.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import { ClanRosterTable, type ClanMember } from "@/components/ClanRosterTable";
+
+const mockMembers: ClanMember[] = [
+  {
+    address: "GABCDE1234567890WXYZ",
+    role: "owner",
+    joinedAt: "2024-01-15T10:00:00Z",
+    isActive: true,
+  },
+  {
+    address: "GXYZ9876543210ABCD",
+    role: "member",
+    joinedAt: "2024-03-22T08:30:00Z",
+    isActive: true,
+  },
+  {
+    address: "GFGHIJ5555555555KL",
+    role: "member",
+    joinedAt: "2024-06-01T12:00:00Z",
+    isActive: false,
+  },
+];
+
+describe("ClanRosterTable (#937)", () => {
+  // ---------------------------------------------------------------------------
+  // Empty state
+  // ---------------------------------------------------------------------------
+  it("renders the default empty message when members array is empty", () => {
+    render(<ClanRosterTable clanId="clan-1" members={[]} />);
+    expect(screen.getByTestId("clan-roster-empty")).toBeInTheDocument();
+    expect(screen.getByText("No active members")).toBeInTheDocument();
+  });
+
+  it("renders a custom empty message when provided", () => {
+    render(
+      <ClanRosterTable
+        clanId="clan-1"
+        members={[]}
+        emptyMessage="This clan has no members yet"
+      />
+    );
+    expect(screen.getByText("This clan has no members yet")).toBeInTheDocument();
+  });
+
+  it("empty state has role=status for accessibility", () => {
+    render(<ClanRosterTable clanId="clan-1" members={[]} />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Loading state
+  // ---------------------------------------------------------------------------
+  it("renders a loading indicator when isLoading is true", () => {
+    render(<ClanRosterTable clanId="clan-1" members={[]} isLoading />);
+    expect(screen.getByTestId("clan-roster-loading")).toBeInTheDocument();
+  });
+
+  it("does not render the table when loading", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} isLoading />);
+    expect(screen.queryByTestId("clan-roster-table")).not.toBeInTheDocument();
+  });
+
+  it("loading state has role=status and aria-live=polite", () => {
+    render(<ClanRosterTable clanId="clan-1" members={[]} isLoading />);
+    const el = screen.getByRole("status");
+    expect(el).toHaveAttribute("aria-live", "polite");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Member rows
+  // ---------------------------------------------------------------------------
+  it("renders a row for each member", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    expect(screen.getByTestId("clan-roster-row-0")).toBeInTheDocument();
+    expect(screen.getByTestId("clan-roster-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("clan-roster-row-2")).toBeInTheDocument();
+  });
+
+  it("renders column headers", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    expect(screen.getByText("Address")).toBeInTheDocument();
+    expect(screen.getByText("Role")).toBeInTheDocument();
+    expect(screen.getByText("Joined")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("renders owner and member role badges", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    expect(screen.getByText("Owner")).toBeInTheDocument();
+    const memberBadges = screen.getAllByText("Member");
+    expect(memberBadges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Truncated addresses
+  // ---------------------------------------------------------------------------
+  it("shows truncated address (first6...last4) for long addresses", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    // "GABCDE1234567890WXYZ" → "GABCDE...WXYZ"
+    expect(screen.getByText("GABCDE...WXYZ")).toBeInTheDocument();
+  });
+
+  it("sets the full address in the title attribute for tooltip access", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    const addressEl = screen.getByTestId("clan-roster-address-0");
+    expect(addressEl).toHaveAttribute("title", "GABCDE1234567890WXYZ");
+  });
+
+  it("does not truncate short addresses", () => {
+    const shortMember: ClanMember = {
+      address: "GABC",
+      role: "member",
+      joinedAt: "2024-01-01T00:00:00Z",
+      isActive: true,
+    };
+    render(<ClanRosterTable clanId="clan-1" members={[shortMember]} />);
+    expect(screen.getByText("GABC")).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Inactive members
+  // ---------------------------------------------------------------------------
+  it("renders Active badge for active members", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    const activeBadges = screen.getAllByText("Active");
+    expect(activeBadges.length).toBe(2);
+  });
+
+  it("renders Inactive badge for inactive members", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+  });
+
+  it("inactive member row carries an aria-label indicating inactive status", () => {
+    render(<ClanRosterTable clanId="clan-1" members={mockMembers} />);
+    const inactiveRow = screen.getByTestId("clan-roster-row-2");
+    expect(inactiveRow.getAttribute("aria-label")).toMatch(/inactive/i);
+  });
+
+  // ---------------------------------------------------------------------------
+  // clanId data attribute
+  // ---------------------------------------------------------------------------
+  it("exposes clanId as a data attribute on the table wrapper", () => {
+    render(<ClanRosterTable clanId="clan-42" members={mockMembers} />);
+    const table = screen.getByTestId("clan-roster-table");
+    expect(table).toHaveAttribute("data-clan-id", "clan-42");
+  });
+});

--- a/frontend/tests/components/ToastQueue.test.tsx
+++ b/frontend/tests/components/ToastQueue.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { ToastQueue, type Toast } from "@/components/ToastQueue";
+import { useToastQueue } from "@/components/useToastQueue";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToast(overrides: Partial<Toast> & { id: string }): Toast {
+  return {
+    message: "Default message",
+    type: "info",
+    duration: 4000,
+    ...overrides,
+  };
+}
+
+describe("ToastQueue (#940)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty queue
+  // ---------------------------------------------------------------------------
+  it("renders nothing when toasts array is empty", () => {
+    const { container } = render(
+      <ToastQueue toasts={[]} onDismiss={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rendering toasts
+  // ---------------------------------------------------------------------------
+  it("renders a toast with the correct message", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1", message: "Hello world" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-message-t1")).toHaveTextContent(
+      "Hello world"
+    );
+  });
+
+  it("renders multiple toasts", () => {
+    const toasts: Toast[] = [
+      makeToast({ id: "t1", message: "First" }),
+      makeToast({ id: "t2", message: "Second" }),
+      makeToast({ id: "t3", message: "Third" }),
+    ];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-item-t1")).toBeInTheDocument();
+    expect(screen.getByTestId("toast-item-t2")).toBeInTheDocument();
+    expect(screen.getByTestId("toast-item-t3")).toBeInTheDocument();
+  });
+
+  it("renders the toast queue container", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-queue")).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dismiss on click
+  // ---------------------------------------------------------------------------
+  it("calls onDismiss with the correct id when close button is clicked", () => {
+    const onDismiss = vi.fn();
+    const toasts: Toast[] = [makeToast({ id: "t1", message: "Click me" })];
+    render(<ToastQueue toasts={toasts} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId("toast-dismiss-t1"));
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(onDismiss).toHaveBeenCalledWith("t1");
+  });
+
+  it("dismiss button has an accessible aria-label", () => {
+    const toasts: Toast[] = [
+      makeToast({ id: "t1", message: "Something happened" }),
+    ];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /dismiss notification/i })
+    ).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auto-dismiss
+  // ---------------------------------------------------------------------------
+  it("calls onDismiss automatically after the default duration (4000 ms)", () => {
+    const onDismiss = vi.fn();
+    const toasts: Toast[] = [
+      makeToast({ id: "t1", message: "Auto dismiss", duration: 4000 }),
+    ];
+    render(<ToastQueue toasts={toasts} onDismiss={onDismiss} />);
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(onDismiss).toHaveBeenCalledWith("t1");
+  });
+
+  it("respects a custom duration", () => {
+    const onDismiss = vi.fn();
+    const toasts: Toast[] = [
+      makeToast({ id: "t1", message: "Custom", duration: 1500 }),
+    ];
+    render(<ToastQueue toasts={toasts} onDismiss={onDismiss} />);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onDismiss).toHaveBeenCalledWith("t1");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Toast types render correctly
+  // ---------------------------------------------------------------------------
+  it("applies data-type=success to success toasts", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1", type: "success" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-item-t1")).toHaveAttribute(
+      "data-type",
+      "success"
+    );
+  });
+
+  it("applies data-type=error to error toasts", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1", type: "error" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-item-t1")).toHaveAttribute(
+      "data-type",
+      "error"
+    );
+  });
+
+  it("applies data-type=warning to warning toasts", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1", type: "warning" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-item-t1")).toHaveAttribute(
+      "data-type",
+      "warning"
+    );
+  });
+
+  it("applies data-type=info to info toasts", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1", type: "info" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-item-t1")).toHaveAttribute(
+      "data-type",
+      "info"
+    );
+  });
+
+  it("uses role=alert for error toasts", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1", type: "error" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-item-t1")).toHaveAttribute("role", "alert");
+  });
+
+  it("uses role=status for info toasts", () => {
+    const toasts: Toast[] = [makeToast({ id: "t1", type: "info" })];
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("toast-item-t1")).toHaveAttribute(
+      "role",
+      "status"
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Max 5 visible
+  // ---------------------------------------------------------------------------
+  it("shows at most 5 toasts when the queue has more than 5", () => {
+    const toasts: Toast[] = Array.from({ length: 8 }, (_, i) =>
+      makeToast({ id: `t${i}`, message: `Toast ${i}` })
+    );
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    // Only the last 5 should be visible (indices 3–7)
+    expect(screen.queryByTestId("toast-item-t0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("toast-item-t1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("toast-item-t2")).not.toBeInTheDocument();
+    expect(screen.getByTestId("toast-item-t3")).toBeInTheDocument();
+    expect(screen.getByTestId("toast-item-t7")).toBeInTheDocument();
+  });
+
+  it("shows exactly 5 toasts when there are exactly 5", () => {
+    const toasts: Toast[] = Array.from({ length: 5 }, (_, i) =>
+      makeToast({ id: `t${i}` })
+    );
+    render(<ToastQueue toasts={toasts} onDismiss={vi.fn()} />);
+    for (let i = 0; i < 5; i++) {
+      expect(screen.getByTestId(`toast-item-t${i}`)).toBeInTheDocument();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useToastQueue hook
+// ---------------------------------------------------------------------------
+
+describe("useToastQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("starts with an empty toasts array", () => {
+    const { result } = renderHook(() => useToastQueue());
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("addToast appends a toast with the correct fields", () => {
+    const { result } = renderHook(() => useToastQueue());
+    act(() => {
+      result.current.addToast("Save successful", "success");
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe("Save successful");
+    expect(result.current.toasts[0].type).toBe("success");
+  });
+
+  it("addToast returns a unique id string", () => {
+    const { result } = renderHook(() => useToastQueue());
+    let id1 = "";
+    let id2 = "";
+    act(() => {
+      id1 = result.current.addToast("First", "info");
+      id2 = result.current.addToast("Second", "warning");
+    });
+    expect(id1).toBeTruthy();
+    expect(id2).toBeTruthy();
+    expect(id1).not.toBe(id2);
+  });
+
+  it("addToast stores the custom duration when provided", () => {
+    const { result } = renderHook(() => useToastQueue());
+    act(() => {
+      result.current.addToast("Ephemeral", "info", 1000);
+    });
+    expect(result.current.toasts[0].duration).toBe(1000);
+  });
+
+  it("dismissToast removes the toast with the matching id", () => {
+    const { result } = renderHook(() => useToastQueue());
+    let id = "";
+    act(() => {
+      id = result.current.addToast("Dismiss me", "error");
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    act(() => {
+      result.current.dismissToast(id);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("dismissToast ignores unknown ids without throwing", () => {
+    const { result } = renderHook(() => useToastQueue());
+    act(() => {
+      result.current.addToast("Keep me", "success");
+    });
+    act(() => {
+      result.current.dismissToast("non-existent-id");
+    });
+    expect(result.current.toasts).toHaveLength(1);
+  });
+
+  it("can queue more than 5 toasts (rendering limits are the component's concern)", () => {
+    const { result } = renderHook(() => useToastQueue());
+    act(() => {
+      for (let i = 0; i < 7; i++) {
+        result.current.addToast(`Toast ${i}`, "info");
+      }
+    });
+    expect(result.current.toasts).toHaveLength(7);
+  });
+});


### PR DESCRIPTION
## Summary

Frontend components and contract read methods across four issues.

## Changes

### #937 — Active clan roster listing table
- `frontend/src/components/ClanRosterTable.tsx`: table component with address truncation, role/status badges, loading skeleton, empty state, inactive member dimming; 13 tests

### #940 — Toast notifications queue manager
- `frontend/src/components/ToastQueue.tsx`: fixed-position toast stack, max 5 visible, auto-dismiss, type icons, accessible roles; 20+ tests
- `frontend/src/components/useToastQueue.ts`: `addToast` / `dismissToast` hook

### #907 — reserve-auction: bid delay config accessor
- `contracts/reserve-auction/src/types.rs`: `BidDelayConfig` struct
- `contracts/reserve-auction/src/storage.rs`: `get/set_bid_delay_blocks` helpers
- `contracts/reserve-auction/src/lib.rs`: `set_bid_delay` (admin) + `bid_delay_config` read method
- `contracts/reserve-auction/src/test.rs`: 2 new tests

### #923 — tournament-lobby: lobby config snapshot and start grace accessor
- `contracts/tournament-lobby/src/types.rs`: `LobbyConfigSnapshot` + `StartGraceConfig` structs
- `contracts/tournament-lobby/src/storage.rs`: `Paused` + `StartGraceBlocks` keys and helpers
- `contracts/tournament-lobby/src/lib.rs`: `lobby_config_snapshot`, `set_start_grace`, `start_grace_config`, `set_paused` methods
- `contracts/tournament-lobby/src/test.rs`: 4 new tests

closes #937
closes #940
closes #907
closes #923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clan roster view with loading, empty, and populated states, including member roles, join dates, and activity badges.
  * Added toast notifications with success, info, warning, and error styling, plus auto-dismiss and manual dismissal.
  * Added new auction and lobby configuration screens/endpoints for viewing and updating bid delay, pause state, and grace periods.

* **Bug Fixes**
  * Improved default handling so unset configuration values now display clear zero/false states instead of missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->