### PR TITLE
Add animated table skeleton placeholders

### DIFF
--- a/frontend/src/components/v1/DataTable.css
+++ b/frontend/src/components/v1/DataTable.css
@@ -103,3 +103,49 @@
     margin-right: 0;
   }
 }
+
+.data-table--loading {
+  overflow: hidden;
+}
+
+.data-table-loading__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.data-table-skeleton-cell {
+  display: block;
+  height: 0.85rem;
+  max-width: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #e8edf5 0%, #f6f8fb 45%, #e8edf5 90%);
+  background-size: 220% 100%;
+  animation: data-table-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+
+.data-table--compact .data-table-skeleton-cell {
+  height: 0.7rem;
+}
+
+@keyframes data-table-skeleton-shimmer {
+  0% {
+    background-position: 120% 0;
+  }
+
+  100% {
+    background-position: -120% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .data-table-skeleton-cell {
+    animation: none;
+  }
+}

--- a/frontend/src/components/v1/DataTable.tsx
+++ b/frontend/src/components/v1/DataTable.tsx
@@ -120,7 +120,52 @@ export function DataTable<T extends object>({
   };
 
   if (isLoading) {
-    return <div className="data-table-loading" data-testid="data-table-loading">Loading table...</div>;
+    const rowCount = Math.max(1, Math.min(skeletonRowCount ?? pageSize, 10));
+
+    return (
+      <div
+        className={[
+          'data-table',
+          'data-table--loading',
+          density === 'compact' ? 'data-table--compact' : '',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        aria-busy="true"
+        data-testid="data-table-loading"
+        data-density={density}
+      >
+        <span className="data-table-loading__status" role="status" aria-live="polite">
+          Loading table rows...
+        </span>
+        <table aria-hidden="true">
+          <thead>
+            <tr>
+              {columns.map((column) => (
+                <th key={String(column.key)} style={column.width ? { width: column.width } : undefined}>
+                  {column.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: rowCount }).map((_, rowIndex) => (
+              <tr key={`skeleton-row-${rowIndex}`} data-testid="data-table-skeleton-row">
+                {columns.map((column, columnIndex) => (
+                  <td key={`${String(column.key)}-skeleton-${rowIndex}`}>
+                    <span
+                      className="data-table-skeleton-cell"
+                      style={{ width: skeletonWidth(rowIndex, columnIndex) }}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
   }
 
   if (data.length === 0) {

--- a/frontend/src/components/v1/DataTable.tsx
+++ b/frontend/src/components/v1/DataTable.tsx
@@ -21,6 +21,7 @@ export interface DataTableProps<T> {
   density?: TableDensityPreference;
   className?: string;
   testId?: string;
+  skeletonRowCount?: number;
   onSortChange?: (field: string, direction: SortDirection) => void;
   onPageChange?: (page: number) => void;
   onPageSizeChange?: (size: number) => void;
@@ -32,6 +33,11 @@ function toggleDirection(current: SortDirection): SortDirection {
   return current === 'asc' ? 'desc' : 'asc';
 }
 
+function skeletonWidth(rowIndex: number, columnIndex: number): string {
+  const widths = ['72%', '56%', '64%', '48%', '80%'];
+  return widths[(rowIndex + columnIndex) % widths.length];
+}
+
 export function DataTable<T extends object>({
   columns,
   data,
@@ -41,6 +47,7 @@ export function DataTable<T extends object>({
   density = 'standard',
   className = '',
   testId = 'data-table',
+  skeletonRowCount,
   onSortChange,
   onPageChange,
   onPageSizeChange,

--- a/frontend/tests/components/v1/DataTable.test.tsx
+++ b/frontend/tests/components/v1/DataTable.test.tsx
@@ -22,6 +22,14 @@ describe('DataTable', () => {
     expect(screen.getByTestId('data-table-loading')).toBeInTheDocument();
   });
 
+
+  it('renders animated skeleton rows while loading', () => {
+    render(<DataTable columns={columns} data={[]} isLoading pageSize={2} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading table rows');
+    expect(screen.getAllByTestId('data-table-skeleton-row')).toHaveLength(2);
+    expect(screen.queryByTestId('data-table-empty')).not.toBeInTheDocument();
+  });
   it('shows empty state when no data', () => {
     render(<DataTable columns={columns} data={[]} />);
     expect(screen.getByTestId('data-table-empty')).toHaveTextContent('No records found.');


### PR DESCRIPTION
Closes #973
Closes #969 
Closes #968 
Closes #967

## Changes
- Replaces the DataTable loading text with animated skeleton table rows that preserve headers and density styling.
- Adds accessible loading status text and respects reduced-motion preferences for the shimmer animation.
- Adds regression coverage for skeleton rows and the loading-vs-empty fallback behavior.

## Testing
Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer loading state for tables with animated skeleton rows and an accessible loading status.
  * Introduced a new option to control how many skeleton rows appear while data is loading.

* **Bug Fixes**
  * Improved the loading experience so tables no longer show the empty-state message during loading.
  * Added reduced-motion support to disable shimmer animation for users who prefer less motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->